### PR TITLE
Add command line arguments for overriding grammar setting

### DIFF
--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -64,6 +64,11 @@ pub struct Builder {
 
     /// if true, an executable called this function
     pub is_executable: bool,
+
+    /// if Some, override the settings with these values
+    glr: Option<bool>,
+    runtime: Option<bool>,
+    dense: Option<bool>,
 }
 
 impl Builder {
@@ -76,7 +81,27 @@ impl Builder {
             verbose_optimization: false,
             print_backtrace: true,
             is_executable: false,
+
+            glr: None,
+            runtime: None,
+            dense: None,
         }
+    }
+
+    /// override the settings
+    pub fn glr(&mut self, glr: bool) -> &mut Self {
+        self.glr = Some(glr);
+        self
+    }
+    /// override the settings
+    pub fn runtime(&mut self, runtime: bool) -> &mut Self {
+        self.runtime = Some(runtime);
+        self
+    }
+    /// override the settings
+    pub fn dense(&mut self, dense: bool) -> &mut Self {
+        self.dense = Some(dense);
+        self
     }
 
     /// set input file
@@ -457,6 +482,16 @@ impl Builder {
                     .expect("Failed to write to stderr");
                 return Err(diag.message);
             }
+        }
+
+        if let Some(glr) = self.glr {
+            grammar_args.glr = glr;
+        }
+        if let Some(runtime) = self.runtime {
+            grammar_args.compiled = !runtime;
+        }
+        if let Some(dense) = self.dense {
+            grammar_args.dense = dense;
         }
 
         // parse lines

--- a/rusty_lr_executable/src/arg.rs
+++ b/rusty_lr_executable/src/arg.rs
@@ -41,4 +41,16 @@ pub struct Args {
     /// do not print the backtrace rules in current state when a conflict occurs
     #[arg(short = 'b', long, default_value = "false")]
     pub no_backtrace: bool,
+
+    /// override the written code and set generated parser use GLR parsing algorithm
+    #[arg(long)]
+    pub glr: Option<bool>,
+
+    /// override the written code and set parser table to be runtime-calculated
+    #[arg(long)]
+    pub runtime: Option<bool>,
+
+    /// override the written code and set generated parser table to use dense arrays
+    #[arg(long)]
+    pub dense: Option<bool>,
 }

--- a/rusty_lr_executable/src/main.rs
+++ b/rusty_lr_executable/src/main.rs
@@ -32,6 +32,15 @@ fn main() {
     if args.no_backtrace {
         builder.no_print_backtrace();
     }
+    if let Some(glr) = args.glr {
+        builder.glr(glr);
+    }
+    if let Some(runtime) = args.runtime {
+        builder.runtime(runtime);
+    }
+    if let Some(dense) = args.dense {
+        builder.dense(dense);
+    }
 
     let out = match builder.build_impl() {
         Ok(out) => out,


### PR DESCRIPTION
Add `glr`, `runtime`, `dense` command line arguments that override written grammar setting