### PR TITLE
Support Bison-like positional variables ($1, $2, ...) and locations (@1, @2, @0) in reduce actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Track the location of tokens and non-terminals for better error reporting and de
 Expr: exp1=Expr '+' exp2=Expr {
     println!("Location of exp1: {:?}", @exp1);
     println!("Location of exp2: {:?}", @exp2);
-    println!("Location of this expression: {:?}", @$); // @$ is the location of the non-terminal itself
+    println!("Location of this expression: {:?}", @$); // @$ (or @0) is the location of the non-terminal itself
     exp1 + exp2
 }
 | Expr error Expr {

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -191,6 +191,9 @@ You can reference any data with below patterns:
  - `var_name: %RuleType`: token data associated with `var_name`
  - `@var_name: %LocationType`: location data associated with `var_name`
  - `@$: &mut %LocationType`: location data of current non-terminal in this reduce action
+ - `$1`, `$2`, ...: index-based token data ($1 is the leftmost symbol, $2 is the second, etc.)
+ - `@1`, `@2`, ...: index-based location data (@1 is the location of the leftmost symbol, @2 is the second, etc.)
+ - `@0`: location data of current non-terminal in this reduce action (equivalent to `@$`)
  - `lookahead: &TerminalSymbol<%TokenType>`: lookahead token that caused this reduce action
  - `shift: &mut bool`: for non-deterministic GLR parser, set this value to `false` to revoke the shift action
 
@@ -211,6 +214,16 @@ This is also possible for advanced patterns:
 E(i32): A* { A.iter().sum() }; // sum all values in A
 ```
 Here, `A` is a `Vec<A>` and you can access its values directly.
+
+**Bison-style Positional Variables:** You can reference values and locations by their indices in the rule.
+ - `$1`, `$2`, ... represent the semantic values of RHS symbols.
+ - `@1`, `@2`, ... represent the location of RHS symbols.
+ - `@0` represents the location of LHS (equivalent to `@$`).
+
+```rust
+E(i32): A '+' A { $1 + $3 }; // sum first and third token
+```
+
 
 **User Data:** Access mutable user-defined data passed to the parser.
 ```rust

--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -808,6 +808,28 @@ impl Builder {
                             .with_labels(vec![Label::primary(file_id, range)])
                     }
 
+                    ParseError::BisonVariableZero(loc) => {
+                        let range = span_manager.get_byterange(&loc).unwrap_or(0..0);
+                        Diagnostic::error()
+                            .with_message("Bison variable $0 is not supported")
+                            .with_labels(vec![Label::primary(file_id, range)
+                                .with_message("This variable reference is invalid")])
+                            .with_notes(vec!["Bison variable $0 is not supported".to_string()])
+                    }
+
+                    ParseError::BisonVariableOutOfRange {
+                        location,
+                        name,
+                        max,
+                    } => {
+                        let range = span_manager.get_byterange(&location).unwrap_or(0..0);
+                        Diagnostic::error()
+                            .with_message("Bison variable is out of range")
+                            .with_labels(vec![Label::primary(file_id, range)
+                                .with_message(format!("references index out of range (max index: {})", max))])
+                            .with_notes(vec![format!("Bison variable {} is out of range (max index: {})", name, max)])
+                    }
+
                     _ => {
                         let message = e.short_message();
                         let mut labels = Vec::new();

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -1087,17 +1087,24 @@ impl Grammar {
                                     None
                                 }
                             } else {
-                                // if variable was not used at this reduce action,
-                                // we can use `truncate` instead of `pop` for optimization
-                                // so check it here
+                                // check if index-based variable __rustylr_data_{token_idx} is used
+                                let index_var_used = rule.reduce_action_contains_ident(&format!("__rustylr_data_{}", token_idx));
+                                
                                 if let Some(mapto) = &token.mapto {
-                                    if rule.reduce_action_contains_ident(mapto.value().as_str()) {
+                                    let mapto_used = rule.reduce_action_contains_ident(mapto.value().as_str());
+                                    if index_var_used {
+                                        Some(format_ident!("__rustylr_data_{}", token_idx))
+                                    } else if mapto_used {
                                         Some(format_ident!("{}", mapto.value()))
                                     } else {
                                         None
                                     }
                                 } else {
-                                    None
+                                    if index_var_used {
+                                        Some(format_ident!("__rustylr_data_{}", token_idx))
+                                    } else {
+                                        None
+                                    }
                                 }
                             };
                             stack_mapto_map
@@ -1106,22 +1113,29 @@ impl Grammar {
                                 .push(mapto);
                         }
                         let location_mapto = if token.reduce_action_chains.is_empty() {
+                            let location_index_varname_str = format!("__rustylr_location_{}", token_idx);
+                            let index_var_used = rule.reduce_action_contains_ident(&location_index_varname_str);
+
                             if let Some(mapto) = &token.mapto {
                                 let location_varname =
                                     format_ident!("__rustylr_location_{}", mapto.value());
-
-                                // if variable was not used at this reduce action,
-                                // we can use `truncate` instead of `pop` for optimization
-                                // so check it here
                                 let location_varname_str =
                                     format!("__rustylr_location_{}", mapto.value());
-                                if rule.reduce_action_contains_ident(&location_varname_str) {
+                                let mapto_used = rule.reduce_action_contains_ident(&location_varname_str);
+
+                                if index_var_used {
+                                    Some(format_ident!("__rustylr_location_{}", token_idx))
+                                } else if mapto_used {
                                     Some(location_varname)
                                 } else {
                                     None
                                 }
                             } else {
-                                None
+                                if index_var_used {
+                                    Some(format_ident!("__rustylr_location_{}", token_idx))
+                                } else {
+                                    None
+                                }
                             }
                         } else {
                             if token.reduce_action_chains.iter().any(|&idx| {
@@ -1284,6 +1298,35 @@ impl Grammar {
                         }
                     }
 
+                    let mut alias_stream = TokenStream::new();
+                    for (token_idx, token) in rule.tokens.iter().enumerate() {
+                        if token.reduce_action_chains.is_empty() {
+                            if let Some(mapto) = &token.mapto {
+                                let mapto_used = rule.reduce_action_contains_ident(mapto.value().as_str());
+                                let index_var_used = rule.reduce_action_contains_ident(&format!("__rustylr_data_{}", token_idx));
+                                if mapto_used && index_var_used {
+                                    let mapto_ident = format_ident!("{}", mapto.value());
+                                    let data_varname = format_ident!("__rustylr_data_{}", token_idx);
+                                    alias_stream.extend(quote! {
+                                        let mut #mapto_ident = #data_varname;
+                                    });
+                                }
+
+                                let location_varname_str = format!("__rustylr_location_{}", mapto.value());
+                                let location_mapto_used = rule.reduce_action_contains_ident(&location_varname_str);
+                                let location_index_varname_str = format!("__rustylr_location_{}", token_idx);
+                                let location_index_var_used = rule.reduce_action_contains_ident(&location_index_varname_str);
+                                if location_mapto_used && location_index_var_used {
+                                    let mapto_ident = format_ident!("{}", location_varname_str);
+                                    let data_varname = format_ident!("{}", location_index_varname_str);
+                                    alias_stream.extend(quote! {
+                                        let mut #mapto_ident = #data_varname;
+                                    });
+                                }
+                            }
+                        }
+                    }
+
                     let mut custom_reduce_action_stream = TokenStream::new();
                     for (token_idx, token) in rule.tokens.iter().enumerate() {
                         if token.reduce_action_chains.is_empty() {
@@ -1399,6 +1442,7 @@ impl Grammar {
                                 #modify_tag_stream
 
                                 #extract_data_stream
+                                #alias_stream
                                 #custom_reduce_action_stream
 
                                 let __res = #reduce_action_body
@@ -1429,6 +1473,7 @@ impl Grammar {
                                 #modify_tag_stream
 
                                 #extract_data_stream
+                                #alias_stream
                                 #custom_reduce_action_stream
 
                                 #reduce_action_body

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -116,6 +116,16 @@ pub enum ParseError {
 
     /// only 'usize' literal is allowed for %dprec
     OnlyUsizeLiteral(Location),
+
+    /// bison variable $0 is not supported
+    BisonVariableZero(Location),
+
+    /// bison variable is out of range
+    BisonVariableOutOfRange {
+        location: Location,
+        name: String,
+        max: usize,
+    },
 }
 #[allow(unused)]
 impl ArgError {
@@ -245,6 +255,8 @@ impl ParseError {
             ParseError::OnlyTerminalSet(location) => vec![*location],
             ParseError::NonTerminalNotDefined(loc) => vec![*loc],
             ParseError::OnlyUsizeLiteral(loc) => vec![*loc],
+            ParseError::BisonVariableZero(loc) => vec![*loc],
+            ParseError::BisonVariableOutOfRange { location, .. } => vec![*location],
         }
     }
 
@@ -298,6 +310,10 @@ impl ParseError {
                 "Unknown non-terminal symbol name".to_string()
             }
             ParseError::OnlyUsizeLiteral(_) => "Only 'usize' literal is allowed for %dprec".into(),
+            ParseError::BisonVariableZero(_) => "bison variable $0 is not supported".into(),
+            ParseError::BisonVariableOutOfRange { name, max, .. } => {
+                format!("bison variable {} is out of range (max: {})", name, max)
+            }
         }
     }
 }

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -752,7 +752,11 @@ impl Grammar {
                 // rename all '@var_name' to '__rustylr_location_{var_name}'
                 // if reduce_action is not defined, check if it can be auto-generated
                 let reduce_action = if let Some(reduce_action) = rule.reduce_action {
-                    fn rename_tokenstream_recursive(ts: TokenStream) -> TokenStream {
+                    fn rename_tokenstream_recursive(
+                        ts: TokenStream,
+                        num_tokens: usize,
+                        span_manager: &mut SpanManager,
+                    ) -> Result<TokenStream, ParseError> {
                         let mut new_ts = TokenStream::new();
                         let mut it = ts.into_iter().peekable();
                         while let Some(token) = it.next() {
@@ -784,10 +788,79 @@ impl Grammar {
                                                     )]);
                                                 }
                                             }
+                                            Some(proc_macro2::TokenTree::Literal(lit)) => {
+                                                let lit_str = lit.to_string();
+                                                if let Ok(n) = lit_str.parse::<usize>() {
+                                                    if n == 0 {
+                                                        // '@0' -> rename to '__rustylr_location0' (self location)
+                                                        new_ts.extend([proc_macro2::TokenTree::Ident(
+                                                            format_ident!("__rustylr_location0"),
+                                                        )]);
+                                                        it.next(); // consume the literal
+                                                    } else {
+                                                        // '@n' where n > 0
+                                                        if n <= num_tokens {
+                                                            let new_ident = format_ident!("__rustylr_location_{}", n - 1);
+                                                            new_ts.extend([proc_macro2::TokenTree::Ident(
+                                                                new_ident,
+                                                            )]);
+                                                            it.next(); // consume the literal
+                                                        } else {
+                                                            let span_idx = span_manager.add_span(punct.span());
+                                                            span_manager.add_span(lit.span());
+                                                            let loc = Location::Range(span_idx, span_idx + 2);
+                                                            return Err(ParseError::BisonVariableOutOfRange {
+                                                                location: loc,
+                                                                name: format!("@{}", n),
+                                                                max: num_tokens,
+                                                            });
+                                                        }
+                                                    }
+                                                } else {
+                                                    new_ts.extend([proc_macro2::TokenTree::Punct(punct)]);
+                                                }
+                                            }
                                             _ => {
                                                 // just a punct, no ident after it
                                                 new_ts
                                                     .extend([proc_macro2::TokenTree::Punct(punct)]);
+                                            }
+                                        }
+                                    } else if punct.as_char() == '$' {
+                                        // found '$', check next token
+                                        match it.peek() {
+                                            Some(proc_macro2::TokenTree::Literal(lit)) => {
+                                                let lit_str = lit.to_string();
+                                                if let Ok(n) = lit_str.parse::<usize>() {
+                                                    if n == 0 {
+                                                        let span_idx = span_manager.add_span(punct.span());
+                                                        span_manager.add_span(lit.span());
+                                                        let loc = Location::Range(span_idx, span_idx + 2);
+                                                        return Err(ParseError::BisonVariableZero(loc));
+                                                    } else {
+                                                        if n <= num_tokens {
+                                                            let new_ident = format_ident!("__rustylr_data_{}", n - 1);
+                                                            new_ts.extend([proc_macro2::TokenTree::Ident(
+                                                                new_ident,
+                                                            )]);
+                                                            it.next(); // consume the literal
+                                                        } else {
+                                                            let span_idx = span_manager.add_span(punct.span());
+                                                            span_manager.add_span(lit.span());
+                                                            let loc = Location::Range(span_idx, span_idx + 2);
+                                                            return Err(ParseError::BisonVariableOutOfRange {
+                                                                location: loc,
+                                                                name: format!("${}", n),
+                                                                max: num_tokens,
+                                                            });
+                                                        }
+                                                    }
+                                                } else {
+                                                    new_ts.extend([proc_macro2::TokenTree::Punct(punct)]);
+                                                }
+                                            }
+                                            _ => {
+                                                new_ts.extend([proc_macro2::TokenTree::Punct(punct)]);
                                             }
                                         }
                                     } else {
@@ -797,7 +870,11 @@ impl Grammar {
                                 proc_macro2::TokenTree::Group(group) => {
                                     let new_group = proc_macro2::Group::new(
                                         group.delimiter(),
-                                        rename_tokenstream_recursive(group.stream()),
+                                        rename_tokenstream_recursive(
+                                            group.stream(),
+                                            num_tokens,
+                                            span_manager,
+                                        )?,
                                     );
                                     let new_group = proc_macro2::TokenTree::Group(new_group);
                                     new_ts.extend([new_group]);
@@ -807,10 +884,14 @@ impl Grammar {
                                 }
                             }
                         }
-                        new_ts
+                        Ok(new_ts)
                     }
 
-                    let new_reduce_action = rename_tokenstream_recursive(reduce_action);
+                    let new_reduce_action = rename_tokenstream_recursive(
+                        reduce_action,
+                        tokens.len(),
+                        &mut grammar.span_manager,
+                    )?;
 
                     // check if this reduce action can be identity action; i.e., { $1 }
                     fn tokenstream_contains_unique_ident(ts: TokenStream) -> Option<Ident> {
@@ -838,16 +919,32 @@ impl Grammar {
                     if let Some(unique_ident) =
                         tokenstream_contains_unique_ident(new_reduce_action.clone())
                     {
-                        if let Some(unique_idx) = tokens
-                            .iter()
-                            .enumerate()
-                            .rev()
-                            .find(move |(_, token)| {
-                                token.mapto.as_ref().map(|m| m.value().as_str())
-                                    == Some(unique_ident.to_string().as_str())
-                            })
-                            .map(|(idx, _)| idx)
-                        {
+                        let unique_idx_opt = if let Some(idx) = {
+                            let s = unique_ident.to_string();
+                            if s.starts_with("__rustylr_data_") {
+                                s["__rustylr_data_".len()..].parse::<usize>().ok()
+                            } else {
+                                None
+                            }
+                        } {
+                            if idx < tokens.len() {
+                                Some(idx)
+                            } else {
+                                None
+                            }
+                        } else {
+                            tokens
+                                .iter()
+                                .enumerate()
+                                .rev()
+                                .find(move |(_, token)| {
+                                    token.mapto.as_ref().map(|m| m.value().as_str())
+                                        == Some(unique_ident.to_string().as_str())
+                                })
+                                .map(|(idx, _)| idx)
+                        };
+
+                        if let Some(unique_idx) = unique_idx_opt {
                             Some(ReduceAction::Identity(unique_idx))
                         } else {
                             Some(ReduceAction::Custom(CustomReduceAction::new(
@@ -2207,5 +2304,50 @@ mod tests {
         assert_eq!(grammar_args.start_rule_name[0].value(), "Expr");
         assert_eq!(grammar_args.rules.len(), 1);
         assert_eq!(grammar_args.rules[0].name.value(), "Expr");
+    }
+
+    #[test]
+    fn test_bison_variables_success() {
+        let input = quote! {
+            %tokentype char;
+            %start Expr;
+            Expr(i32) : 'a' 'b' { $1 as i32 + $2 as i32 + @0.to_range().start as i32 + @1.to_range().start as i32 };
+        };
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args);
+        assert!(grammar.is_ok());
+    }
+
+    #[test]
+    fn test_bison_variables_zero_error() {
+        let input = quote! {
+            %tokentype char;
+            %start Expr;
+            Expr(i32) : 'a' 'b' { $0 };
+        };
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args);
+        assert!(matches!(grammar, Err(ParseError::BisonVariableZero(_))));
+    }
+
+    #[test]
+    fn test_bison_variables_out_of_range_error() {
+        let input = quote! {
+            %tokentype char;
+            %start Expr;
+            Expr(i32) : 'a' 'b' { $3 };
+        };
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args);
+        assert!(matches!(grammar, Err(ParseError::BisonVariableOutOfRange { .. })));
+
+        let input_loc = quote! {
+            %tokentype char;
+            %start Expr;
+            Expr(i32) : 'a' 'b' { @3.to_range().start as i32 };
+        };
+        let grammar_args = Grammar::parse_args(input_loc).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args);
+        assert!(matches!(grammar, Err(ParseError::BisonVariableOutOfRange { .. })));
     }
 }


### PR DESCRIPTION
# Summary
This PR adds support for Bison-like positional variables ($1, $2, ...) to reference semantic values of RHS symbols, and positional location variables (@1, @2, ... and @0) to reference locations of RHS symbols and the LHS symbol respectively in parser reduce actions.

# Detailed Changes
1. Bison Variable and Location Renaming (rusty_lr_parser)
- Modified the TokenStream rewriting logic (rename_tokenstream_recursive in grammar.rs) to translate positional syntax to internal variables:
    - $n (where 0 < n <= num_tokens) translates to __rustylr_data_{n - 1}.
    - @n (where 0 < n <= num_tokens) translates to __rustylr_location_{n - 1}.
    - @0 translates to __rustylr_location0 (LHS location, equivalent to @$).
- Added compile-time validation:
    - Using $0 triggers a ParseError::BisonVariableZero compiler error.
    - Using indices out of bounds (e.g. $4 on a rule with 3 RHS symbols) triggers a ParseError::BisonVariableOutOfRange compiler error.
- Identity action checks (tokenstream_contains_unique_ident) were updated to recognize and optimize { $1 } syntax into an identity reduction (ReduceAction::Identity).
2. Code Generation and Aliasing (rusty_lr_parser)
- Updated emit.rs to verify if positional internal variables (__rustylr_data_N / __rustylr_location_N) are referenced in reduce actions. If referenced, stack pop code is correctly generated for them.
- Emits alias statements (e.g. let mut custom_name = __rustylr_data_0;) if both a custom mapped name and a positional variable are used for the same token.
3. Verification & Testing
- Added new test cases in grammar.rs tests module:
    - test_bison_variables_success: Ensures $1, $2, @0, and @1 resolve correctly inside a valid grammar definition.
    - test_bison_variables_zero_error: Verifies $0 triggers a compile error.
    - test_bison_variables_out_of_range_error: Verifies out-of-range index usage triggers a compile error.
- All workspace tests passed successfully.
4. Documentation
Updated README.md and SYNTAX.md to explain how to use Bison-style variables and locations.