### PR TITLE
add `IntermediateState` for lightweight state generation

### DIFF
--- a/rusty_lr_core/src/builder/state.rs
+++ b/rusty_lr_core/src/builder/state.rs
@@ -37,3 +37,20 @@ impl<Term, NonTerm, StateIndex, RuleIndex> Default for State<Term, NonTerm, Stat
         Self::new()
     }
 }
+
+impl<Term, NonTerm, StateIndex, RuleIndex> From<State<Term, NonTerm, StateIndex, RuleIndex>>
+    for crate::parser::state::IntermediateState<Term, NonTerm, StateIndex, RuleIndex>
+{
+    fn from(state: crate::builder::State<Term, NonTerm, StateIndex, RuleIndex>) -> Self {
+        crate::parser::state::IntermediateState {
+            shift_goto_map_term: state.shift_goto_map_term.into_iter().collect(),
+            shift_goto_map_nonterm: state.shift_goto_map_nonterm.into_iter().collect(),
+            reduce_map: state
+                .reduce_map
+                .into_iter()
+                .map(|(term, rules)| (term, rules.into_iter().collect()))
+                .collect(),
+            ruleset: state.ruleset.into_iter().collect(),
+        }
+    }
+}

--- a/rusty_lr_core/src/builder/state.rs
+++ b/rusty_lr_core/src/builder/state.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-/// state in DFA building
+/// state for internal usage during grammar building stage
 #[derive(Debug, Clone)]
 pub struct State<Term, NonTerm, StateIndex, RuleIndex> {
     pub shift_goto_map_term: BTreeMap<Term, StateIndex>,

--- a/rusty_lr_core/src/parser/state.rs
+++ b/rusty_lr_core/src/parser/state.rs
@@ -324,13 +324,30 @@ where
     fn from(
         mut builder_state: IntermediateState<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>,
     ) -> Self {
-        debug_assert!(
-            TerminalSymbol::Term(0) < TerminalSymbol::Error
-                && TerminalSymbol::<i32>::Error < TerminalSymbol::Eof
-        );
-
         // TerminalSymbol::Term(_) < TerminalSymbol::Error < TerminalSymbol::Eof
-        // since any maps are sorted, eof and error should be at the end of the array
+        // since maps are sorted, eof and error should be at the end of the array
+
+        // make sure the order is preserved
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                TerminalSymbol::Term(0) < TerminalSymbol::Error
+                    && TerminalSymbol::<i32>::Error < TerminalSymbol::Eof
+            );
+            let keys = builder_state
+                .shift_goto_map_term
+                .iter()
+                .map(|(term, _)| term)
+                .collect::<Vec<_>>();
+            debug_assert!(keys.is_sorted());
+
+            let keys = builder_state
+                .reduce_map
+                .iter()
+                .map(|(term, _)| term)
+                .collect::<Vec<_>>();
+            debug_assert!(keys.is_sorted());
+        }
         let eof_shift = if builder_state
             .shift_goto_map_term
             .last()
@@ -433,13 +450,31 @@ where
     fn from(
         mut builder_state: IntermediateState<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>,
     ) -> Self {
-        debug_assert!(
-            TerminalSymbol::Term(0) < TerminalSymbol::Error
-                && TerminalSymbol::<i32>::Error < TerminalSymbol::Eof
-        );
-
         // TerminalSymbol::Term(_) < TerminalSymbol::Error < TerminalSymbol::Eof
-        // since any maps are sorted, eof and error should be at the end of the array
+        // since maps are sorted, eof and error should be at the end of the array
+
+        // make sure the order is preserved
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                TerminalSymbol::Term(0) < TerminalSymbol::Error
+                    && TerminalSymbol::<i32>::Error < TerminalSymbol::Eof
+            );
+            let keys = builder_state
+                .shift_goto_map_term
+                .iter()
+                .map(|(term, _)| term)
+                .collect::<Vec<_>>();
+            debug_assert!(keys.is_sorted());
+
+            let keys = builder_state
+                .reduce_map
+                .iter()
+                .map(|(term, _)| term)
+                .collect::<Vec<_>>();
+            debug_assert!(keys.is_sorted());
+        }
+
         let eof_shift = if builder_state
             .shift_goto_map_term
             .last()

--- a/rusty_lr_core/src/parser/state.rs
+++ b/rusty_lr_core/src/parser/state.rs
@@ -4,8 +4,8 @@ use crate::hash::HashMap;
 use crate::nonterminal::NonTerminal;
 use crate::TerminalSymbol;
 
-/// this intermediate_state is common structure to convert from generated code, grammar builder
-/// into various types of parser states ( SparseState, DenseState, ... )
+/// This intermediate state is a common structure to convert from generated code and grammar builder
+/// into various types of parser states (SparseState, DenseState, ...).
 pub struct IntermediateState<Term, NonTerm, StateIndex, RuleIndex> {
     pub shift_goto_map_term: Vec<(Term, StateIndex)>, // must be sorted
     pub shift_goto_map_nonterm: Vec<(NonTerm, StateIndex)>, // must be sorted

--- a/rusty_lr_core/src/parser/state.rs
+++ b/rusty_lr_core/src/parser/state.rs
@@ -13,24 +13,6 @@ pub struct IntermediateState<Term, NonTerm, StateIndex, RuleIndex> {
     pub ruleset: Vec<crate::rule::ShiftedRuleRef>,
 }
 
-impl<Term, NonTerm, StateIndex, RuleIndex>
-    From<crate::builder::State<Term, NonTerm, StateIndex, RuleIndex>>
-    for IntermediateState<Term, NonTerm, StateIndex, RuleIndex>
-{
-    fn from(state: crate::builder::State<Term, NonTerm, StateIndex, RuleIndex>) -> Self {
-        IntermediateState {
-            shift_goto_map_term: state.shift_goto_map_term.into_iter().collect(),
-            shift_goto_map_nonterm: state.shift_goto_map_nonterm.into_iter().collect(),
-            reduce_map: state
-                .reduce_map
-                .into_iter()
-                .map(|(term, rules)| (term, rules.into_iter().collect()))
-                .collect(),
-            ruleset: state.ruleset.into_iter().collect(),
-        }
-    }
-}
-
 /// For state, terminal and class indices, we use the most compact integer type that can hold the maximum value.
 /// This trait defines the conversion between {u8, u16, u32, usize} <-> usize.
 pub trait Index {

--- a/rusty_lr_core/src/parser/state.rs
+++ b/rusty_lr_core/src/parser/state.rs
@@ -4,6 +4,33 @@ use crate::hash::HashMap;
 use crate::nonterminal::NonTerminal;
 use crate::TerminalSymbol;
 
+/// this intermediate_state is common structure to convert from generated code, grammar builder
+/// into various types of parser states ( SparseState, DenseState, ... )
+pub struct IntermediateState<Term, NonTerm, StateIndex, RuleIndex> {
+    pub shift_goto_map_term: Vec<(Term, StateIndex)>, // must be sorted
+    pub shift_goto_map_nonterm: Vec<(NonTerm, StateIndex)>, // must be sorted
+    pub reduce_map: Vec<(Term, Vec<RuleIndex>)>,      // must be sorted
+    pub ruleset: Vec<crate::rule::ShiftedRuleRef>,
+}
+
+impl<Term, NonTerm, StateIndex, RuleIndex>
+    From<crate::builder::State<Term, NonTerm, StateIndex, RuleIndex>>
+    for IntermediateState<Term, NonTerm, StateIndex, RuleIndex>
+{
+    fn from(state: crate::builder::State<Term, NonTerm, StateIndex, RuleIndex>) -> Self {
+        IntermediateState {
+            shift_goto_map_term: state.shift_goto_map_term.into_iter().collect(),
+            shift_goto_map_nonterm: state.shift_goto_map_nonterm.into_iter().collect(),
+            reduce_map: state
+                .reduce_map
+                .into_iter()
+                .map(|(term, rules)| (term, rules.into_iter().collect()))
+                .collect(),
+            ruleset: state.ruleset.into_iter().collect(),
+        }
+    }
+}
+
 /// For state, terminal and class indices, we use the most compact integer type that can hold the maximum value.
 /// This trait defines the conversion between {u8, u16, u32, usize} <-> usize.
 pub trait Index {
@@ -50,9 +77,7 @@ pub trait ReduceRules {
     type RuleIndex: Index;
 
     fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone;
-    fn from_set<RuleIndexFrom: TryInto<Self::RuleIndex>>(
-        set: std::collections::BTreeSet<RuleIndexFrom>,
-    ) -> Self;
+    fn from_set<RuleIndexFrom: TryInto<Self::RuleIndex>>(set: Vec<RuleIndexFrom>) -> Self;
 }
 
 /// For deterministic parser behavior
@@ -62,9 +87,7 @@ impl<Integral: Index + Copy> ReduceRules for Integral {
     fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
         std::iter::once(self.into_usize())
     }
-    fn from_set<RuleIndexFrom: TryInto<Self::RuleIndex>>(
-        set: std::collections::BTreeSet<RuleIndexFrom>,
-    ) -> Self {
+    fn from_set<RuleIndexFrom: TryInto<Self::RuleIndex>>(set: Vec<RuleIndexFrom>) -> Self {
         debug_assert!(set.len() == 1, "Expected a single element set");
         set.into_iter().next().unwrap().try_into().ok().unwrap()
     }
@@ -78,9 +101,7 @@ where
     fn to_usize_list(&self) -> impl Iterator<Item = usize> + Clone {
         self.iter().map(|&x| x.into_usize())
     }
-    fn from_set<RuleIndexFrom: TryInto<Self::RuleIndex>>(
-        set: std::collections::BTreeSet<RuleIndexFrom>,
-    ) -> Self {
+    fn from_set<RuleIndexFrom: TryInto<Self::RuleIndex>>(set: Vec<RuleIndexFrom>) -> Self {
         set.into_iter()
             .map(|value| value.try_into().ok().unwrap())
             .collect()
@@ -306,7 +327,7 @@ impl<Term, NonTerm: Copy, RuleContainer: ReduceRules, StateIndex: Into<usize> + 
 }
 
 impl<Term, TermTo, NonTerm, RuleContainer, StateIndex, StateIndexTo, RuleIndex>
-    From<crate::builder::State<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>>
+    From<IntermediateState<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>>
     for SparseState<TermTo, NonTerm, RuleContainer, StateIndexTo>
 where
     Term: Ord + TryInto<TermTo>,
@@ -319,27 +340,56 @@ where
     RuleContainer::RuleIndex: TryFrom<RuleIndex>,
 {
     fn from(
-        mut builder_state: crate::builder::State<
-            TerminalSymbol<Term>,
-            NonTerm,
-            StateIndex,
-            RuleIndex,
-        >,
+        mut builder_state: IntermediateState<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>,
     ) -> Self {
-        let error_shift = builder_state
+        debug_assert!(
+            TerminalSymbol::Term(0) < TerminalSymbol::Error
+                && TerminalSymbol::<i32>::Error < TerminalSymbol::Eof
+        );
+
+        // TerminalSymbol::Term(_) < TerminalSymbol::Error < TerminalSymbol::Eof
+        // since any maps are sorted, eof and error should be at the end of the array
+        let eof_shift = if builder_state
             .shift_goto_map_term
-            .remove(&TerminalSymbol::Error);
-        let eof_shift = builder_state
+            .last()
+            .map(|(term, _)| term)
+            == Some(&TerminalSymbol::Eof)
+        {
+            Some(builder_state.shift_goto_map_term.pop().unwrap().1)
+        } else {
+            None
+        };
+
+        let error_shift = if builder_state
             .shift_goto_map_term
-            .remove(&TerminalSymbol::Eof);
-        let error_reduce = builder_state
-            .reduce_map
-            .remove(&TerminalSymbol::Error)
-            .map(|reduce_rules| RuleContainer::from_set(reduce_rules));
-        let eof_reduce = builder_state
-            .reduce_map
-            .remove(&TerminalSymbol::Eof)
-            .map(|reduce_rules| RuleContainer::from_set(reduce_rules));
+            .last()
+            .map(|(term, _)| term)
+            == Some(&TerminalSymbol::Error)
+        {
+            Some(builder_state.shift_goto_map_term.pop().unwrap().1)
+        } else {
+            None
+        };
+
+        let eof_reduce = if builder_state.reduce_map.last().map(|(term, _)| term)
+            == Some(&TerminalSymbol::Eof)
+        {
+            Some(RuleContainer::from_set(
+                builder_state.reduce_map.pop().unwrap().1,
+            ))
+        } else {
+            None
+        };
+        let error_reduce = if builder_state.reduce_map.last().map(|(term, _)| term)
+            == Some(&TerminalSymbol::Error)
+        {
+            Some(RuleContainer::from_set(
+                builder_state.reduce_map.pop().unwrap().1,
+            ))
+        } else {
+            None
+        };
+
         SparseState {
             shift_goto_map_class: builder_state
                 .shift_goto_map_term
@@ -388,7 +438,7 @@ where
     }
 }
 impl<Term, TermTo, NonTerm, RuleContainer, StateIndex, StateIndexTo: Copy, RuleIndex>
-    From<crate::builder::State<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>>
+    From<IntermediateState<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>>
     for DenseState<TermTo, NonTerm, RuleContainer, StateIndexTo>
 where
     Term: Ord + Into<usize> + Copy,
@@ -399,30 +449,61 @@ where
     RuleContainer::RuleIndex: TryFrom<RuleIndex>,
 {
     fn from(
-        mut builder_state: crate::builder::State<
-            TerminalSymbol<Term>,
-            NonTerm,
-            StateIndex,
-            RuleIndex,
-        >,
+        mut builder_state: IntermediateState<TerminalSymbol<Term>, NonTerm, StateIndex, RuleIndex>,
     ) -> Self {
-        let error_shift = builder_state
+        debug_assert!(
+            TerminalSymbol::Term(0) < TerminalSymbol::Error
+                && TerminalSymbol::<i32>::Error < TerminalSymbol::Eof
+        );
+
+        // TerminalSymbol::Term(_) < TerminalSymbol::Error < TerminalSymbol::Eof
+        // since any maps are sorted, eof and error should be at the end of the array
+        let eof_shift = if builder_state
             .shift_goto_map_term
-            .remove(&TerminalSymbol::Error);
-        let eof_shift = builder_state
+            .last()
+            .map(|(term, _)| term)
+            == Some(&TerminalSymbol::Eof)
+        {
+            Some(builder_state.shift_goto_map_term.pop().unwrap().1)
+        } else {
+            None
+        };
+
+        let error_shift = if builder_state
             .shift_goto_map_term
-            .remove(&TerminalSymbol::Eof);
-        let error_reduce = builder_state
-            .reduce_map
-            .remove(&TerminalSymbol::Error)
-            .map(|reduce_map| RuleContainer::from_set(reduce_map));
-        let eof_reduce = builder_state
-            .reduce_map
-            .remove(&TerminalSymbol::Eof)
-            .map(|reduce_map| RuleContainer::from_set(reduce_map));
+            .last()
+            .map(|(term, _)| term)
+            == Some(&TerminalSymbol::Error)
+        {
+            Some(builder_state.shift_goto_map_term.pop().unwrap().1)
+        } else {
+            None
+        };
+
+        let eof_reduce = if builder_state.reduce_map.last().map(|(term, _)| term)
+            == Some(&TerminalSymbol::Eof)
+        {
+            Some(RuleContainer::from_set(
+                builder_state.reduce_map.pop().unwrap().1,
+            ))
+        } else {
+            None
+        };
+        let error_reduce = if builder_state.reduce_map.last().map(|(term, _)| term)
+            == Some(&TerminalSymbol::Error)
+        {
+            Some(RuleContainer::from_set(
+                builder_state.reduce_map.pop().unwrap().1,
+            ))
+        } else {
+            None
+        };
 
         let (shift_min, shift_len) = {
-            let mut iter = builder_state.shift_goto_map_term.keys();
+            let mut iter = builder_state
+                .shift_goto_map_term
+                .iter()
+                .map(|(term, _)| term);
             let min: Option<usize> = iter.next().map(|x| x.into_term().unwrap().into());
             let max: Option<usize> = iter
                 .next_back()
@@ -436,7 +517,7 @@ where
             }
         };
         let (reduce_min, reduce_len) = {
-            let mut iter = builder_state.reduce_map.keys();
+            let mut iter = builder_state.reduce_map.iter().map(|(term, _)| term);
             let min: Option<usize> = iter.next().map(|x| x.into_term().unwrap().into());
             let max: Option<usize> = iter
                 .next_back()
@@ -449,7 +530,10 @@ where
             }
         };
         let (nonterm_min, nonterm_len) = {
-            let mut iter = builder_state.shift_goto_map_nonterm.keys();
+            let mut iter = builder_state
+                .shift_goto_map_nonterm
+                .iter()
+                .map(|(nonterm, _)| nonterm);
             let min = iter.next().map(|x| x.to_usize());
             let max = iter.next_back().map(|x| x.to_usize()).or(min);
             if let (Some(min), Some(max)) = (min, max) {
@@ -473,8 +557,8 @@ where
 
         let nonterm_keys = builder_state
             .shift_goto_map_nonterm
-            .keys()
-            .copied()
+            .iter()
+            .map(|(nonterm, _)| *nonterm)
             .collect();
         let mut shift_goto_map_nonterm = vec![None; nonterm_len];
         for (nonterm, state) in builder_state.shift_goto_map_nonterm {

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -477,7 +477,7 @@ impl Grammar {
                         });
                     }
                     reduce_body_stream.extend(quote! {
-                        let reduce_rules = std::collections::BTreeSet::from([#rules_body_stream]);
+                        let reduce_rules = vec![#rules_body_stream];
                         __reduce_map.extend(
                             #terms_set_name.iter().map(
                                 |term| (*term, reduce_rules.clone())
@@ -511,11 +511,11 @@ impl Grammar {
                 };
 
                 states_body_stream.extend(quote! {
-                    #module_prefix::builder::State {
-                        shift_goto_map_term: std::collections::BTreeMap::from([#shift_term_body_stream]),
-                        shift_goto_map_nonterm: std::collections::BTreeMap::from([#shift_nonterm_body_stream]),
+                    #module_prefix::parser::state::IntermediateState {
+                        shift_goto_map_term: vec![#shift_term_body_stream],
+                        shift_goto_map_nonterm: vec![#shift_nonterm_body_stream],
                         reduce_map: {
-                            let mut __reduce_map = std::collections::BTreeMap::new();
+                            let mut __reduce_map = Vec::new();
                             #reduce_body_stream
                             __reduce_map
                         },
@@ -586,7 +586,7 @@ impl Grammar {
                 ).collect();
 
                 #terminal_set_initialize_stream
-                let states: Vec<#module_prefix::builder::State<
+                let states: Vec<#module_prefix::parser::state::IntermediateState<
                     #module_prefix::TerminalSymbol<#class_index_typename>, _, #state_index_typename, #rule_index_typename
                 >> = vec![
                     #states_body_stream
@@ -743,7 +743,10 @@ impl Grammar {
                 ).collect();
 
                 let states:Vec<#state_typename> = states.into_iter().map(
-                    |state| state.into(),
+                    |state| {
+                        let state: #module_prefix::parser::state::IntermediateState<_,_,_,_> = state.into();
+                        state.into()
+                    }
                 ).collect();
             }
         };

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -7638,1021 +7638,906 @@ impl GrammarParser {
             ::rusty_lr_core::TerminalSymbol<u8>,
         > = std::collections::BTreeSet::from([::rusty_lr_core::TerminalSymbol::Eof]);
         let states: Vec<
-            ::rusty_lr_core::builder::State<
+            ::rusty_lr_core::parser::state::IntermediateState<
                 ::rusty_lr_core::TerminalSymbol<u8>,
                 _,
                 u8,
                 u8,
             >,
         > = vec![
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            1), (::rusty_lr_core::TerminalSymbol::Term(4), 90),]), shift_goto_map_nonterm
-            : std::collections::BTreeMap::from([(GrammarNonTerminals::Rule, 223),
-            (GrammarNonTerminals::Directive, 224), (GrammarNonTerminals::GrammarLine,
-            225), (GrammarNonTerminals::Grammar, 227),
-            (GrammarNonTerminals::_GrammarLinePlus31, 229),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [0, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
-            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
-            71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 155, 156, 157,]; let shifted : &
-            'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,];
-            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(17),
-            2),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RuleType, 3),]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([2,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 1),
+            (::rusty_lr_core::TerminalSymbol::Term(4), 90),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::Rule, 223), (GrammarNonTerminals::Directive, 224),
+            (GrammarNonTerminals::GrammarLine, 225), (GrammarNonTerminals::Grammar, 227),
+            (GrammarNonTerminals::_GrammarLinePlus31, 229),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [0, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+            58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+            77, 78, 79, 80, 81, 155, 156, 157,]; let shifted : & 'static [u8] = & [0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(17), 2),], shift_goto_map_nonterm
+            : vec![(GrammarNonTerminals::RuleType, 3),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![2,]; __reduce_map
             .extend(__rustylr_tset0.iter().map(| term | (* term, reduce_rules.clone())));
             __reduce_map }, ruleset : { let rules : & 'static [u8] = & [0, 1, 2,]; let
             shifted : & 'static [u8] = & [1, 0, 0,]; rules.iter().zip(shifted.iter())
             .map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule :
             rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([1,]); __reduce_map.extend(__rustylr_tset0
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [1,]; let shifted : & 'static [u8]
-            = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(1),
-            4),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [0,]; let shifted
-            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![1,]; __reduce_map
+            .extend(__rustylr_tset0.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [1,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            5), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(1), 4),], shift_goto_map_nonterm
+            : vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [0,]; let shifted : & 'static [u8]
+            = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 5),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RuleLines, 64),
-            (GrammarNonTerminals::RuleLine, 89), (GrammarNonTerminals::TokenMapped, 68),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RuleLines, 64), (GrammarNonTerminals::RuleLine,
+            89), (GrammarNonTerminals::TokenMapped, 68),
             (GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern, 69),
             (GrammarNonTerminals::_TokenMappedPlus15, 70),
-            (GrammarNonTerminals::_TokenMappedStar16, 72),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([85,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [0, 3, 4, 5, 11, 12, 19, 20, 21,
-            22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 82, 83, 84, 85,];
-            let shifted : & 'static [u8] = & [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter())
-            .map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule :
-            rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(5),
-            6),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([21,]); __reduce_map
-            .extend(__rustylr_tset2.iter().map(| term | (* term, reduce_rules.clone())));
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [12, 21,]; let
-            shifted : & 'static [u8] = & [1, 1,]; rules.iter().zip(shifted.iter()).map(|
+            (GrammarNonTerminals::_TokenMappedStar16, 72),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![85,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [0, 3, 4, 5, 11,
+            12, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+            82, 83, 84, 85,]; let shifted : & 'static [u8] = & [3, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter()
+            .zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(5), 6),], shift_goto_map_nonterm
+            : vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules
+            = vec![21,]; __reduce_map.extend(__rustylr_tset2.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [12, 21,]; let shifted : & 'static [u8] = & [1, 1,]; rules.iter()
+            .zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
+            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            63),], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [12, 19, 20, 21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,]; let shifted : & 'static [u8] =
+            & [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter()
+            .zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![21,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [21,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![20,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [20,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 10),], shift_goto_map_nonterm
+            : vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [32, 33, 34, 35, 36,]; let shifted
+            : & 'static [u8] = & [1, 1, 1, 1, 1,]; rules.iter().zip(shifted.iter()).map(|
             (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
             as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(19), 11),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [32,
+            33, 34, 35, 36,]; let shifted : & 'static [u8] = & [2, 2, 2, 2, 2,]; rules
+            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 63),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [12, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
-            33, 34, 35, 36,]; let shifted : & 'static [u8] = & [2, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (&
-            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
-            usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([21,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [21,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            31),], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26,
+            27, 28, 29, 30, 31, 32, 32, 33, 33, 34, 34, 35, 35, 36, 36,]; let shifted : &
+            'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 3, 0, 3, 0,
+            3, 0, 3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([20,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [20,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            10),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [32, 33, 34, 35,
-            36,]; let shifted : & 'static [u8] = & [1, 1, 1, 1, 1,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(19),
-            11),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [32, 33, 34, 35,
-            36,]; let shifted : & 'static [u8] = & [2, 2, 2, 2, 2,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
-            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
-            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 31),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 32,
-            33, 33, 34, 34, 35, 35, 36, 36,]; let shifted : & 'static [u8] = & [0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 3, 0, 3, 0, 3, 0, 3,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([30,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [30,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![30,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [30,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
             (::rusty_lr_core::TerminalSymbol::Term(21), 14),
-            (::rusty_lr_core::TerminalSymbol::Error, 41),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 43), (GrammarNonTerminals::_PatternPlus22,
-            44), (GrammarNonTerminals::_PatternStar23, 46),
-            (GrammarNonTerminals::__PatternStar23SepPlus24, 47),]), reduce_map : { let
-            mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([99,]); __reduce_map.extend(__rustylr_tset4
+            (::rusty_lr_core::TerminalSymbol::Error, 41),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            43), (GrammarNonTerminals::_PatternPlus22, 44),
+            (GrammarNonTerminals::_PatternStar23, 46),
+            (GrammarNonTerminals::__PatternStar23SepPlus24, 47),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![99,]; __reduce_map
+            .extend(__rustylr_tset4.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22,
+            23, 24, 25, 26, 27, 28, 28, 29, 29, 30, 31, 32, 33, 34, 35, 36, 96, 97, 98,
+            99, 100, 101,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(9), 15),], shift_goto_map_nonterm
+            : vec![(GrammarNonTerminals::_caretQuestion19, 16),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![91,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [19, 90, 91,]; let
+            shifted : & 'static [u8] = & [1, 0, 0,]; rules.iter().zip(shifted.iter())
+            .map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule :
+            rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![90,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [90,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 17),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 21),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSetItem, 25),
+            (GrammarNonTerminals::_TerminalSetItemPlus20, 26),
+            (GrammarNonTerminals::_TerminalSetItemStar21, 28),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![95,]; __reduce_map
+            .extend(__rustylr_tset6.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [13, 14, 15, 16,
+            17, 18, 19, 92, 93, 94, 95,]; let shifted : & 'static [u8] = & [0, 0, 0, 0,
+            0, 0, 2, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(10), 18),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); let reduce_rules = vec![13,]; __reduce_map.extend(__rustylr_tset5
             .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26,
-            27, 28, 28, 29, 29, 30, 31, 32, 33, 34, 35, 36, 96, 97, 98, 99, 100, 101,];
-            let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(|
-            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
-            as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(9),
-            15),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::_caretQuestion19,
-            16),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([91,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [19, 90, 91,]; let shifted : &
-            'static [u8] = & [1, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (& rule,
+            ruleset : { let rules : & 'static [u8] = & [13, 14, 15,]; let shifted : &
+            'static [u8] = & [1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule,
             & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([90,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [90,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            17), (::rusty_lr_core::TerminalSymbol::Term(16), 21),]),
-            shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSetItem, 25),
-            (GrammarNonTerminals::_TerminalSetItemPlus20, 26),
-            (GrammarNonTerminals::_TerminalSetItemStar21, 28),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([95,]); __reduce_map.extend(__rustylr_tset6
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [13, 14, 15, 16, 17, 18, 19, 92,
-            93, 94, 95,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
-            0,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(10),
-            18),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([13,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 19),
+            (::rusty_lr_core::TerminalSymbol::Error, 20),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [14, 15,]; let shifted : & 'static
+            [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
+            | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![14,]; __reduce_map
             .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [13, 14, 15,]; let
-            shifted : & 'static [u8] = & [1, 1, 1,]; rules.iter().zip(shifted.iter())
-            .map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule :
-            rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            19), (::rusty_lr_core::TerminalSymbol::Error, 20),]), shift_goto_map_nonterm
-            : std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [14, 15,]; let shifted : & 'static [u8] = & [2, 2,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([14,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [14,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([15,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [15,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(10),
-            22),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([16,]); __reduce_map
-            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [16, 17, 18,]; let
-            shifted : & 'static [u8] = & [1, 1, 1,]; rules.iter().zip(shifted.iter())
-            .map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule :
-            rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(16),
-            23), (::rusty_lr_core::TerminalSymbol::Error, 24),]), shift_goto_map_nonterm
-            : std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [17, 18,]; let shifted : & 'static [u8] = & [2, 2,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([17,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [17,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([18,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [18,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([92,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [92,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            17), (::rusty_lr_core::TerminalSymbol::Term(16), 21),]),
-            shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSetItem,
-            27),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([94,]); __reduce_map.extend(__rustylr_tset6
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [13, 14, 15, 16, 17, 18, 93, 94,];
-            let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 1, 1,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([93,]); __reduce_map.extend(__rustylr_tset5
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [93,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(22),
-            29),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [19,]; let shifted
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [14,]; let shifted
             : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([19,]); __reduce_map.extend(__rustylr_tset3
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![15,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [15,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(10), 22),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); let reduce_rules = vec![16,]; __reduce_map.extend(__rustylr_tset5
             .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [19,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ruleset : { let rules : & 'static [u8] = & [16, 17, 18,]; let shifted : &
+            'static [u8] = & [1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule,
+            & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(16), 23),
+            (::rusty_lr_core::TerminalSymbol::Error, 24),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [17, 18,]; let shifted : & 'static
+            [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
+            | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![17,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [17,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![18,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [18,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![92,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [92,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 17),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 21),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSetItem, 27),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![94,]; __reduce_map
+            .extend(__rustylr_tset6.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [13, 14, 15, 16,
+            17, 18, 93, 94,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 1, 1,];
+            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([26,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [26,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![93,]; __reduce_map
+            .extend(__rustylr_tset5.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [93,]; let shifted
+            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(22), 29),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [19,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![19,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [19,]; let shifted
+            : & 'static [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![26,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [26,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
             (::rusty_lr_core::TerminalSymbol::Term(8), 34),
             (::rusty_lr_core::TerminalSymbol::Term(10), 35),
             (::rusty_lr_core::TerminalSymbol::Term(11), 37),
             (::rusty_lr_core::TerminalSymbol::Term(12), 38),
-            (::rusty_lr_core::TerminalSymbol::Term(15), 40),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [22, 23, 24, 25, 27, 31, 32, 33, 34, 35, 36,]; let shifted :
-            & 'static [u8] = & [1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
+            (::rusty_lr_core::TerminalSymbol::Term(15), 40),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [22, 23, 24, 25, 27, 31, 32, 33,
+            34, 35, 36,]; let shifted : & 'static [u8] = & [1, 1, 1, 1, 1, 1, 4, 4, 4, 4,
+            4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([22,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [22,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([23,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [23,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([24,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [24,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
-            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
-            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 36),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 32,
-            33, 34, 35, 36,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (&
-            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
-            usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
-            (::rusty_lr_core::TerminalSymbol::Term(8), 34),
-            (::rusty_lr_core::TerminalSymbol::Term(11), 37),
-            (::rusty_lr_core::TerminalSymbol::Term(12), 38),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([31,]); __reduce_map.extend(__rustylr_tset7
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [22, 23, 24, 25, 27, 31,]; let
-            shifted : & 'static [u8] = & [1, 1, 1, 1, 1, 3,]; rules.iter().zip(shifted
-            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
-            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([25,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [25,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
-            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
-            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 39),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26, 27, 27, 28, 29, 30, 31, 32,
-            33, 34, 35, 36,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0,
-            0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (&
-            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
-            usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
-            (::rusty_lr_core::TerminalSymbol::Term(8), 34),
-            (::rusty_lr_core::TerminalSymbol::Term(11), 37),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([27,]); __reduce_map.extend(__rustylr_tset8
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [22, 23, 24, 25, 27,]; let shifted
-            : & 'static [u8] = & [1, 1, 1, 1, 3,]; rules.iter().zip(shifted.iter()).map(|
-            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
-            as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
-            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
-            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 51),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 32,
-            33, 33, 34, 34, 35, 35, 36, 36,]; let shifted : & 'static [u8] = & [0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 5, 0, 5, 0, 5, 0, 5,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(20),
-            42),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [29,]; let shifted
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![22,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [22,]; let shifted
             : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([29,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [29,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
-            (::rusty_lr_core::TerminalSymbol::Term(8), 34),
-            (::rusty_lr_core::TerminalSymbol::Term(10), 35),
-            (::rusty_lr_core::TerminalSymbol::Term(11), 37),
-            (::rusty_lr_core::TerminalSymbol::Term(12), 38),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([96,]); __reduce_map.extend(__rustylr_tset9
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [22, 23, 24, 25, 27, 31, 96,]; let
-            shifted : & 'static [u8] = & [1, 1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted
-            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
-            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![23,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [23,]; let shifted
+            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![24,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [24,]; let shifted
+            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 45),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([98,]); __reduce_map.extend(__rustylr_tset4
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            36),], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26,
-            27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 97, 98,]; let shifted : & 'static
-            [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            27, 28, 29, 30, 31, 31, 32, 33, 34, 35, 36,]; let shifted : & 'static [u8] =
+            & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,]; rules.iter()
+            .zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            (::rusty_lr_core::TerminalSymbol::Term(8), 34),
+            (::rusty_lr_core::TerminalSymbol::Term(11), 37),
+            (::rusty_lr_core::TerminalSymbol::Term(12), 38),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![31,]; __reduce_map.extend(__rustylr_tset7.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [22, 23, 24, 25, 27, 31,]; let shifted : & 'static [u8] = & [1, 1,
+            1, 1, 1, 3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![25,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [25,]; let shifted
+            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
+            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            39),], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26,
+            27, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,]; let shifted : & 'static [u8] =
+            & [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter()
+            .zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            (::rusty_lr_core::TerminalSymbol::Term(8), 34),
+            (::rusty_lr_core::TerminalSymbol::Term(11), 37),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![27,]; __reduce_map.extend(__rustylr_tset8.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [22, 23, 24, 25, 27,]; let shifted : & 'static [u8] = & [1, 1, 1, 1,
+            3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
+            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            51),], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26,
+            27, 28, 29, 30, 31, 32, 32, 33, 33, 34, 34, 35, 35, 36, 36,]; let shifted : &
+            'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 5, 0, 5, 0,
+            5, 0, 5,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(20), 42),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [29,];
+            let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![29,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [29,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
             (::rusty_lr_core::TerminalSymbol::Term(8), 34),
             (::rusty_lr_core::TerminalSymbol::Term(10), 35),
             (::rusty_lr_core::TerminalSymbol::Term(11), 37),
-            (::rusty_lr_core::TerminalSymbol::Term(12), 38),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([97,]); __reduce_map.extend(__rustylr_tset9
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [22, 23, 24, 25, 27, 31, 97,]; let
-            shifted : & 'static [u8] = & [1, 1, 1, 1, 1, 1, 2,]; rules.iter().zip(shifted
-            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
-            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([100,]); __reduce_map.extend(__rustylr_tset4
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [100,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(3),
-            48), (::rusty_lr_core::TerminalSymbol::Term(20), 50),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            (::rusty_lr_core::TerminalSymbol::Term(12), 38),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![96,]; __reduce_map.extend(__rustylr_tset9.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [22, 23, 24, 25, 27, 31, 96,]; let shifted : & 'static [u8] = & [1,
+            1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            (::rusty_lr_core::TerminalSymbol::Term(14), 9),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 12),
+            (::rusty_lr_core::TerminalSymbol::Term(19), 13),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            45),], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![98,]; __reduce_map.extend(__rustylr_tset4.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+            36, 97, 98,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (&
+            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
+            usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            (::rusty_lr_core::TerminalSymbol::Term(8), 34),
+            (::rusty_lr_core::TerminalSymbol::Term(10), 35),
+            (::rusty_lr_core::TerminalSymbol::Term(11), 37),
+            (::rusty_lr_core::TerminalSymbol::Term(12), 38),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![97,]; __reduce_map.extend(__rustylr_tset9.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [22, 23, 24, 25, 27, 31, 97,]; let shifted : & 'static [u8] = & [1,
+            1, 1, 1, 1, 1, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![100,]; __reduce_map
+            .extend(__rustylr_tset4.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [100,]; let
+            shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (&
+            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
+            usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(3), 48),
+            (::rusty_lr_core::TerminalSymbol::Term(20), 50),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [28, 101,]; let shifted : &
             'static [u8] = & [2, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            7), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 7),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TerminalSet, 30),
-            (GrammarNonTerminals::Pattern, 43), (GrammarNonTerminals::_PatternPlus22,
-            44), (GrammarNonTerminals::_PatternStar23, 49),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([99,]); __reduce_map.extend(__rustylr_tset4
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22, 23, 24, 25, 26,
-            27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 96, 97, 98, 99, 101,]; let shifted :
-            & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([101,]); __reduce_map.extend(__rustylr_tset4
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [101,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([28,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [28,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            43), (GrammarNonTerminals::_PatternPlus22, 44),
+            (GrammarNonTerminals::_PatternStar23, 49),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![99,]; __reduce_map
+            .extend(__rustylr_tset4.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [19, 20, 21, 22,
+            23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 96, 97, 98, 99,
+            101,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,]; rules.iter().zip(shifted.iter()).map(| (&
+            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
+            usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![101,]; __reduce_map
+            .extend(__rustylr_tset4.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [101,]; let
+            shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (&
+            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
+            usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![28,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [28,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
             (::rusty_lr_core::TerminalSymbol::Term(8), 34),
             (::rusty_lr_core::TerminalSymbol::Term(10), 35),
             (::rusty_lr_core::TerminalSymbol::Term(11), 37),
             (::rusty_lr_core::TerminalSymbol::Term(12), 38),
             (::rusty_lr_core::TerminalSymbol::Term(15), 52),
-            (::rusty_lr_core::TerminalSymbol::Error, 59),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::_commaQuestion25,
-            61),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([103,]); __reduce_map
+            (::rusty_lr_core::TerminalSymbol::Error, 59),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::_commaQuestion25, 61),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![103,]; __reduce_map
             .extend(__rustylr_tset10.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [22,
             23, 24, 25, 27, 31, 32, 33, 34, 35, 36, 102, 103,]; let shifted : & 'static
             [u8] = & [1, 1, 1, 1, 1, 1, 6, 6, 6, 6, 6, 0, 0,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            53), (::rusty_lr_core::TerminalSymbol::Term(7), 55),
-            (::rusty_lr_core::TerminalSymbol::Error, 57),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([102,]); __reduce_map
-            .extend(__rustylr_tset10.iter().map(| term | (* term, reduce_rules
-            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [33,
-            34, 36, 102,]; let shifted : & 'static [u8] = & [7, 7, 7, 1,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 53),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 55),
+            (::rusty_lr_core::TerminalSymbol::Error, 57),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![102,]; __reduce_map.extend(__rustylr_tset10.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [33, 34, 36, 102,]; let shifted : & 'static [u8] = & [7, 7, 7, 1,];
+            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(20),
-            54),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(20), 54),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [33,];
+            let shifted : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![33,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
             __reduce_map }, ruleset : { let rules : & 'static [u8] = & [33,]; let shifted
-            : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            : & 'static [u8] = & [9,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([33,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [33,]; let shifted : & 'static
-            [u8] = & [9,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(20),
-            56),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(20), 56),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [34,];
+            let shifted : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![34,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
             __reduce_map }, ruleset : { let rules : & 'static [u8] = & [34,]; let shifted
-            : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            : & 'static [u8] = & [9,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([34,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [34,]; let shifted : & 'static
-            [u8] = & [9,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(20),
-            58),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(20), 58),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [36,];
+            let shifted : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![36,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
             __reduce_map }, ruleset : { let rules : & 'static [u8] = & [36,]; let shifted
+            : & 'static [u8] = & [9,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(20), 60),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [35,];
+            let shifted : & 'static [u8] = & [7,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![35,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [35,]; let shifted
             : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([36,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [36,]; let shifted : & 'static
-            [u8] = & [9,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(20),
-            60),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [35,]; let shifted
-            : & 'static [u8] = & [7,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([35,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [35,]; let shifted : & 'static
-            [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(20),
-            62),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(20), 62),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [32,];
+            let shifted : & 'static [u8] = & [7,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![32,]; __reduce_map
+            .extend(__rustylr_tset3.iter().map(| term | (* term, reduce_rules.clone())));
             __reduce_map }, ruleset : { let rules : & 'static [u8] = & [32,]; let shifted
-            : & 'static [u8] = & [7,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            : & 'static [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
             shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([32,]); __reduce_map.extend(__rustylr_tset3
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [32,]; let shifted : & 'static
-            [u8] = & [8,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
             (::rusty_lr_core::TerminalSymbol::Term(8), 34),
             (::rusty_lr_core::TerminalSymbol::Term(10), 35),
             (::rusty_lr_core::TerminalSymbol::Term(11), 37),
-            (::rusty_lr_core::TerminalSymbol::Term(12), 38),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([12,]); __reduce_map.extend(__rustylr_tset11
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [12, 22, 23, 24, 25, 27, 31,]; let
-            shifted : & 'static [u8] = & [3, 1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted
-            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
-            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            65), (::rusty_lr_core::TerminalSymbol::Term(3), 66),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            (::rusty_lr_core::TerminalSymbol::Term(12), 38),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![12,]; __reduce_map.extend(__rustylr_tset11.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [12, 22, 23, 24, 25, 27, 31,]; let shifted : & 'static [u8] = & [3,
+            1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 65),
+            (::rusty_lr_core::TerminalSymbol::Term(3), 66),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [0, 3,]; let shifted : & 'static
             [u8] = & [4, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([0,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [0,]; let shifted : & 'static [u8]
-            = & [5,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            5), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![0,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [0,];
+            let shifted : & 'static [u8] = & [5,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 5),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RuleLine, 67),
-            (GrammarNonTerminals::TokenMapped, 68), (GrammarNonTerminals::TerminalSet,
-            30), (GrammarNonTerminals::Pattern, 69),
-            (GrammarNonTerminals::_TokenMappedPlus15, 70),
-            (GrammarNonTerminals::_TokenMappedStar16, 72),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([85,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [3, 5, 11, 12, 19, 20, 21, 22, 23,
-            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 82, 83, 84, 85,]; let
-            shifted : & 'static [u8] = & [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (&
-            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
-            usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([3,]); __reduce_map.extend(__rustylr_tset13
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [3,]; let shifted : & 'static [u8]
-            = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([82,]); __reduce_map.extend(__rustylr_tset11
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [82,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(6),
-            32), (::rusty_lr_core::TerminalSymbol::Term(7), 33),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RuleLine, 67), (GrammarNonTerminals::TokenMapped,
+            68), (GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
+            69), (GrammarNonTerminals::_TokenMappedPlus15, 70),
+            (GrammarNonTerminals::_TokenMappedStar16, 72),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![85,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [3, 5, 11, 12, 19,
+            20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 82, 83,
+            84, 85,]; let shifted : & 'static [u8] = & [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![3,]; __reduce_map
+            .extend(__rustylr_tset13.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [3,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![82,]; __reduce_map
+            .extend(__rustylr_tset11.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [82,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(6), 32),
+            (::rusty_lr_core::TerminalSymbol::Term(7), 33),
             (::rusty_lr_core::TerminalSymbol::Term(8), 34),
             (::rusty_lr_core::TerminalSymbol::Term(10), 35),
             (::rusty_lr_core::TerminalSymbol::Term(11), 37),
-            (::rusty_lr_core::TerminalSymbol::Term(12), 38),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([11,]); __reduce_map.extend(__rustylr_tset11
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [11, 22, 23, 24, 25, 27, 31,]; let
-            shifted : & 'static [u8] = & [1, 1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted
-            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
-            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            5), (::rusty_lr_core::TerminalSymbol::Term(13), 8),
+            (::rusty_lr_core::TerminalSymbol::Term(12), 38),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![11,]; __reduce_map.extend(__rustylr_tset11.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [11, 22, 23, 24, 25, 27, 31,]; let shifted : & 'static [u8] = & [1,
+            1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 5),
+            (::rusty_lr_core::TerminalSymbol::Term(13), 8),
             (::rusty_lr_core::TerminalSymbol::Term(14), 9),
             (::rusty_lr_core::TerminalSymbol::Term(16), 12),
             (::rusty_lr_core::TerminalSymbol::Term(19), 13),
-            (::rusty_lr_core::TerminalSymbol::Term(21), 14),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::TokenMapped, 71),
-            (GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern,
-            69),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([84,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [11, 12, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 83, 84,]; let shifted : &
-            'static [u8] = & [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([83,]); __reduce_map.extend(__rustylr_tset11
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [83,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(4),
-            73),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::PrecDef, 83),
+            (::rusty_lr_core::TerminalSymbol::Term(21), 14),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::TokenMapped, 71),
+            (GrammarNonTerminals::TerminalSet, 30), (GrammarNonTerminals::Pattern, 69),],
+            reduce_map : { let mut __reduce_map = Vec::new(); let reduce_rules =
+            vec![84,]; __reduce_map.extend(__rustylr_tset1.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [11, 12, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+            34, 35, 36, 83, 84,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![83,]; __reduce_map
+            .extend(__rustylr_tset11.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [83,]; let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(4), 73),], shift_goto_map_nonterm
+            : vec![(GrammarNonTerminals::PrecDef, 83),
             (GrammarNonTerminals::_PrecDefPlus17, 84),
-            (GrammarNonTerminals::_PrecDefStar18, 86),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([89,]); __reduce_map.extend(__rustylr_tset14
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [5, 6, 7, 8, 9, 10, 86, 87, 88,
-            89,]; let shifted : & 'static [u8] = & [1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            (GrammarNonTerminals::_PrecDefStar18, 86),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![89,]; __reduce_map
+            .extend(__rustylr_tset14.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [5,
+            6, 7, 8, 9, 10, 86, 87, 88, 89,]; let shifted : & 'static [u8] = & [1, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(34), 74),
+            (::rusty_lr_core::TerminalSymbol::Term(39), 79),
+            (::rusty_lr_core::TerminalSymbol::Error, 82),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [6, 7, 8, 9, 10,]; let shifted : &
+            'static [u8] = & [1, 1, 1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (&
+            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
+            usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),
+            (::rusty_lr_core::TerminalSymbol::Error, 77),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 78),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [6, 7, 39, 40,]; let shifted : & 'static [u8] = & [2, 2, 0, 0,];
+            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(34),
-            74), (::rusty_lr_core::TerminalSymbol::Term(39), 79),
-            (::rusty_lr_core::TerminalSymbol::Error, 82),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [6, 7, 8, 9, 10,]; let shifted : & 'static [u8] = & [1, 1,
-            1, 1, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(16), 76),
-            (::rusty_lr_core::TerminalSymbol::Error, 77),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral,
-            78),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [6, 7, 39, 40,]; let shifted : & 'static [u8] = & [2, 2, 0,
-            0,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([39,]); __reduce_map.extend(__rustylr_tset15
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [39,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([40,]); __reduce_map.extend(__rustylr_tset15
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [40,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([7,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [7,]; let shifted : & 'static [u8]
-            = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([6,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [6,]; let shifted : & 'static [u8]
-            = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(16),
-            80), (::rusty_lr_core::TerminalSymbol::Error, 81),]), shift_goto_map_nonterm
-            : std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [8, 9,]; let shifted : & 'static [u8] = & [2, 2,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([8,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [8,]; let shifted : & 'static [u8]
-            = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([9,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [9,]; let shifted : & 'static [u8]
-            = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([10,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [10,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([86,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [86,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(4),
-            73),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::PrecDef, 85),]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([88,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![39,]; __reduce_map
+            .extend(__rustylr_tset15.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [39,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![40,]; __reduce_map
+            .extend(__rustylr_tset15.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [40,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![7,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [7,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![6,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [6,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(16), 80),
+            (::rusty_lr_core::TerminalSymbol::Error, 81),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [8, 9,]; let shifted : & 'static
+            [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
+            | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![8,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [8,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![9,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [9,]; let shifted
+            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![10,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [10,]; let shifted
+            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![86,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [86,]; let shifted
+            : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(4), 73),], shift_goto_map_nonterm
+            : vec![(GrammarNonTerminals::PrecDef, 85),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![88,]; __reduce_map
             .extend(__rustylr_tset14.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [6,
             7, 8, 9, 10, 87, 88,]; let shifted : & 'static [u8] = & [0, 0, 0, 0, 0, 1,
             1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([87,]); __reduce_map.extend(__rustylr_tset1
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [87,]; let shifted : & 'static
-            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![87,]; __reduce_map
+            .extend(__rustylr_tset1.iter().map(| term | (* term, reduce_rules.clone())));
+            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [87,]; let shifted
+            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
+            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
+            shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(18), 87),],
+            shift_goto_map_nonterm : vec![(GrammarNonTerminals::Action, 88),], reduce_map
+            : { let mut __reduce_map = Vec::new(); let reduce_rules = vec![38,];
+            __reduce_map.extend(__rustylr_tset13.iter().map(| term | (* term,
+            reduce_rules.clone()))); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [5, 37, 38,]; let shifted : & 'static [u8] = & [2, 0, 0,]; rules
+            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(18),
-            87),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::Action, 88),]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([38,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![37,]; __reduce_map
             .extend(__rustylr_tset13.iter().map(| term | (* term, reduce_rules
-            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [5,
-            37, 38,]; let shifted : & 'static [u8] = & [2, 0, 0,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([37,]); __reduce_map.extend(__rustylr_tset13
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [37,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([5,]); __reduce_map.extend(__rustylr_tset13
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [5,]; let shifted : & 'static [u8]
-            = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([4,]); __reduce_map.extend(__rustylr_tset13
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [4,]; let shifted : & 'static [u8]
-            = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(23),
-            91), (::rusty_lr_core::TerminalSymbol::Term(24), 98),
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [37,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![5,]; __reduce_map
+            .extend(__rustylr_tset13.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [5,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![4,]; __reduce_map
+            .extend(__rustylr_tset13.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [4,];
+            let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(23), 91),
+            (::rusty_lr_core::TerminalSymbol::Term(24), 98),
             (::rusty_lr_core::TerminalSymbol::Term(25), 103),
             (::rusty_lr_core::TerminalSymbol::Term(26), 156),
             (::rusty_lr_core::TerminalSymbol::Term(27), 161),
@@ -8669,144 +8554,130 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 209),
             (::rusty_lr_core::TerminalSymbol::Term(41), 213),
             (::rusty_lr_core::TerminalSymbol::Term(42), 217),
-            (::rusty_lr_core::TerminalSymbol::Error, 221),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-            57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
-            76, 77, 78,]; let shifted : & 'static [u8] = & [1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(16), 76),
-            (::rusty_lr_core::TerminalSymbol::Error, 92),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral, 94),
-            (GrammarNonTerminals::_IdentOrLiteralPlus28, 95),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [39, 40, 52, 53, 149, 150,]; let shifted : &
-            'static [u8] = & [0, 0, 2, 2, 0, 0,]; rules.iter().zip(shifted.iter()).map(|
+            (::rusty_lr_core::TerminalSymbol::Error, 221),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [42, 43, 44, 45, 46, 47, 48, 49,
+            50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+            69, 70, 71, 72, 73, 74, 75, 76, 77, 78,]; let shifted : & 'static [u8] = &
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,]; rules.iter().zip(shifted.iter()).map(|
             (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
             as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            93),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [53,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([53,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [53,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),
+            (::rusty_lr_core::TerminalSymbol::Error, 92),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 94),
+            (GrammarNonTerminals::_IdentOrLiteralPlus28, 95),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [39, 40, 52, 53, 149, 150,]; let shifted : & 'static [u8] = & [0, 0,
+            2, 2, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([149,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 93),], shift_goto_map_nonterm
+            : vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [53,]; let shifted : & 'static
+            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![53,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [53,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![149,]; __reduce_map
             .extend(__rustylr_tset16.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [149,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(2), 96),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 76),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral,
-            97),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [39, 40, 52, 150,]; let shifted : & 'static [u8] = & [0, 0,
-            3, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(2), 96),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 97),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [39, 40, 52, 150,]; let shifted : & 'static [u8] = & [0, 0, 3, 1,];
+            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([52,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [52,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([150,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![52,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [52,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![150,]; __reduce_map
             .extend(__rustylr_tset16.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [150,]; let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(16), 76),
-            (::rusty_lr_core::TerminalSymbol::Error, 99),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral, 94),
-            (GrammarNonTerminals::_IdentOrLiteralPlus28, 101),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [39, 40, 54, 55, 149, 150,]; let shifted : &
-            'static [u8] = & [0, 0, 2, 2, 0, 0,]; rules.iter().zip(shifted.iter()).map(|
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),
+            (::rusty_lr_core::TerminalSymbol::Error, 99),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 94),
+            (GrammarNonTerminals::_IdentOrLiteralPlus28, 101),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [39, 40, 54, 55, 149, 150,]; let shifted : & 'static [u8] = & [0, 0,
+            2, 2, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 100),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [55,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
             (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
             as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            100),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [55,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([55,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [55,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![55,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [55,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(2), 102),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 97),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [39, 40, 54, 150,]; let shifted : & 'static [u8] = & [0, 0, 3, 1,];
+            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(2), 102),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 76),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral,
-            97),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [39, 40, 54, 150,]; let shifted : & 'static [u8] = & [0, 0,
-            3, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([54,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [54,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            104), (::rusty_lr_core::TerminalSymbol::Error, 154),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![54,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [54,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 104),
+            (::rusty_lr_core::TerminalSymbol::Error, 154),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [42, 43, 44,]; let shifted : &
             'static [u8] = & [2, 2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule,
             & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
             shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 107),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -8848,488 +8719,396 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 149),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 42, 43, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([104,]); __reduce_map
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 149), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 42, 43, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 3, 3, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![104,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [104,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([105,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![105,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [105,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([43,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [43,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([106,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![43,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [43,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![106,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [106,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([107,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![107,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [107,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([108,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![108,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [108,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([109,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![109,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [109,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([110,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![110,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [110,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([111,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![111,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [111,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([112,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![112,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [112,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([113,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![113,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [113,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([114,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![114,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [114,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([115,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![115,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [115,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([116,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![116,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [116,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([117,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![117,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [117,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([118,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![118,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [118,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([119,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![119,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [119,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([120,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![120,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [120,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([121,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![121,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [121,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([122,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![122,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [122,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([123,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![123,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [123,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([124,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![124,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [124,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([125,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![125,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [125,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([126,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![126,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [126,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([127,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![127,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [127,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([128,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![128,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [128,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([129,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![129,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [129,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([130,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![130,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [130,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([131,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![131,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [131,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([132,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![132,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [132,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([133,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![133,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [133,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([134,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![134,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [134,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([135,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![135,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [135,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([136,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![136,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [136,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([137,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![137,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [137,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([138,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![138,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [138,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([139,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![139,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [139,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([140,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![140,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [140,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([141,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![141,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [141,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([142,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![142,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [142,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([143,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![143,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [143,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([144,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![144,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [144,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([145,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![145,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [145,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([146,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![146,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [146,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            150),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [42,]; let shifted
-            : & 'static [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([42,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [42,]; let shifted : & 'static
-            [u8] = & [5,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([147,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 150),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [42,];
+            let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![42,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [42,]; let shifted : & 'static [u8] = & [5,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![147,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [147,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
             (::rusty_lr_core::TerminalSymbol::Term(5), 110),
@@ -9370,10 +9149,9 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::_TermSet26, 153),]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([41,]); __reduce_map
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::_TermSet26, 153),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![41,]; __reduce_map
             .extend(__rustylr_tset18.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [41,
             104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,
@@ -9383,108 +9161,93 @@ impl GrammarParser {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([148,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![148,]; __reduce_map
             .extend(__rustylr_tset17.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [148,]; let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            155),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [44,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([44,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [44,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            157), (::rusty_lr_core::TerminalSymbol::Error, 159),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 155),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [44,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![44,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [44,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 157),
+            (::rusty_lr_core::TerminalSymbol::Error, 159),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [45, 46,]; let shifted : & 'static
             [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            158),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [45,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([45,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [45,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            160),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [46,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([46,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [46,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Error,
-            162),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [47,]; let shifted
-            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            163),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [47,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([47,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 158),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [45,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![45,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [45,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 160),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [46,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![46,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [46,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Error, 162),], shift_goto_map_nonterm
+            : vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [47,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 163),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [47,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![47,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [47,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 165),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -9526,50 +9289,44 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 166),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 48, 49, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([49,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [49,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            167),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [48,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([48,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [48,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 166), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 48, 49, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 2, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![49,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [49,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 167),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [48,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![48,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [48,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 169),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -9611,50 +9368,44 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 170),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 50, 51, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([51,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [51,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            171),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [50,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([50,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [50,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 170), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 50, 51, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 2, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![51,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [51,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 171),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [50,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![50,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [50,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 173),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -9696,50 +9447,44 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 174),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 58, 59, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([59,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [59,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            175),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [58,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([58,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [58,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 174), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 58, 59, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 2, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![59,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [59,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 175),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [58,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![58,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [58,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 177),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -9781,322 +9526,279 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 178),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 60, 61, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([61,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [61,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            179),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [60,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([60,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [60,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            181), (::rusty_lr_core::TerminalSymbol::Error, 182),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 178), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 60, 61, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 2, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![61,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [61,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 179),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [60,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![60,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [60,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 181),
+            (::rusty_lr_core::TerminalSymbol::Error, 182),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [64, 65,]; let shifted : & 'static
             [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([64,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [64,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            183),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [65,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([65,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [65,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            185), (::rusty_lr_core::TerminalSymbol::Error, 186),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![64,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [64,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 183),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [65,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![65,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [65,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 185),
+            (::rusty_lr_core::TerminalSymbol::Error, 186),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [62, 63,]; let shifted : & 'static
             [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([62,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [62,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            187),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [63,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([63,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [63,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(16), 76),
-            (::rusty_lr_core::TerminalSymbol::Error, 189),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral, 94),
-            (GrammarNonTerminals::_IdentOrLiteralPlus28, 191),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [39, 40, 56, 57, 149, 150,]; let shifted : &
-            'static [u8] = & [0, 0, 2, 2, 0, 0,]; rules.iter().zip(shifted.iter()).map(|
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![62,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [62,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 187),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [63,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
             (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
             as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            190),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [57,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([57,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [57,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![63,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [63,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),
+            (::rusty_lr_core::TerminalSymbol::Error, 189),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 94),
+            (GrammarNonTerminals::_IdentOrLiteralPlus28, 191),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [39, 40, 56, 57, 149, 150,]; let shifted : & 'static [u8] = & [0, 0,
+            2, 2, 0, 0,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            75), (::rusty_lr_core::TerminalSymbol::Term(2), 192),
-            (::rusty_lr_core::TerminalSymbol::Term(16), 76),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::IdentOrLiteral,
-            97),]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [39, 40, 56, 150,]; let shifted : & 'static [u8] = & [0, 0,
-            3, 1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 190),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [57,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![57,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [57,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 75),
+            (::rusty_lr_core::TerminalSymbol::Term(2), 192),
+            (::rusty_lr_core::TerminalSymbol::Term(16), 76),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::IdentOrLiteral, 97),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [39, 40, 56, 150,]; let shifted : & 'static [u8] = & [0, 0, 3, 1,];
+            rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([56,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [56,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            194), (::rusty_lr_core::TerminalSymbol::Error, 195),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![56,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [56,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 194),
+            (::rusty_lr_core::TerminalSymbol::Error, 195),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [66, 67,]; let shifted : & 'static
             [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([66,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [66,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            196),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [67,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([67,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [67,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            198), (::rusty_lr_core::TerminalSymbol::Error, 199),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![66,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [66,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 196),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [67,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![67,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [67,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 198),
+            (::rusty_lr_core::TerminalSymbol::Error, 199),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [68, 69,]; let shifted : & 'static
             [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([68,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [68,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            200),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [69,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([69,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [69,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            202), (::rusty_lr_core::TerminalSymbol::Error, 203),]),
-            shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::_identPlus29, 205),
-            (GrammarNonTerminals::_identStar30, 207),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([154,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![68,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [68,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 200),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [69,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![69,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [69,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 202),
+            (::rusty_lr_core::TerminalSymbol::Error, 203),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::_identPlus29, 205),
+            (GrammarNonTerminals::_identStar30, 207),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![154,]; __reduce_map
             .extend(__rustylr_tset18.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [70,
             71, 151, 152, 153, 154,]; let shifted : & 'static [u8] = & [2, 2, 0, 0, 0,
             0,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([151,]); __reduce_map
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![151,]; __reduce_map
             .extend(__rustylr_tset19.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [151,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            204),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [71,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([71,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [71,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            206),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new(); let
-            reduce_rules = std::collections::BTreeSet::from([153,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 204),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [71,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![71,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [71,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 206),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); let reduce_rules = vec![153,]; __reduce_map
             .extend(__rustylr_tset18.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [152,
             153,]; let shifted : & 'static [u8] = & [1, 1,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([152,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![152,]; __reduce_map
             .extend(__rustylr_tset19.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [152,]; let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            208),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [70,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([70,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [70,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 208),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [70,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![70,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [70,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 210),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -10138,86 +9840,75 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 211),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 72, 73, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([73,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [73,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            212),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [72,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([72,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [72,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            214), (::rusty_lr_core::TerminalSymbol::Error, 215),]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); __reduce_map },
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 211), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 72, 73, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 2, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![73,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [73,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 212),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [72,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![72,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [72,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 214),
+            (::rusty_lr_core::TerminalSymbol::Error, 215),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
             ruleset : { let rules : & 'static [u8] = & [74, 75,]; let shifted : & 'static
             [u8] = & [2, 2,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted)
             | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([74,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [74,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            216),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [75,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([75,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [75,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            105), (::rusty_lr_core::TerminalSymbol::Term(1), 106),
+            shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![74,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [74,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 216),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [75,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![75,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [75,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 105),
+            (::rusty_lr_core::TerminalSymbol::Term(1), 106),
             (::rusty_lr_core::TerminalSymbol::Term(2), 218),
             (::rusty_lr_core::TerminalSymbol::Term(3), 108),
             (::rusty_lr_core::TerminalSymbol::Term(4), 109),
@@ -10259,91 +9950,79 @@ impl GrammarParser {
             (::rusty_lr_core::TerminalSymbol::Term(40), 145),
             (::rusty_lr_core::TerminalSymbol::Term(41), 146),
             (::rusty_lr_core::TerminalSymbol::Term(42), 147),
-            (::rusty_lr_core::TerminalSymbol::Term(43), 148),]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([(GrammarNonTerminals::RustCode, 219),
-            (GrammarNonTerminals::_TermSet26, 151),
-            (GrammarNonTerminals::__TermSet26Plus27, 152),]), reduce_map : { let mut
-            __reduce_map = std::collections::BTreeMap::new(); __reduce_map }, ruleset : {
-            let rules : & 'static [u8] = & [41, 76, 77, 104, 105, 106, 107, 108, 109,
-            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-            125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-            140, 141, 142, 143, 144, 145, 146, 147, 148,]; let shifted : & 'static [u8] =
-            & [0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules
-            .iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([77,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [77,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            220),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [76,]; let shifted
-            : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([76,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [76,]; let shifted : & 'static
-            [u8] = & [4,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(2),
-            222),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [78,]; let shifted
-            : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(| (& rule, &
-            shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize,
-            shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([78,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [78,]; let shifted : & 'static
-            [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([79,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [79,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([80,]); __reduce_map.extend(__rustylr_tset12
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [80,]; let shifted : & 'static
-            [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Term(0),
-            1), (::rusty_lr_core::TerminalSymbol::Term(4), 90),]), shift_goto_map_nonterm
-            : std::collections::BTreeMap::from([(GrammarNonTerminals::Rule, 223),
-            (GrammarNonTerminals::Directive, 224), (GrammarNonTerminals::GrammarLine,
-            225), (GrammarNonTerminals::_GrammarLinePlus31, 226),]), reduce_map : { let
-            mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([155,]); __reduce_map
+            (::rusty_lr_core::TerminalSymbol::Term(43), 148),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::RustCode, 219), (GrammarNonTerminals::_TermSet26,
+            151), (GrammarNonTerminals::__TermSet26Plus27, 152),], reduce_map : { let mut
+            __reduce_map = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static
+            [u8] = & [41, 76, 77, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+            115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+            130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144,
+            145, 146, 147, 148,]; let shifted : & 'static [u8] = & [0, 2, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![77,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [77,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 220),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [76,];
+            let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![76,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [76,]; let shifted : & 'static [u8] = & [4,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(2), 222),],
+            shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map =
+            Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [78,];
+            let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted.iter()).map(|
+            (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
+            as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![78,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [78,]; let shifted : & 'static [u8] = & [3,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![79,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [79,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![80,]; __reduce_map
+            .extend(__rustylr_tset12.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [80,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Term(0), 1),
+            (::rusty_lr_core::TerminalSymbol::Term(4), 90),], shift_goto_map_nonterm :
+            vec![(GrammarNonTerminals::Rule, 223), (GrammarNonTerminals::Directive, 224),
+            (GrammarNonTerminals::GrammarLine, 225),
+            (GrammarNonTerminals::_GrammarLinePlus31, 226),], reduce_map : { let mut
+            __reduce_map = Vec::new(); let reduce_rules = vec![155,]; __reduce_map
             .extend(__rustylr_tset20.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = & [0,
             42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
@@ -10353,41 +10032,35 @@ impl GrammarParser {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1,]; rules.iter().zip(shifted.iter()).map(|
             (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule
             as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([156,]); __reduce_map
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![156,]; __reduce_map
             .extend(__rustylr_tset20.iter().map(| term | (* term, reduce_rules
             .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
             [156,]; let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted
             .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
             { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([(::rusty_lr_core::TerminalSymbol::Eof,
-            228),]), shift_goto_map_nonterm : std::collections::BTreeMap::from([]),
-            reduce_map : { let mut __reduce_map = std::collections::BTreeMap::new();
-            __reduce_map }, ruleset : { let rules : & 'static [u8] = & [157,]; let
-            shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (&
-            rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as
-            usize, shifted : shifted as usize, } }).collect() } },
-            ::rusty_lr_core::builder::State { shift_goto_map_term :
-            std::collections::BTreeMap::from([]), shift_goto_map_nonterm :
-            std::collections::BTreeMap::from([]), reduce_map : { let mut __reduce_map =
-            std::collections::BTreeMap::new(); __reduce_map }, ruleset : { let rules : &
-            'static [u8] = & [157,]; let shifted : & 'static [u8] = & [2,]; rules.iter()
-            .zip(shifted.iter()).map(| (& rule, & shifted) | {
-            ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
-            shifted as usize, } }).collect() } }, ::rusty_lr_core::builder::State {
-            shift_goto_map_term : std::collections::BTreeMap::from([]),
-            shift_goto_map_nonterm : std::collections::BTreeMap::from([]), reduce_map : {
-            let mut __reduce_map = std::collections::BTreeMap::new(); let reduce_rules =
-            std::collections::BTreeSet::from([81,]); __reduce_map.extend(__rustylr_tset20
-            .iter().map(| term | (* term, reduce_rules.clone()))); __reduce_map },
-            ruleset : { let rules : & 'static [u8] = & [81,]; let shifted : & 'static
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![(::rusty_lr_core::TerminalSymbol::Eof, 228),], shift_goto_map_nonterm :
+            vec![], reduce_map : { let mut __reduce_map = Vec::new(); __reduce_map },
+            ruleset : { let rules : & 'static [u8] = & [157,]; let shifted : & 'static
             [u8] = & [1,]; rules.iter().zip(shifted.iter()).map(| (& rule, & shifted) | {
             ::rusty_lr_core::rule::ShiftedRuleRef { rule : rule as usize, shifted :
             shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [157,]; let shifted : & 'static [u8] = & [2,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
+            ::rusty_lr_core::parser::state::IntermediateState { shift_goto_map_term :
+            vec![], shift_goto_map_nonterm : vec![], reduce_map : { let mut __reduce_map
+            = Vec::new(); let reduce_rules = vec![81,]; __reduce_map
+            .extend(__rustylr_tset20.iter().map(| term | (* term, reduce_rules
+            .clone()))); __reduce_map }, ruleset : { let rules : & 'static [u8] = &
+            [81,]; let shifted : & 'static [u8] = & [1,]; rules.iter().zip(shifted
+            .iter()).map(| (& rule, & shifted) | { ::rusty_lr_core::rule::ShiftedRuleRef
+            { rule : rule as usize, shifted : shifted as usize, } }).collect() } },
         ];
         let states: Vec<GrammarState> = states
             .into_iter()


### PR DESCRIPTION
this could reduce binary size by 10%

we were using `builder::State` for state generation which was using `BTreeMap`.
add new `IntermediateState` struct for common type convertion into any parser state type, and it is using `Vec`.