### PR TITLE
use `SmallVec` for reduce_rules container in GLR parser

### DIFF
--- a/rusty_lr_core/Cargo.toml
+++ b/rusty_lr_core/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["parsing"]
 [dependencies]
 rustc-hash = "2.1"
 termtree = { version = "0.5", optional = true }
+smallvec = { version = "1.15" }
 
 [features]
 default = []

--- a/rusty_lr_core/src/builder/state.rs
+++ b/rusty_lr_core/src/builder/state.rs
@@ -94,12 +94,12 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         }
     }
 
-    pub fn into_glr_sparse_state<RuleVec, NewNonTerm>(
+    pub fn into_glr_sparse_state<RuleContainer, NewNonTerm>(
         self,
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
-        rule_vec_map: impl Fn(BTreeSet<usize>) -> RuleVec,
-    ) -> crate::glr::SparseState<NewNonTerm, RuleVec>
+        rule_vec_map: impl Fn(BTreeSet<usize>) -> RuleContainer,
+    ) -> crate::glr::SparseState<NewNonTerm, RuleContainer>
     where
         NewNonTerm: Hash + Eq,
     {
@@ -174,13 +174,13 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         )
     }
 
-    pub fn into_glr_dense_state<RuleVec: Clone, NewNonTerm>(
+    pub fn into_glr_dense_state<RuleContainer: Clone, NewNonTerm>(
         self,
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
         terms_len: usize,
-        rule_vec_map: impl Fn(BTreeSet<usize>) -> RuleVec,
-    ) -> crate::glr::DenseState<NewNonTerm, RuleVec>
+        rule_vec_map: impl Fn(BTreeSet<usize>) -> RuleContainer,
+    ) -> crate::glr::DenseState<NewNonTerm, RuleContainer>
     where
         NewNonTerm: Hash + Eq,
     {

--- a/rusty_lr_core/src/builder/state.rs
+++ b/rusty_lr_core/src/builder/state.rs
@@ -15,32 +15,6 @@ pub struct State<Term, NonTerm> {
     /// The token that shifted into this state.
     pub token: Option<Token<Term, NonTerm>>,
 }
-use crate::glr::state::ToUsizeList;
-use smallvec::SmallVec;
-type SmallVecU8 = SmallVec<[u8; 16]>;
-type SmallVecU16 = SmallVec<[u16; 8]>;
-type SmallVecU32 = SmallVec<[u32; 4]>;
-type SmallVecU = SmallVec<[usize; 2]>;
-impl ToUsizeList for SmallVecU {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().copied()
-    }
-}
-impl ToUsizeList for SmallVecU32 {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().map(|&x| x as usize)
-    }
-}
-impl ToUsizeList for SmallVecU16 {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().map(|&x| x as usize)
-    }
-}
-impl ToUsizeList for SmallVecU8 {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().map(|&x| x as usize)
-    }
-}
 impl<Term, NonTerm> State<Term, NonTerm> {
     pub fn new() -> Self {
         State {
@@ -153,47 +127,51 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         self,
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
-    ) -> crate::glr::SparseState<NewNonTerm, SmallVecU8>
+    ) -> crate::glr::SparseState<NewNonTerm, crate::stackvec::SmallVecU8>
     where
         NewNonTerm: Hash + Eq,
     {
         self.into_glr_sparse_state(term_map, nonterm_map, |reduce_map| {
-            SmallVecU8::from_iter(reduce_map.into_iter().map(|x| x as u8))
+            crate::stackvec::SmallVecU8::from_iter(reduce_map.into_iter().map(|x| x as u8))
         })
     }
     pub fn into_glr_sparse_state_u16<NewNonTerm>(
         self,
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
-    ) -> crate::glr::SparseState<NewNonTerm, SmallVecU16>
+    ) -> crate::glr::SparseState<NewNonTerm, crate::stackvec::SmallVecU16>
     where
         NewNonTerm: Hash + Eq,
     {
         self.into_glr_sparse_state(term_map, nonterm_map, |reduce_map| {
-            SmallVecU16::from_iter(reduce_map.into_iter().map(|x| x as u16))
+            crate::stackvec::SmallVecU16::from_iter(reduce_map.into_iter().map(|x| x as u16))
         })
     }
     pub fn into_glr_sparse_state_u32<NewNonTerm>(
         self,
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
-    ) -> crate::glr::SparseState<NewNonTerm, SmallVecU32>
+    ) -> crate::glr::SparseState<NewNonTerm, crate::stackvec::SmallVecU32>
     where
         NewNonTerm: Hash + Eq,
     {
         self.into_glr_sparse_state(term_map, nonterm_map, |reduce_map| {
-            SmallVecU32::from_iter(reduce_map.into_iter().map(|x| x as u32))
+            crate::stackvec::SmallVecU32::from_iter(reduce_map.into_iter().map(|x| x as u32))
         })
     }
     pub fn into_glr_sparse_state_usize<NewNonTerm>(
         self,
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
-    ) -> crate::glr::SparseState<NewNonTerm, SmallVecU>
+    ) -> crate::glr::SparseState<NewNonTerm, crate::stackvec::SmallVecUsize>
     where
         NewNonTerm: Hash + Eq,
     {
-        self.into_glr_sparse_state(term_map, nonterm_map, SmallVecU::from_iter)
+        self.into_glr_sparse_state(
+            term_map,
+            nonterm_map,
+            crate::stackvec::SmallVecUsize::from_iter,
+        )
     }
 
     pub fn into_glr_dense_state<RuleVec: Clone, NewNonTerm>(
@@ -230,12 +208,12 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
         terms_len: usize,
-    ) -> crate::glr::DenseState<NewNonTerm, SmallVecU8>
+    ) -> crate::glr::DenseState<NewNonTerm, crate::stackvec::SmallVecU8>
     where
         NewNonTerm: Hash + Eq,
     {
         self.into_glr_dense_state(term_map, nonterm_map, terms_len, |reduce_map| {
-            SmallVecU8::from_iter(reduce_map.into_iter().map(|x| x as u8))
+            crate::stackvec::SmallVecU8::from_iter(reduce_map.into_iter().map(|x| x as u8))
         })
     }
     pub fn into_glr_dense_state_u16<NewNonTerm>(
@@ -243,12 +221,12 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
         terms_len: usize,
-    ) -> crate::glr::DenseState<NewNonTerm, SmallVecU16>
+    ) -> crate::glr::DenseState<NewNonTerm, crate::stackvec::SmallVecU16>
     where
         NewNonTerm: Hash + Eq,
     {
         self.into_glr_dense_state(term_map, nonterm_map, terms_len, |reduce_map| {
-            SmallVecU16::from_iter(reduce_map.into_iter().map(|x| x as u16))
+            crate::stackvec::SmallVecU16::from_iter(reduce_map.into_iter().map(|x| x as u16))
         })
     }
     pub fn into_glr_dense_state_u32<NewNonTerm>(
@@ -256,12 +234,12 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
         terms_len: usize,
-    ) -> crate::glr::DenseState<NewNonTerm, SmallVecU32>
+    ) -> crate::glr::DenseState<NewNonTerm, crate::stackvec::SmallVecU32>
     where
         NewNonTerm: Hash + Eq,
     {
         self.into_glr_dense_state(term_map, nonterm_map, terms_len, |reduce_map| {
-            SmallVecU32::from_iter(reduce_map.into_iter().map(|x| x as u32))
+            crate::stackvec::SmallVecU32::from_iter(reduce_map.into_iter().map(|x| x as u32))
         })
     }
     pub fn into_glr_dense_state_usize<NewNonTerm>(
@@ -269,11 +247,16 @@ impl<Term, NonTerm> State<Term, NonTerm> {
         term_map: impl Fn(Term) -> usize,
         nonterm_map: impl Fn(NonTerm) -> NewNonTerm,
         terms_len: usize,
-    ) -> crate::glr::DenseState<NewNonTerm, SmallVecU>
+    ) -> crate::glr::DenseState<NewNonTerm, crate::stackvec::SmallVecUsize>
     where
         NewNonTerm: Hash + Eq,
     {
-        self.into_glr_dense_state(term_map, nonterm_map, terms_len, SmallVecU::from_iter)
+        self.into_glr_dense_state(
+            term_map,
+            nonterm_map,
+            terms_len,
+            crate::stackvec::SmallVecUsize::from_iter,
+        )
     }
 }
 

--- a/rusty_lr_core/src/glr/context.rs
+++ b/rusty_lr_core/src/glr/context.rs
@@ -287,9 +287,12 @@ impl<Data: TokenData> Context<Data> {
                     for node in nodes.into_iter() {
                         let mut shift_for_this_node = false;
 
+                        let mut reduce_rules = reduce_rules.clone();
+                        let reduce0 = reduce_rules.next().unwrap();
+
                         // In reduce action, we call `Rc::try_unwrap` to avoid `clone()` data if possible.
                         // So we need to avoid `Rc::clone()` if possible.
-                        for reduce_rule in reduce_rules.iter().skip(1).copied() {
+                        for reduce_rule in reduce_rules {
                             shift_for_this_node |= super::reduce(
                                 parser,
                                 reduce_rule,
@@ -303,7 +306,7 @@ impl<Data: TokenData> Context<Data> {
                         if let Some(next_term_shift_state) = next_term_shift_state {
                             shift_for_this_node |= super::reduce(
                                 parser,
-                                reduce_rules[0],
+                                reduce0,
                                 Rc::clone(&node),
                                 self,
                                 &term,
@@ -329,15 +332,7 @@ impl<Data: TokenData> Context<Data> {
                                     .push(Rc::new(next_node));
                             }
                         } else {
-                            super::reduce(
-                                parser,
-                                reduce_rules[0],
-                                node,
-                                self,
-                                &term,
-                                false,
-                                userdata,
-                            );
+                            super::reduce(parser, reduce0, node, self, &term, false, userdata);
                         }
                     }
                 } else if let Some(next_term_shift_state) = next_term_shift_state {
@@ -479,7 +474,7 @@ impl<Data: TokenData> Context<Data> {
 
                 if let Some(reduce_rules) = state.reduce(class) {
                     for reduce_rule in reduce_rules {
-                        let reduce_rule = &parser.get_rules()[*reduce_rule];
+                        let reduce_rule = &parser.get_rules()[reduce_rule];
                         let reduce_len = reduce_rule.rule.len();
 
                         for p in nodes.iter() {

--- a/rusty_lr_core/src/glr/state.rs
+++ b/rusty_lr_core/src/glr/state.rs
@@ -33,13 +33,13 @@ pub trait State<NonTerm> {
 
 /// `State` implementation for a sparse state representation using HashMap
 #[derive(Debug, Clone)]
-pub struct SparseState<NonTerm, RuleVec> {
+pub struct SparseState<NonTerm, RuleContainer> {
     /// terminal symbol -> next state
     pub(crate) shift_goto_map_class: HashMap<usize, usize>,
     /// non-terminal symbol -> next state
     pub(crate) shift_goto_map_nonterm: HashMap<NonTerm, usize>,
     /// terminal symbol -> reduce rule index
-    pub(crate) reduce_map: HashMap<usize, RuleVec>,
+    pub(crate) reduce_map: HashMap<usize, RuleContainer>,
     /// set of rules that this state is trying to parse
     pub(crate) ruleset: Vec<ShiftedRuleRef>,
 }
@@ -85,18 +85,18 @@ impl<NonTerm, RuleIndex: crate::stackvec::ToUsizeList> State<NonTerm>
 
 /// `State` implementation for a dense state representation using Vec
 #[derive(Debug, Clone)]
-pub struct DenseState<NonTerm, RuleVec> {
+pub struct DenseState<NonTerm, RuleContainer> {
     /// terminal symbol -> next state
     pub(crate) shift_goto_map_class: Vec<Option<usize>>,
     /// non-terminal symbol -> next state
     pub(crate) shift_goto_map_nonterm: HashMap<NonTerm, usize>,
     /// terminal symbol -> reduce rule index
-    pub(crate) reduce_map: Vec<Option<RuleVec>>,
+    pub(crate) reduce_map: Vec<Option<RuleContainer>>,
     /// set of rules that this state is trying to parse
     pub(crate) ruleset: Vec<ShiftedRuleRef>,
 }
-impl<NonTerm, RuleVec: crate::stackvec::ToUsizeList> State<NonTerm>
-    for DenseState<NonTerm, RuleVec>
+impl<NonTerm, RuleContainer: crate::stackvec::ToUsizeList> State<NonTerm>
+    for DenseState<NonTerm, RuleContainer>
 {
     fn shift_goto_class(&self, class: usize) -> Option<usize> {
         self.shift_goto_map_class[class]

--- a/rusty_lr_core/src/glr/state.rs
+++ b/rusty_lr_core/src/glr/state.rs
@@ -34,27 +34,6 @@ pub trait State<NonTerm> {
 pub trait ToUsizeList {
     fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone;
 }
-use smallvec::SmallVec;
-impl ToUsizeList for SmallVec<[usize; 2]> {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().copied()
-    }
-}
-impl ToUsizeList for SmallVec<[u32; 4]> {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().map(|&x| x as usize)
-    }
-}
-impl ToUsizeList for SmallVec<[u16; 8]> {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().map(|&x| x as usize)
-    }
-}
-impl ToUsizeList for SmallVec<[u8; 16]> {
-    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
-        self.iter().map(|&x| x as usize)
-    }
-}
 
 /// `State` implementation for a sparse state representation using HashMap
 #[derive(Debug, Clone)]

--- a/rusty_lr_core/src/lib.rs
+++ b/rusty_lr_core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod hashmap;
 pub(crate) mod rule;
+pub mod stackvec;
 pub(crate) mod token;
 
 #[cfg(feature = "tree")]

--- a/rusty_lr_core/src/stackvec.rs
+++ b/rusty_lr_core/src/stackvec.rs
@@ -1,0 +1,31 @@
+// stack allocated Vec for small lists ( ~ 8 elements )
+// currently only for reduce_rules in GLR parser
+
+pub trait ToUsizeList {
+    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone;
+}
+
+pub type SmallVecU8 = smallvec::SmallVec<[u8; 16]>;
+pub type SmallVecU16 = smallvec::SmallVec<[u16; 8]>;
+pub type SmallVecU32 = smallvec::SmallVec<[u32; 4]>;
+pub type SmallVecUsize = smallvec::SmallVec<[usize; 2]>;
+impl ToUsizeList for SmallVecU8 {
+    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
+        self.iter().map(|&x| x as usize)
+    }
+}
+impl ToUsizeList for SmallVecU16 {
+    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
+        self.iter().map(|&x| x as usize)
+    }
+}
+impl ToUsizeList for SmallVecU32 {
+    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
+        self.iter().map(|&x| x as usize)
+    }
+}
+impl ToUsizeList for SmallVecUsize {
+    fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
+        self.iter().copied()
+    }
+}

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -63,7 +63,7 @@ type ClassIndex = usize;
 type TerminalIndex = usize;
 
 pub struct Grammar {
-    /// %moduleprefix
+    /// %moduleprefix, "rusty_lr" for normal use
     pub(crate) module_prefix: TokenStream,
 
     /// %tokentype


### PR DESCRIPTION
Since len() of `reduce_rules` of each state in GLR parser is typically around 1 ~ 2,
use stack allocated `SmallVec` instead of `Vec` for performance.

Additionally, count for the maximum number of production rules and use the most compact integral type instead of `usize`.