### PR TITLE
DataStack to use a single unified enum stack & document memory optimizations

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -171,6 +171,13 @@ If `_` is used, the type will be inferred by analyzing the rules (specifically f
 
 The actual value of `E` is evaluated by the result of the ReduceAction.
 
+### Memory Optimization with `Box`
+Internally, the generated parser stores all semantic values—including the `%tokentype` (terminal token type) and all non-terminals' `RuleType`s—within a single unified `enum` that represents the data stack.
+
+Because the size of a Rust enum is determined by its largest variant, if even a single `RuleType` (or the token type itself) has a large memory footprint, it will inflate the size of the entire enum. Consequently, the data stack will consume significantly more memory, as every element pushed onto the stack will allocate space corresponding to that largest variant.
+
+To avoid this overhead, it is highly recommended to wrap large data types in a `Box` (e.g., `Box<MyLargeStruct>`). This keeps the variant size minimal (the size of a single pointer) and optimizes the memory consumption of the data stack as a whole.
+
 
 ## ReduceAction <sub><sup>(optional)</sup></sub>
 A ReduceAction is Rust code executed when a production rule is reduced.

--- a/example/calculator/src/main.rs
+++ b/example/calculator/src/main.rs
@@ -43,3 +43,34 @@ fn main() {
     println!("{}", res);
     println!("userdata: {}", userdata);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::Token;
+
+    #[test]
+    fn test_calculator_success() {
+        let input = vec![
+            Token::Num(1),
+            Token::Plus,
+            Token::Num(2),
+            Token::Star,
+            Token::LParen,
+            Token::Num(3),
+            Token::Plus,
+            Token::Num(4),
+            Token::RParen,
+        ];
+
+        let parser = parser::EParser::new();
+        let mut context = parser::EContext::new();
+        let mut userdata: i32 = 0;
+        for token in input {
+            context.feed(&parser, token, &mut userdata).expect("Failed to feed token");
+        }
+        let res = context.accept(&parser, &mut userdata).expect("Failed to accept");
+        assert_eq!(res, 15);
+        assert_eq!(userdata, 2);
+    }
+}

--- a/example/calculator_u8/src/main.rs
+++ b/example/calculator_u8/src/main.rs
@@ -42,3 +42,39 @@ fn main() {
     }
     context.feed(&parser, 0 as char, &mut userdata).unwrap(); // feed EOF
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculator_u8_success() {
+        let input = "  1 +  -20 *   (3 + 4 )   ";
+        let parser = parser::EParser::new();
+        let mut context = parser::EContext::new();
+        let mut userdata: i32 = 0;
+        for b in input.chars() {
+            context.feed(&parser, b, &mut userdata).expect("Failed to feed char");
+        }
+        let result = context.accept(&parser, &mut userdata).expect("Failed to accept");
+        assert_eq!(result, -139.0);
+    }
+
+    #[test]
+    fn test_calculator_u8_invalid_input() {
+        let error_input = "1+2**(3+4)";
+        let parser = parser::EParser::new();
+        let mut context = parser::EContext::new();
+        let mut userdata: i32 = 0;
+        
+        let mut has_err = false;
+        for b in error_input.chars() {
+            if context.feed(&parser, b, &mut userdata).is_err() {
+                has_err = true;
+                break;
+            }
+        }
+        assert!(has_err);
+    }
+}
+

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -922,7 +922,6 @@ impl Grammar {
         // for consistent output
         let mut variant_names_in_order = Vec::new();
 
-        let mut empty_tag_used = false;
         let mut terminal_data_used = false;
 
         // insert variant for terminal token type
@@ -934,9 +933,6 @@ impl Grammar {
             );
             variant_names_in_order
                 .push((terminal_variant_name.clone(), self.token_typename.clone()));
-        }
-        if self.terminal_classes.iter().any(|c| !c.data_used) {
-            empty_tag_used = true;
         }
 
         fn remove_whitespaces(s: String) -> String {
@@ -958,7 +954,6 @@ impl Grammar {
                     .clone();
                 variant_names_for_nonterm.push(variant_name);
             } else {
-                empty_tag_used = true;
                 variant_names_for_nonterm.push(empty_variant_name.clone());
             }
         }
@@ -1464,11 +1459,9 @@ impl Grammar {
                     #variant_name(#typename),
                 });
             }
-            if empty_tag_used {
-                variants.extend(quote! {
-                    Empty,
-                });
-            }
+            variants.extend(quote! {
+                Empty,
+            });
             quote! {
                 /// enum for each non-terminal and terminal symbol, that actually hold data
                 #[rustfmt::skip]

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -894,6 +894,7 @@ impl Grammar {
         let nonterminals_enum_name = format_ident!("{}NonTerminals", &start_rule_ident);
         let reduce_error_typename = &self.error_typename;
         let data_stack_typename = format_ident!("{}DataStack", start_rule_ident);
+        let data_enum_typename = format_ident!("{}Data", &start_rule_ident);
         let token_typename = &self.token_typename;
         let user_data_parameter_name =
             Ident::new(utils::USER_DATA_PARAMETER_NAME, Span::call_site());
@@ -904,37 +905,35 @@ impl Grammar {
             .cloned()
             .unwrap_or_else(|| quote! { #module_prefix::DefaultLocation });
 
-        // stack name for tags
-        let tag_stack_name = format_ident!("__tags");
-        let tag_enum_name = format_ident!("{}Tags", &start_rule_ident);
+        // empty tag name
+        let empty_variant_name = format_ident!("Empty");
+        // variant name for terminal symbol
+        let terminal_variant_name = format_ident!("__terminals");
 
-        // empty tag
-        let empty_tag_name = format_ident!("Empty");
-        // stack name for terminal symbol
-        let terminal_stack_name = format_ident!("__terminals");
+        // variant name for each non-terminal
+        let mut variant_names_for_nonterm = Vec::with_capacity(self.nonterminals.len());
 
-        // stack name for each non-terminal
-        let mut stack_names_for_nonterm = Vec::with_capacity(self.nonterminals.len());
-
-        // (<RuleType as ToString>, stack_name) map
-        let mut ruletype_stack_map: rusty_lr_core::hash::HashMap<String, Option<Ident>> =
+        // Map containing (<RuleType as ToString>, variant_name).
+        // This maps each rule type to its enum variant name (e.g. __variant0, __variant1), merging identical types.
+        let mut ruletype_variant_map: rusty_lr_core::hash::HashMap<String, Ident> =
             Default::default();
 
-        // (stack_name, TokenStream for typename) sorted in insertion order
+        // (variant_name, TokenStream for typename) sorted in insertion order
         // for consistent output
-        let mut stack_names_in_order = Vec::new();
+        let mut variant_names_in_order = Vec::new();
 
         let mut empty_tag_used = false;
         let mut terminal_data_used = false;
 
-        // insert stack for terminal token type
+        // insert variant for terminal token type
         if self.terminal_classes.iter().any(|c| c.data_used) {
             terminal_data_used = true;
-            ruletype_stack_map.insert(
+            ruletype_variant_map.insert(
                 self.token_typename.to_string(),
-                Some(terminal_stack_name.clone()),
+                terminal_variant_name.clone(),
             );
-            stack_names_in_order.push((terminal_stack_name.clone(), self.token_typename.clone()));
+            variant_names_in_order
+                .push((terminal_variant_name.clone(), self.token_typename.clone()));
         }
         if self.terminal_classes.iter().any(|c| !c.data_used) {
             empty_tag_used = true;
@@ -947,40 +946,36 @@ impl Grammar {
         // iterates through nonterminals
         for nonterm in self.nonterminals.iter() {
             if let Some(ruletype_stream) = nonterm.ruletype.as_ref().cloned() {
-                let cur_len = ruletype_stack_map.len();
-                let stack_name = ruletype_stack_map
+                let cur_len = ruletype_variant_map.len();
+                let variant_name = ruletype_variant_map
                     .entry(remove_whitespaces(ruletype_stream.to_string()))
                     .or_insert_with(|| {
-                        let new_stack_name = format_ident!("__stack{}", cur_len);
-                        stack_names_in_order
-                            .push((new_stack_name.clone(), ruletype_stream.clone()));
-                        Some(new_stack_name)
+                        let new_variant_name = format_ident!("__variant{}", cur_len);
+                        variant_names_in_order
+                            .push((new_variant_name.clone(), ruletype_stream.clone()));
+                        new_variant_name
                     })
                     .clone();
-                stack_names_for_nonterm.push(stack_name);
+                variant_names_for_nonterm.push(variant_name);
             } else {
                 empty_tag_used = true;
-                stack_names_for_nonterm.push(None);
+                variant_names_for_nonterm.push(empty_variant_name.clone());
             }
         }
 
-        // if only one tag kind was used, no need to emit tag_stack
-        let unique_tag = (empty_tag_used && stack_names_in_order.is_empty())
-            || (!empty_tag_used && stack_names_in_order.len() == 1);
-
-        // Token -> Option<stack_name> map, `None` for empty
-        let token_to_stack_name = |token: Token<TerminalSymbol<usize>, usize>| match token {
+        // Maps tokens to their corresponding variant names. If the token holds no data, it maps to `Empty`.
+        let token_to_variant_name = |token: Token<TerminalSymbol<usize>, usize>| match token {
             Token::Term(term) => match term {
                 TerminalSymbol::Term(term) => {
                     if self.terminal_classes[term].data_used {
-                        Some(&terminal_stack_name)
+                        &terminal_variant_name
                     } else {
-                        None
+                        &empty_variant_name
                     }
                 }
-                TerminalSymbol::Error | TerminalSymbol::Eof => None,
+                TerminalSymbol::Error | TerminalSymbol::Eof => &empty_variant_name,
             },
-            Token::NonTerm(nonterm_idx) => stack_names_for_nonterm[nonterm_idx].as_ref(),
+            Token::NonTerm(nonterm_idx) => &variant_names_for_nonterm[nonterm_idx],
         };
 
         let mut reduce_action_case_streams = quote! {};
@@ -1052,76 +1047,59 @@ impl Grammar {
 
                 use super::nonterminal_info::ReduceAction;
 
-                #[derive(PartialEq, Eq, PartialOrd, Ord)]
-                enum StackName {
-                    DataStack(Ident),
-                    LocationStack,
-                }
-                impl StackName {
-                    pub fn to_token_stream(&self) -> TokenStream {
-                        match self {
-                            StackName::DataStack(name) => {
-                                quote! {__data_stack.#name}
-                            }
-                            StackName::LocationStack => quote! {__location_stack},
-                        }
-                    }
-                }
-
                 if rule.is_used {
+                    // Generate debug assertions to verify that the variants on the data stack
+                    // match the expected token/non-terminal variants in the production rule.
                     let mut debug_tag_check_stream = TokenStream::new();
-                    let mut stack_mapto_map = std::collections::BTreeMap::new();
                     for (token_idx, token) in rule.tokens.iter().enumerate().rev() {
                         let token_index_from_end = rule.tokens.len() - 1 - token_idx;
-                        let stack_name = token_to_stack_name(token.token);
-                        let tag_name = stack_name.unwrap_or(&empty_tag_name);
+                        let variant_name = token_to_variant_name(token.token);
 
-                        if let Some(stack_name) = stack_name {
-                            let mapto = if let Some(first_chain) =
-                                token.reduce_action_chains.first()
-                            {
-                                let first_chain = &self.custom_reduce_actions[*first_chain];
-                                if first_chain.input_type.is_some() {
-                                    Some(format_ident!("__rustylr_data_{}", token_idx))
-                                } else {
-                                    None
-                                }
-                            } else {
-                                // check if index-based variable __rustylr_data_{token_idx} is used
-                                let index_var_used = rule.reduce_action_contains_ident(&format!("__rustylr_data_{}", token_idx));
-                                
-                                if let Some(mapto) = &token.mapto {
-                                    let mapto_used = rule.reduce_action_contains_ident(mapto.value().as_str());
-                                    if index_var_used {
-                                        Some(format_ident!("__rustylr_data_{}", token_idx))
-                                    } else if mapto_used {
-                                        Some(format_ident!("{}", mapto.value()))
-                                    } else {
-                                        None
-                                    }
-                                } else {
-                                    if index_var_used {
-                                        Some(format_ident!("__rustylr_data_{}", token_idx))
-                                    } else {
-                                        None
-                                    }
-                                }
-                            };
-                            stack_mapto_map
-                                .entry(StackName::DataStack(stack_name.clone()))
-                                .or_insert_with(Vec::new)
-                                .push(mapto);
+                        if variant_name == &empty_variant_name {
+                            debug_tag_check_stream.extend(quote! {
+                                debug_assert!(
+                                    matches!(
+                                        __data_stack.__stack.get(
+                                            __data_stack.__stack.len()-1-#token_index_from_end
+                                        ),
+                                        Some(&#data_enum_typename::Empty)
+                                    )
+                                );
+                            });
+                        } else {
+                            debug_tag_check_stream.extend(quote! {
+                                debug_assert!(
+                                    matches!(
+                                        __data_stack.__stack.get(
+                                            __data_stack.__stack.len()-1-#token_index_from_end
+                                        ),
+                                        Some(&#data_enum_typename::#variant_name(_))
+                                    )
+                                );
+                            });
                         }
+                    }
+
+                    // Generate code to extract values and locations from the stacks for the reduce action.
+                    // Since the data stack is a single unified vector, we pop from it in reverse chronological order (right to left).
+                    let mut extract_data_stream = TokenStream::new();
+                    for (token_idx, token) in rule.tokens.iter().enumerate().rev() {
+                        let variant_name = token_to_variant_name(token.token);
+
+                        // Determine location_mapto
                         let location_mapto = if token.reduce_action_chains.is_empty() {
-                            let location_index_varname_str = format!("__rustylr_location_{}", token_idx);
-                            let index_var_used = rule.reduce_action_contains_ident(&location_index_varname_str);
+                            let location_index_varname_str =
+                                format!("__rustylr_location_{}", token_idx);
+                            let index_var_used =
+                                rule.reduce_action_contains_ident(&location_index_varname_str);
 
                             if let Some(mapto) = &token.mapto {
                                 let location_varname =
                                     format_ident!("__rustylr_location_{}", mapto.value());
                                 let location_varname_str =
                                     format!("__rustylr_location_{}", mapto.value());
-                                let mapto_used = rule.reduce_action_contains_ident(&location_varname_str);
+                                let mapto_used =
+                                    rule.reduce_action_contains_ident(&location_varname_str);
 
                                 if index_var_used {
                                     Some(format_ident!("__rustylr_location_{}", token_idx))
@@ -1147,153 +1125,66 @@ impl Grammar {
                                 None
                             }
                         };
-                        stack_mapto_map
-                            .entry(StackName::LocationStack)
-                            .or_insert_with(Vec::new)
-                            .push(location_mapto);
 
-                        if !unique_tag {
-                            debug_tag_check_stream.extend(quote! {
-                                debug_assert!(
-                                    __data_stack.#tag_stack_name.get(
-                                        __data_stack.#tag_stack_name.len()-1-#token_index_from_end
-                                    ) == Some( &#tag_enum_name::#tag_name )
-                                );
+                        if let Some(loc_mapto) = location_mapto {
+                            extract_data_stream.extend(quote! {
+                                let mut #loc_mapto = __location_stack.pop().unwrap();
+                            });
+                        } else {
+                            extract_data_stream.extend(quote! {
+                                __location_stack.pop().unwrap();
                             });
                         }
-                    }
 
-                    // new tag that will be inserted by this reduce action
-                    let new_tag_name = stack_names_for_nonterm[nonterm_idx]
-                        .as_ref()
-                        .unwrap_or(&empty_tag_name);
-                    // pop n tokens from tag_stack and push new reduced tag
-                    let modify_tag_stream = if unique_tag {
-                        TokenStream::new()
-                    } else {
-                        if rule.tokens.len() > 0 {
-                            if new_tag_name == &empty_tag_name {
-                                // if first token's tag is equal to new_tag, no need to (pop n tokens -> push new token).
-                                // just pop n-1 tokens
-                                let first_tag_name = token_to_stack_name(rule.tokens[0].token)
-                                    .unwrap_or(&empty_tag_name);
-
-                                if first_tag_name == new_tag_name {
-                                    // pop n-1 tokens, no new insertion
-                                    let len = rule.tokens.len() - 1;
-                                    let truncate_stream = if len > 0 {
-                                        quote! {__data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #len);}
-                                    } else {
-                                        TokenStream::new()
-                                    };
-                                    truncate_stream
+                        // Determine mapto for data
+                        let mapto = if variant_name != &empty_variant_name {
+                            if let Some(first_chain) = token.reduce_action_chains.first() {
+                                let first_chain = &self.custom_reduce_actions[*first_chain];
+                                if first_chain.input_type.is_some() {
+                                    Some(format_ident!("__rustylr_data_{}", token_idx))
                                 } else {
-                                    let len = rule.tokens.len();
-                                    // len > 0 here
-                                    quote! {
-                                        __data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #len);
-                                        __data_stack.#tag_stack_name.push(#tag_enum_name::#new_tag_name);
-                                    }
+                                    None
                                 }
                             } else {
-                                // if first token's tag is equal to new_tag, no need to (pop n tokens -> push new token).
-                                // just pop n-1 tokens
-                                let first_tag_name = token_to_stack_name(rule.tokens[0].token)
-                                    .unwrap_or(&empty_tag_name);
+                                // check if index-based variable __rustylr_data_{token_idx} is used
+                                let index_var_used = rule.reduce_action_contains_ident(&format!(
+                                    "__rustylr_data_{}",
+                                    token_idx
+                                ));
 
-                                if first_tag_name == new_tag_name {
-                                    // pop n-1 tokens, no new insertion
-                                    let lenm1 = rule.tokens.len() - 1;
-                                    let truncate_stream = if lenm1 > 0 {
-                                        quote! {__data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #lenm1);}
+                                if let Some(mapto) = &token.mapto {
+                                    let mapto_used =
+                                        rule.reduce_action_contains_ident(mapto.value().as_str());
+                                    if index_var_used {
+                                        Some(format_ident!("__rustylr_data_{}", token_idx))
+                                    } else if mapto_used {
+                                        Some(format_ident!("{}", mapto.value()))
                                     } else {
-                                        TokenStream::new()
-                                    };
-
-                                    let len = rule.tokens.len();
-                                    quote! {
-                                        if __push_data {
-                                            #truncate_stream
-                                        } else {
-                                            __data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #len);
-                                            __data_stack.#tag_stack_name.push(#tag_enum_name::#empty_tag_name);
-                                        }
-                                    }
-                                } else if first_tag_name == &empty_tag_name {
-                                    // pop n-1 tokens, no new insertion
-                                    let lenm1 = rule.tokens.len() - 1;
-                                    let truncate_stream = if lenm1 > 0 {
-                                        quote! {__data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #lenm1);}
-                                    } else {
-                                        TokenStream::new()
-                                    };
-
-                                    let len = rule.tokens.len();
-                                    quote! {
-                                        if __push_data {
-                                            __data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #len);
-                                            __data_stack.#tag_stack_name.push(#tag_enum_name::#new_tag_name);
-                                        } else {
-                                            #truncate_stream
-                                        }
+                                        None
                                     }
                                 } else {
-                                    let len = rule.tokens.len();
-                                    // len > 0 here
-                                    quote! {
-                                        __data_stack.#tag_stack_name.truncate(__data_stack.#tag_stack_name.len() - #len);
-                                        if __push_data {
-                                            __data_stack.#tag_stack_name.push(#tag_enum_name::#new_tag_name);
-                                        } else {
-                                            __data_stack.#tag_stack_name.push(#tag_enum_name::#empty_tag_name);
-                                        }
+                                    if index_var_used {
+                                        Some(format_ident!("__rustylr_data_{}", token_idx))
+                                    } else {
+                                        None
                                     }
                                 }
                             }
                         } else {
-                            if new_tag_name == &empty_tag_name {
-                                quote! {
-                                    __data_stack.#tag_stack_name.push(#tag_enum_name::#new_tag_name);
-                                }
-                            } else {
-                                quote! {
-                                    if __push_data {
-                                        __data_stack.#tag_stack_name.push(#tag_enum_name::#new_tag_name);
-                                    } else {
-                                        __data_stack.#tag_stack_name.push(#tag_enum_name::#empty_tag_name);
-                                    }
-                                }
-                            }
-                        }
-                    };
+                            None
+                        };
 
-                    let mut extract_data_stream = TokenStream::new();
-                    for (stack_name, maptos) in stack_mapto_map.iter() {
-                        let stack_stream = stack_name.to_token_stream();
-
-                        // if there are consecutive `None` mapto, truncate instead of pop
-                        let mut last_none_count: usize = 0;
-                        for mapto in maptos {
-                            match mapto {
-                                Some(mapto) => {
-                                    if last_none_count > 0 {
-                                        extract_data_stream.extend(quote! {
-                                                #stack_stream.truncate(#stack_stream.len() - #last_none_count);
-                                            });
-                                        last_none_count = 0;
-                                    }
-                                    extract_data_stream.extend(quote! {
-                                        let mut #mapto = #stack_stream.pop().unwrap();
-                                    });
-                                }
-                                None => {
-                                    last_none_count += 1;
-                                }
-                            }
-                        }
-                        if last_none_count > 0 {
+                        if variant_name != &empty_variant_name && mapto.is_some() {
+                            let data_mapto = mapto.unwrap();
                             extract_data_stream.extend(quote! {
-                                #stack_stream.truncate(#stack_stream.len() - #last_none_count);
+                                let mut #data_mapto = match __data_stack.__stack.pop().unwrap() {
+                                    #data_enum_typename::#variant_name(val) => val,
+                                    _ => unreachable!(),
+                                };
+                            });
+                        } else {
+                            extract_data_stream.extend(quote! {
+                                __data_stack.__stack.pop().unwrap();
                             });
                         }
                     }
@@ -1302,23 +1193,33 @@ impl Grammar {
                     for (token_idx, token) in rule.tokens.iter().enumerate() {
                         if token.reduce_action_chains.is_empty() {
                             if let Some(mapto) = &token.mapto {
-                                let mapto_used = rule.reduce_action_contains_ident(mapto.value().as_str());
-                                let index_var_used = rule.reduce_action_contains_ident(&format!("__rustylr_data_{}", token_idx));
+                                let mapto_used =
+                                    rule.reduce_action_contains_ident(mapto.value().as_str());
+                                let index_var_used = rule.reduce_action_contains_ident(&format!(
+                                    "__rustylr_data_{}",
+                                    token_idx
+                                ));
                                 if mapto_used && index_var_used {
                                     let mapto_ident = format_ident!("{}", mapto.value());
-                                    let data_varname = format_ident!("__rustylr_data_{}", token_idx);
+                                    let data_varname =
+                                        format_ident!("__rustylr_data_{}", token_idx);
                                     alias_stream.extend(quote! {
                                         let mut #mapto_ident = #data_varname;
                                     });
                                 }
 
-                                let location_varname_str = format!("__rustylr_location_{}", mapto.value());
-                                let location_mapto_used = rule.reduce_action_contains_ident(&location_varname_str);
-                                let location_index_varname_str = format!("__rustylr_location_{}", token_idx);
-                                let location_index_var_used = rule.reduce_action_contains_ident(&location_index_varname_str);
+                                let location_varname_str =
+                                    format!("__rustylr_location_{}", mapto.value());
+                                let location_mapto_used =
+                                    rule.reduce_action_contains_ident(&location_varname_str);
+                                let location_index_varname_str =
+                                    format!("__rustylr_location_{}", token_idx);
+                                let location_index_var_used =
+                                    rule.reduce_action_contains_ident(&location_index_varname_str);
                                 if location_mapto_used && location_index_var_used {
                                     let mapto_ident = format_ident!("{}", location_varname_str);
-                                    let data_varname = format_ident!("{}", location_index_varname_str);
+                                    let data_varname =
+                                        format_ident!("{}", location_index_varname_str);
                                     alias_stream.extend(quote! {
                                         let mut #mapto_ident = #data_varname;
                                     });
@@ -1411,18 +1312,24 @@ impl Grammar {
                     let reduce_action_body = match &rule.reduce_action {
                         Some(ReduceAction::Custom(custom)) => {
                             let body = &custom.body;
-                            quote! { #body; }
+                            quote! { #body }
                         }
                         Some(ReduceAction::Identity(identity_idx)) => {
                             let ith_ident = format_ident!(
                                 "{}",
                                 rule.tokens[*identity_idx].mapto.as_ref().unwrap().value()
                             );
-                            quote! { #ith_ident; }
+                            quote! { #ith_ident }
                         }
                         None => TokenStream::new(),
                     };
-                    if let Some(stack_name) = &stack_names_for_nonterm[nonterm_idx] {
+                    let variant_name = &variant_names_for_nonterm[nonterm_idx];
+                    if variant_name != &empty_variant_name {
+                        let res_expr = if reduce_action_body.is_empty() {
+                            quote! { () }
+                        } else {
+                            quote! { #reduce_action_body }
+                        };
                         fn_reduce_for_each_rule_stream.extend(quote! {
                             #[doc = #rule_debug_str]
                             #[inline]
@@ -1439,21 +1346,27 @@ impl Grammar {
                                 {
                                     #debug_tag_check_stream
                                 }
-                                #modify_tag_stream
 
                                 #extract_data_stream
                                 #alias_stream
                                 #custom_reduce_action_stream
 
-                                let __res = #reduce_action_body
+                                let __res = #res_expr;
                                 if __push_data {
-                                    __data_stack.#stack_name.push(__res);
+                                    __data_stack.__stack.push(#data_enum_typename::#variant_name(__res));
+                                } else {
+                                    __data_stack.__stack.push(#data_enum_typename::Empty);
                                 }
 
                                 Ok(())
                             }
                         });
                     } else {
+                        let semicolon_or_empty = if reduce_action_body.is_empty() {
+                            quote! {}
+                        } else {
+                            quote! { ; }
+                        };
                         fn_reduce_for_each_rule_stream.extend(quote! {
                             #[doc = #rule_debug_str]
                             #[inline]
@@ -1470,13 +1383,13 @@ impl Grammar {
                                 {
                                     #debug_tag_check_stream
                                 }
-                                #modify_tag_stream
 
                                 #extract_data_stream
                                 #alias_stream
                                 #custom_reduce_action_stream
 
-                                #reduce_action_body
+                                #reduce_action_body #semicolon_or_empty
+                                __data_stack.__stack.push(#data_enum_typename::Empty);
 
                                 Ok(())
                             }
@@ -1491,169 +1404,38 @@ impl Grammar {
             .nonterminals_index
             .get(self.start_rule_name.value())
             .unwrap();
-        let start_stack_name = &stack_names_for_nonterm[start_idx];
-        let tag_name = start_stack_name.as_ref().unwrap_or(&empty_tag_name);
-        let tag_check_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            quote! {
-                let tag = self.#tag_stack_name.pop();
-                debug_assert!(tag == Some(#tag_enum_name::#tag_name));
-            }
-        };
-        let (start_typename, pop_start) = match start_stack_name {
-            Some(stack_name) => {
-                let ruletype = self.nonterminals[start_idx]
-                    .ruletype
-                    .as_ref()
-                    .unwrap()
-                    .clone();
+        let start_variant_name = &variant_names_for_nonterm[start_idx];
+        // Generate the pop_start implementation.
+        // At the time of acceptance, the stack contains the EOF token (which has no data, i.e., Empty)
+        // on top of the actual start symbol's value. We pop the EOF token first, and then retrieve the start value.
+        let (start_typename, pop_start) = if start_variant_name != &empty_variant_name {
+            let ruletype = self.nonterminals[start_idx]
+                .ruletype
+                .as_ref()
+                .unwrap()
+                .clone();
 
-                let discard_empty_tag = if unique_tag {
-                    TokenStream::new()
-                } else {
-                    quote! {
-                        self.#tag_stack_name.pop();
+            (
+                ruletype,
+                quote! {
+                    self.__stack.pop();
+                    match self.__stack.pop() {
+                        Some(#data_enum_typename::#start_variant_name(val)) => Some(val),
+                        _ => None,
                     }
-                };
-
-                (
-                    ruletype,
-                    quote! {
-                        #discard_empty_tag
-                        #tag_check_stream
-                        self.#stack_name.pop()
-                    },
-                )
-            }
-            None => (
+                },
+            )
+        } else {
+            (
                 quote! {()},
                 quote! {
-                    #tag_check_stream
-                    Some(())
+                    self.__stack.pop();
+                    match self.__stack.pop() {
+                        Some(#data_enum_typename::Empty) => Some(()),
+                        _ => None,
+                    }
                 },
-            ),
-        };
-
-        // typename for count the number of tokens in each production rule
-        let max_shift = self
-            .nonterminals
-            .iter()
-            .map(|nonterm| {
-                nonterm
-                    .rules
-                    .iter()
-                    .map(|rule| rule.tokens.len())
-                    .max()
-                    .unwrap_or(0)
-            })
-            .max()
-            .unwrap_or(0);
-        let shift_typename = if max_shift <= u8::MAX as usize {
-            quote! { u8 }
-        } else if max_shift <= u16::MAX as usize {
-            quote! { u16 }
-        } else if max_shift <= u32::MAX as usize {
-            quote! { u32 }
-        } else {
-            quote! { usize }
-        };
-
-        let mut stack_definition_stream = TokenStream::new();
-        let mut stack_default_stream = TokenStream::new();
-        let mut pop_body_stream = TokenStream::new();
-        let mut stack_clear_stream = TokenStream::new();
-        let mut stack_append_stream = TokenStream::new();
-        let stack_len = stack_names_in_order.len();
-        let mut split_off_split_stream = TokenStream::new();
-        let mut split_off_ctor_stream = TokenStream::new();
-        let mut truncate_stream = TokenStream::new();
-        for (stack_idx, (stack_name, typename)) in stack_names_in_order.iter().enumerate() {
-            stack_definition_stream.extend(quote! {
-                #stack_name: Vec<#typename>,
-            });
-            stack_default_stream.extend(quote! {
-                #stack_name: Vec::new(),
-            });
-            if unique_tag {
-                pop_body_stream.extend(quote! {
-                    self.#stack_name.pop();
-                });
-            } else {
-                pop_body_stream.extend(quote! {
-                    #tag_enum_name::#stack_name => { self.#stack_name.pop(); }
-                });
-            };
-            stack_clear_stream.extend(quote! {
-                self.#stack_name.clear();
-            });
-            stack_append_stream.extend(quote! {
-                self.#stack_name.append(&mut other.#stack_name);
-            });
-
-            let other_stack_name = format_ident!("__other_{}", stack_name);
-            if unique_tag {
-                split_off_split_stream.extend(quote! {
-                    let #other_stack_name = self.#stack_name.split_off( at );
-                });
-            } else {
-                split_off_split_stream.extend(quote! {
-                    let #other_stack_name = self.#stack_name.split_off( self.#stack_name.len() - (__counts[#stack_idx] as usize) );
-                });
-            };
-            split_off_ctor_stream.extend(quote! {
-                #stack_name: #other_stack_name,
-            });
-
-            if unique_tag {
-                truncate_stream.extend(quote! {
-                    self.#stack_name.truncate( at );
-                });
-            } else {
-                truncate_stream.extend(quote! {
-                    self.#stack_name.truncate( self.#stack_name.len() - (__counts[#stack_idx] as usize) );
-                });
-            };
-        }
-
-        let pop_stream = if unique_tag {
-            pop_body_stream
-        } else {
-            quote! {
-                match self.#tag_stack_name.pop().unwrap() {
-                    #pop_body_stream
-                    _ => {}
-                }
-            }
-        };
-
-        let split_off_count_stream = if unique_tag {
-            quote! {}
-        } else {
-            quote! {
-                let mut __counts: [#shift_typename; #stack_len+1] = [0; #stack_len+1];
-                let __other_tag_stack = self.#tag_stack_name.split_off(at);
-                for &tag in &__other_tag_stack {
-                    __counts[ tag as usize ] += 1;
-                }
-            }
-        };
-        if !unique_tag {
-            split_off_ctor_stream.extend(quote! {
-                #tag_stack_name: __other_tag_stack,
-            });
-        }
-
-        let truncate_count_stream = if unique_tag {
-            quote! {}
-        } else {
-            quote! {
-                let mut __counts: [#shift_typename; #stack_len+1] = [0; #stack_len+1];
-                for &tag in &self.#tag_stack_name[at..] {
-                    __counts[ tag as usize ] += 1;
-                }
-                self.#tag_stack_name.truncate( at );
-            }
+            )
         };
 
         let derive_clone_for_glr = if self.glr {
@@ -1663,113 +1445,57 @@ impl Grammar {
         };
 
         let push_terminal_body_stream = if terminal_data_used {
-            if unique_tag {
-                quote! {
-                    self.#terminal_stack_name.push( term );
-                }
-            } else {
-                quote! {
-                    self.#tag_stack_name.push(#tag_enum_name::#terminal_stack_name);
-                    self.#terminal_stack_name.push( term );
-                }
+            quote! {
+                self.__stack.push(#data_enum_typename::#terminal_variant_name(term));
             }
         } else {
             quote! {
-                unreachable!();
+                self.__stack.push(#data_enum_typename::Empty);
             }
         };
-        let push_empty_body_stream = if empty_tag_used {
-            if unique_tag {
-                TokenStream::new()
-            } else {
-                quote! {
-                    self.#tag_stack_name.push(#tag_enum_name::#empty_tag_name);
-                }
-            }
-        } else {
-            quote! { unreachable!(); }
+        let push_empty_body_stream = quote! {
+            self.__stack.push(#data_enum_typename::Empty);
         };
 
-        let tag_definition_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            let mut tag_definition_body_stream = TokenStream::new();
-            for (stack_name, _) in &stack_names_in_order {
-                tag_definition_body_stream.extend(quote! {
-                    #stack_name,
+        let data_enum_definition = {
+            let mut variants = TokenStream::new();
+            for (variant_name, typename) in &variant_names_in_order {
+                variants.extend(quote! {
+                    #variant_name(#typename),
                 });
             }
             if empty_tag_used {
-                tag_definition_body_stream.extend(quote! {
-                    #empty_tag_name,
+                variants.extend(quote! {
+                    Empty,
                 });
             }
             quote! {
-                /// tag for token that represents which stack a token is using
+                /// enum for each non-terminal and terminal symbol, that actually hold data
                 #[rustfmt::skip]
                 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
-                #[derive(Clone, Copy, PartialEq, Eq)]
-                pub enum #tag_enum_name {
-                    #tag_definition_body_stream
+                #derive_clone_for_glr
+                pub enum #data_enum_typename {
+                    #variants
                 }
-            }
-        };
-
-        let tag_stack_definition_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            quote! { pub #tag_stack_name: Vec<#tag_enum_name>, }
-        };
-        let tag_stack_init_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            quote! {
-                #tag_stack_name: Vec::new(),
-            }
-        };
-
-        let tag_stack_clear_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            quote! {
-                self.#tag_stack_name.clear();
-            }
-        };
-
-        let tag_stack_reserve_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            quote! {
-                self.#tag_stack_name.reserve(additional);
-            }
-        };
-
-        let tag_stack_append_stream = if unique_tag {
-            TokenStream::new()
-        } else {
-            quote! {
-                self.#tag_stack_name.append(&mut other.#tag_stack_name);
             }
         };
 
         stream.extend(quote! {
 
-        #tag_definition_stream
+        #data_enum_definition
 
         /// enum for each non-terminal and terminal symbol, that actually hold data
         #[rustfmt::skip]
         #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
         #derive_clone_for_glr
         pub struct #data_stack_typename {
-            #tag_stack_definition_stream
-            #stack_definition_stream
+            pub __stack: Vec<#data_enum_typename>,
         }
 
         impl Default for #data_stack_typename {
             fn default() -> Self {
                 Self {
-                    #tag_stack_init_stream
-                    #stack_default_stream
+                    __stack: Vec::new(),
                 }
             }
         }
@@ -1795,7 +1521,7 @@ impl Grammar {
                 #pop_start
             }
             fn pop(&mut self) {
-                #pop_stream
+                self.__stack.pop();
             }
             fn push_terminal(&mut self, term: Self::Term) {
                 #push_terminal_body_stream
@@ -1804,28 +1530,25 @@ impl Grammar {
                 #push_empty_body_stream
             }
 
+            // Trait operations like clear, split_off, truncate, and append are highly simplified
+            // and efficient because they only need to perform a single vector operation on the unified stack.
             fn clear(&mut self) {
-                #tag_stack_clear_stream
-                #stack_clear_stream
+                self.__stack.clear();
             }
             fn reserve(&mut self, additional: usize) {
-                #tag_stack_reserve_stream
+                self.__stack.reserve(additional);
             }
 
             fn split_off(&mut self, at: usize) -> Self {
-                #split_off_count_stream
-                #split_off_split_stream
                 Self {
-                    #split_off_ctor_stream
+                    __stack: self.__stack.split_off(at),
                 }
             }
             fn truncate(&mut self, at: usize) {
-                #truncate_count_stream
-                #truncate_stream
+                self.__stack.truncate(at);
             }
             fn append(&mut self, other: &mut Self) {
-                #tag_stack_append_stream
-                #stack_append_stream
+                self.__stack.append(&mut other.__stack);
             }
 
             fn reduce_action(

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -2582,4 +2582,26 @@ mod tests {
         let grammar = Grammar::from_grammar_args(grammar_args);
         assert!(matches!(grammar, Err(ParseError::TypeInferenceFailed(_))));
     }
+
+    #[test]
+    fn test_codegen_no_empty_tags() {
+        let input = quote! {
+            %tokentype Token;
+            %start Expr;
+            %token a Token::A(_);
+            Expr(i32) : a { 1 };
+        };
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+        let code = grammar.emit_compiletime();
+        
+        // Ensure the generated code compiles successfully as a valid Rust TokenStream
+        let parsed = syn::parse2::<syn::File>(code.clone());
+        assert!(parsed.is_ok(), "Generated code failed to parse: {:?}", parsed.err());
+        
+        // Check that the Empty variant is present in the output
+        let code_str = code.to_string();
+        assert!(code_str.contains("Empty"), "Empty variant should be unconditionally included");
+    }
 }
+

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -630,81 +630,40 @@ impl ::rusty_lr_core::parser::nonterminal::NonTerminal for GrammarNonTerminals {
         *self as usize
     }
 }
-/// tag for token that represents which stack a token is using
+/// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum GrammarTags {
-    __terminals,
-    __stack1,
-    __stack2,
-    __stack3,
-    __stack4,
-    __stack5,
-    __stack6,
-    __stack7,
-    __stack8,
-    __stack9,
-    __stack10,
-    __stack11,
-    __stack12,
-    __stack13,
-    __stack14,
-    __stack15,
-    __stack16,
-    __stack17,
-    __stack18,
+pub enum GrammarData {
+    __terminals(Lexed),
+    __variant1(RuleDefArgs),
+    __variant2(Option<Group>),
+    __variant3(Vec<RuleLineArgs>),
+    __variant4(RuleLineArgs),
+    __variant5(PrecDPrecArgs),
+    __variant6((Option<Located<String>>, PatternArgs)),
+    __variant7(TerminalSetItem),
+    __variant8(TerminalSet),
+    __variant9(PatternArgs),
+    __variant10(IdentOrLiteral),
+    __variant11(Vec<(Option<Located<String>>, PatternArgs)>),
+    __variant12(Vec<PrecDPrecArgs>),
+    __variant13(Option<Lexed>),
+    __variant14(Vec<TerminalSetItem>),
+    __variant15(Vec<PatternArgs>),
+    __variant16(Vec<Vec<PatternArgs>>),
+    __variant17(Vec<Lexed>),
+    __variant18(Vec<IdentOrLiteral>),
     Empty,
 }
 /// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
 pub struct GrammarDataStack {
-    pub __tags: Vec<GrammarTags>,
-    __terminals: Vec<Lexed>,
-    __stack1: Vec<RuleDefArgs>,
-    __stack2: Vec<Option<Group>>,
-    __stack3: Vec<Vec<RuleLineArgs>>,
-    __stack4: Vec<RuleLineArgs>,
-    __stack5: Vec<PrecDPrecArgs>,
-    __stack6: Vec<(Option<Located<String>>, PatternArgs)>,
-    __stack7: Vec<TerminalSetItem>,
-    __stack8: Vec<TerminalSet>,
-    __stack9: Vec<PatternArgs>,
-    __stack10: Vec<IdentOrLiteral>,
-    __stack11: Vec<Vec<(Option<Located<String>>, PatternArgs)>>,
-    __stack12: Vec<Vec<PrecDPrecArgs>>,
-    __stack13: Vec<Option<Lexed>>,
-    __stack14: Vec<Vec<TerminalSetItem>>,
-    __stack15: Vec<Vec<PatternArgs>>,
-    __stack16: Vec<Vec<Vec<PatternArgs>>>,
-    __stack17: Vec<Vec<Lexed>>,
-    __stack18: Vec<Vec<IdentOrLiteral>>,
+    pub __stack: Vec<GrammarData>,
 }
 impl Default for GrammarDataStack {
     fn default() -> Self {
-        Self {
-            __tags: Vec::new(),
-            __terminals: Vec::new(),
-            __stack1: Vec::new(),
-            __stack2: Vec::new(),
-            __stack3: Vec::new(),
-            __stack4: Vec::new(),
-            __stack5: Vec::new(),
-            __stack6: Vec::new(),
-            __stack7: Vec::new(),
-            __stack8: Vec::new(),
-            __stack9: Vec::new(),
-            __stack10: Vec::new(),
-            __stack11: Vec::new(),
-            __stack12: Vec::new(),
-            __stack13: Vec::new(),
-            __stack14: Vec::new(),
-            __stack15: Vec::new(),
-            __stack16: Vec::new(),
-            __stack17: Vec::new(),
-            __stack18: Vec::new(),
-        }
+        Self { __stack: Vec::new() }
     }
 }
 #[rustfmt::skip]
@@ -744,40 +703,45 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack3)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant3(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__stack2)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__variant2(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 5usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack1);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut RuleType = __data_stack.__stack2.pop().unwrap();
-        let mut RuleLines = __data_stack.__stack3.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut RuleLines = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant3(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_colon = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut RuleType = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Rule-Ident");
@@ -792,7 +756,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -810,18 +776,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack2);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut parengroup = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut parengroup = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::ParenGroup(group) = parengroup else {
                 unreachable!("RuleType - Group");
@@ -829,7 +792,9 @@ impl GrammarDataStack {
             Some(group)
         };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -845,14 +810,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack2);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { None };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -870,37 +832,39 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack4)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant4(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack3)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant3(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut RuleLines = __data_stack.__stack3.pop().unwrap();
-        let mut RuleLine = __data_stack.__stack4.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut RuleLine = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant4(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_pipe = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut RuleLines = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant3(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             RuleLine.separator_location = __rustylr_location_pipe;
             RuleLines.push(RuleLine);
             RuleLines
         };
         if __push_data {
-            __data_stack.__stack3.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant3(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -918,21 +882,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack4)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant4(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack3);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut RuleLine = __data_stack.__stack4.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut RuleLine = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant4(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![RuleLine] };
         if __push_data {
-            __data_stack.__stack3.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant3(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -950,28 +913,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack2)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant2(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack12)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant12(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack11)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant11(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack4);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut TokenMapped = __data_stack.__stack11.pop().unwrap();
-        let mut PrecDef = __data_stack.__stack12.pop().unwrap();
-        let mut Action = __data_stack.__stack2.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut Action = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut PrecDef = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant12(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut TokenMapped = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant11(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             RuleLineArgs {
                 tokens: TokenMapped,
@@ -981,7 +949,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack4.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant4(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -999,30 +969,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack10)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant10(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack5);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut IdentOrLiteral = __data_stack.__stack10.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut IdentOrLiteral = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant10(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = { PrecDPrecArgs::Prec(IdentOrLiteral) };
         if __push_data {
-            __data_stack.__stack5.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant5(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1040,27 +1012,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack5);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -1072,7 +1041,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::None
         };
         if __push_data {
-            __data_stack.__stack5.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant5(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1090,28 +1061,27 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack5);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut int_literal = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_int_literal = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        let mut int_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let Lexed::IntLiteral(i) = int_literal else {
                 unreachable!("PrecDPrecArgs-DPrec");
@@ -1119,7 +1089,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::DPrec(Located::new(i, __rustylr_location_int_literal))
         };
         if __push_data {
-            __data_stack.__stack5.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant5(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1137,27 +1109,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack5);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -1169,7 +1138,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::None
         };
         if __push_data {
-            __data_stack.__stack5.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant5(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1187,23 +1158,18 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack5);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -1215,7 +1181,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::None
         };
         if __push_data {
-            __data_stack.__stack5.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant5(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1233,21 +1201,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack6);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack9.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { (None, Pattern) };
         if __push_data {
-            __data_stack.__stack6.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant6(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1265,29 +1232,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack6);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Token-Ident");
@@ -1295,7 +1263,9 @@ impl GrammarDataStack {
             (Some(Located::new(ident.to_string(), __rustylr_location_ident)), Pattern)
         };
         if __push_data {
-            __data_stack.__stack6.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant6(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1313,18 +1283,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut ident = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("TerminalSetItem-Range1");
@@ -1334,7 +1301,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1352,30 +1321,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut last = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        let mut first = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_last = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut last = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_first = __location_stack.pop().unwrap();
+        let mut first = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Ident(first) = first else {
                 unreachable!("TerminalSetItem-Range1");
@@ -1389,7 +1358,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1407,27 +1378,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -1439,7 +1407,9 @@ impl GrammarDataStack {
             TerminalSetItem::Terminal(Default::default())
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1457,18 +1427,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut char_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_char_literal = __location_stack.pop().unwrap();
+        let mut char_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::CharLiteral(ch) = char_literal else {
                 unreachable!("TerminalSetItem-CharLiteral1");
@@ -1478,7 +1445,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1496,30 +1465,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut last = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        let mut first = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_last = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut last = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_first = __location_stack.pop().unwrap();
+        let mut first = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::CharLiteral(first) = first else {
                 unreachable!("TerminalSetItem-CharLiteral2");
@@ -1533,7 +1502,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1551,27 +1522,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -1583,7 +1551,9 @@ impl GrammarDataStack {
             TerminalSetItem::Terminal(Default::default())
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1601,18 +1571,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut byte_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_byte_literal = __location_stack.pop().unwrap();
+        let mut byte_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::ByteLiteral(b) = byte_literal else {
                 unreachable!("TerminalSetItem-ByteLiteral1");
@@ -1622,7 +1589,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1640,30 +1609,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut last = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        let mut first = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_last = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut last = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_first = __location_stack.pop().unwrap();
+        let mut first = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::ByteLiteral(first) = first else {
                 unreachable!("TerminalSetItem-ByteLiteral2");
@@ -1677,7 +1646,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1695,27 +1666,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack7);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -1727,7 +1695,9 @@ impl GrammarDataStack {
             TerminalSetItem::Terminal(Default::default())
         };
         if __push_data {
-            __data_stack.__stack7.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant7(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1745,34 +1715,36 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack14)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant14(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack13)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant13(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack8);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut caret = __data_stack.__stack13.pop().unwrap();
-        let mut TerminalSetItem = __data_stack.__stack14.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_rbracket = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut TerminalSetItem = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant14(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut caret = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant13(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_lbracket = __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             TerminalSet {
                 negate: caret.is_some(),
@@ -1782,7 +1754,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack8.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant8(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1800,18 +1774,12 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack8);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
         let mut __rustylr_location_dot = __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let span = __rustylr_location_dot;
             TerminalSet {
@@ -1822,7 +1790,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack8.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant8(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1840,18 +1810,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut ident = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Pattern-Ident");
@@ -1859,7 +1826,9 @@ impl GrammarDataStack {
             PatternArgs::Ident(Located::new(ident.to_string(), __rustylr_location_ident))
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1877,24 +1846,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack9.pop().unwrap();
-        let mut plus = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_plus = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut plus = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Plus(plus) = plus else {
                 unreachable!("Pattern-Plus");
@@ -1905,7 +1874,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1923,24 +1894,21 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
         let mut __rustylr_location_star = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             PatternArgs::Star {
                 base: Box::new(Pattern),
@@ -1948,7 +1916,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -1966,24 +1936,21 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
         let mut __rustylr_location_question = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             PatternArgs::Question {
                 base: Box::new(Pattern),
@@ -1991,7 +1958,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2009,24 +1978,21 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
         let mut __rustylr_location_exclamation = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             PatternArgs::Exclamation {
                 base: Box::new(Pattern),
@@ -2034,7 +2000,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2052,21 +2020,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack8)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant8(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut TerminalSet = __data_stack.__stack8.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut TerminalSet = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant8(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { PatternArgs::TerminalSet(TerminalSet) };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2084,28 +2051,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut lh = __data_stack.__stack9.pop().unwrap();
-        let mut p1 = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut lh = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut p1 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             PatternArgs::Lookaheads {
                 pattern: Box::new(p1),
@@ -2113,7 +2082,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2131,29 +2102,27 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack16)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant16(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Pattern = __data_stack.__stack16.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
         let mut __rustylr_location_rparen = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut Pattern = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant16(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_lparen = __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             PatternArgs::Group {
                 alternatives: Pattern,
@@ -2162,7 +2131,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2180,28 +2151,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             data.error_recovered
                 .push(RecoveredError {
@@ -2213,7 +2180,9 @@ impl GrammarDataStack {
             PatternArgs::Ident(Default::default())
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2231,18 +2200,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut byte_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_byte_literal = __location_stack.pop().unwrap();
+        let mut byte_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::ByteLiteral(b) = byte_literal else {
                 unreachable!("Pattern-ByteLiteral");
@@ -2250,7 +2216,9 @@ impl GrammarDataStack {
             PatternArgs::Byte(Located::new(b.value(), __rustylr_location_byte_literal))
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2268,18 +2236,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut byte_str_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_byte_str_literal = __location_stack.pop().unwrap();
+        let mut byte_str_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::ByteStrLiteral(b) = byte_str_literal else {
                 unreachable!("Pattern-ByteStringLiteral");
@@ -2289,7 +2254,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2307,18 +2274,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut char_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_char_literal = __location_stack.pop().unwrap();
+        let mut char_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::CharLiteral(c) = char_literal else {
                 unreachable!("Pattern-CharLiteral");
@@ -2326,7 +2290,9 @@ impl GrammarDataStack {
             PatternArgs::Char(Located::new(c.value(), __rustylr_location_char_literal))
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2344,18 +2310,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut str_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_str_literal = __location_stack.pop().unwrap();
+        let mut str_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::StrLiteral(s) = str_literal else {
                 unreachable!("Pattern-StringLiteral");
@@ -2363,7 +2326,9 @@ impl GrammarDataStack {
             PatternArgs::String(Located::new(s.value(), __rustylr_location_str_literal))
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2381,28 +2346,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut p2 = __data_stack.__stack9.pop().unwrap();
-        let mut p1 = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut p2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut p1 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             PatternArgs::Minus {
                 base: Box::new(p1),
@@ -2410,7 +2377,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2428,52 +2397,63 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 5usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                5usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 6usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                6usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 7usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                7usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 8usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut del = __data_stack.__stack9.pop().unwrap();
-        let mut base = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 3usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 6usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut del = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut base = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Pattern-Sep-Ident");
@@ -2495,7 +2475,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2513,56 +2495,69 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 5usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                5usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 6usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                6usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 7usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                7usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 8usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                8usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 9usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut del = __data_stack.__stack9.pop().unwrap();
-        let mut base = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 5usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 7usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut del = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut base = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Pattern-Sep-Ident");
@@ -2584,7 +2579,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2602,56 +2599,69 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 5usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                5usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 6usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                6usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 7usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                7usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 8usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                8usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 9usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut del = __data_stack.__stack9.pop().unwrap();
-        let mut base = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 5usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 7usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut del = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut base = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Pattern-Sep-Ident");
@@ -2673,7 +2683,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2691,54 +2703,63 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 5usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                5usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 6usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                6usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 7usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                7usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 8usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut del = __data_stack.__stack9.pop().unwrap();
-        let mut base = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 3usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 4usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut del = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut base = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Pattern-Sep-Ident");
@@ -2767,7 +2788,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2785,58 +2808,69 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 5usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                5usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 6usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                6usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 7usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                7usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 8usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                8usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 9usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack9);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut del = __data_stack.__stack9.pop().unwrap();
-        let mut base = __data_stack.__stack9.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 4usize);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 5usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut del = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut base = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("Pattern-Sep-Ident");
@@ -2865,7 +2899,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack9.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant9(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2883,18 +2919,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack2);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut bracegroup = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut bracegroup = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::BraceGroup(group) = bracegroup else {
                 unreachable!("Action0");
@@ -2902,7 +2935,9 @@ impl GrammarDataStack {
             Some(group)
         };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2918,14 +2953,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack2);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { None };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2943,18 +2975,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack10);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut ident = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("IdentOrLiteral-Ident");
@@ -2964,7 +2993,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack10.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant10(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -2982,18 +3013,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack10);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut byte_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_byte_literal = __location_stack.pop().unwrap();
+        let mut byte_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::ByteLiteral(b) = byte_literal else {
                 unreachable!("IdentOrLiteral-ByteLiteral");
@@ -3003,7 +3031,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack10.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant10(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -3021,18 +3051,15 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack10);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut char_literal = __data_stack.__terminals.pop().unwrap();
         let mut __rustylr_location_char_literal = __location_stack.pop().unwrap();
+        let mut char_literal = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             let Lexed::CharLiteral(c) = char_literal else {
                 unreachable!("IdentOrLiteral-CharLiteral");
@@ -3042,7 +3069,9 @@ impl GrammarDataStack {
             )
         };
         if __push_data {
-            __data_stack.__stack10.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant10(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -3060,34 +3089,42 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 5usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_3 = __data_stack.__stack17.pop().unwrap();
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_3 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_3 = Self::custom_reduce_action_0(
             __rustylr_data_3,
             data,
@@ -3104,6 +3141,7 @@ impl GrammarDataStack {
                     RustCode,
                 ));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent token ident semicolon
@@ -3120,28 +3158,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 3usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3151,6 +3191,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_ident,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent token error semicolon
@@ -3167,28 +3208,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3198,6 +3241,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent start ident semicolon
@@ -3214,29 +3258,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut ident = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             let Lexed::Ident(ident) = ident else {
                 unreachable!("StartDef-Ident");
@@ -3244,6 +3292,7 @@ impl GrammarDataStack {
             data.start_rule_name
                 .push(Located::new(ident.to_string(), __rustylr_location_ident));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent start error semicolon
@@ -3260,28 +3309,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3291,6 +3342,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent tokentype [^semicolon]+ semicolon
@@ -3307,29 +3359,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_2 = __data_stack.__stack17.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_tokentype = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_2 = Self::custom_reduce_action_0(
             __rustylr_data_2,
             data,
@@ -3339,6 +3395,7 @@ impl GrammarDataStack {
         {
             data.token_typename.push((__rustylr_location_tokentype, RustCode));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent tokentype semicolon
@@ -3355,24 +3412,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_tokentype = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3382,6 +3439,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_tokentype,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent userdata [^semicolon]+ semicolon
@@ -3398,29 +3456,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_2 = __data_stack.__stack17.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_userdata = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_2 = Self::custom_reduce_action_0(
             __rustylr_data_2,
             data,
@@ -3430,6 +3492,7 @@ impl GrammarDataStack {
         {
             data.userdata_typename.push((__rustylr_location_userdata, RustCode));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent userdata semicolon
@@ -3446,24 +3509,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_userdata = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3473,6 +3536,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_userdata,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent left IdentOrLiteral+ semicolon
@@ -3489,33 +3553,38 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack18)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant18(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut IdentOrLiteral = __data_stack.__stack18.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut IdentOrLiteral = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant18(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_left = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.precedences
                 .push((__rustylr_location_left, Some(ReduceType::Left), IdentOrLiteral));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent left error semicolon
@@ -3532,28 +3601,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3563,6 +3634,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent right IdentOrLiteral+ semicolon
@@ -3579,29 +3651,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack18)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant18(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut IdentOrLiteral = __data_stack.__stack18.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut IdentOrLiteral = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant18(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_right = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.precedences
                 .push((
@@ -3610,6 +3686,7 @@ impl GrammarDataStack {
                     IdentOrLiteral,
                 ));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent right error semicolon
@@ -3626,28 +3703,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3657,6 +3736,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent precedence IdentOrLiteral+ semicolon
@@ -3673,32 +3753,37 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack18)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant18(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut IdentOrLiteral = __data_stack.__stack18.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut IdentOrLiteral = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant18(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_precedence = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.precedences.push((__rustylr_location_precedence, None, IdentOrLiteral));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent precedence error semicolon
@@ -3715,28 +3800,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3746,6 +3833,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent errortype [^semicolon]+ semicolon
@@ -3762,29 +3850,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_2 = __data_stack.__stack17.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_errortype = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_2 = Self::custom_reduce_action_0(
             __rustylr_data_2,
             data,
@@ -3794,6 +3886,7 @@ impl GrammarDataStack {
         {
             data.error_typename.push((__rustylr_location_errortype, RustCode));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent errortype semicolon
@@ -3810,24 +3903,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_errortype = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3837,6 +3930,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_errortype,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent moduleprefix [^semicolon]+ semicolon
@@ -3853,29 +3947,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_2 = __data_stack.__stack17.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let mut __rustylr_location_moduleprefix = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_2 = Self::custom_reduce_action_0(
             __rustylr_data_2,
             data,
@@ -3885,6 +3983,7 @@ impl GrammarDataStack {
         {
             data.module_prefix.push((__rustylr_location_moduleprefix, RustCode));
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent moduleprefix semicolon
@@ -3901,24 +4000,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_moduleprefix = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -3928,6 +4027,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_moduleprefix,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent glr semicolon
@@ -3944,26 +4044,31 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut glr = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut glr = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.glr = true;
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent glr error semicolon
@@ -3980,28 +4085,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4011,6 +4118,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent lalr semicolon
@@ -4027,26 +4135,31 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut lalr = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut lalr = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.lalr = true;
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent lalr error semicolon
@@ -4063,28 +4176,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4094,6 +4209,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent nooptim semicolon
@@ -4110,25 +4226,28 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.no_optim = true;
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent nooptim error semicolon
@@ -4145,28 +4264,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4176,6 +4297,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent dense semicolon
@@ -4192,26 +4314,31 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut dense = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut dense = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.dense = true;
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent dense error semicolon
@@ -4228,28 +4355,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4259,6 +4388,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent trace ident* semicolon
@@ -4275,29 +4405,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut ident = __data_stack.__stack17.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_ident = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        let mut ident = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             let idents = ident
                 .into_iter()
@@ -4309,6 +4443,7 @@ impl GrammarDataStack {
                 });
             data.traces.extend(idents);
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent trace error semicolon
@@ -4325,28 +4460,30 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4356,6 +4493,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent filter [^semicolon]+ semicolon
@@ -4372,28 +4510,36 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_2 = __data_stack.__stack17.pop().unwrap();
-        let mut filter = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 4usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut filter = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_2 = Self::custom_reduce_action_0(
             __rustylr_data_2,
             data,
@@ -4403,6 +4549,7 @@ impl GrammarDataStack {
         {
             data.filter = Some(RustCode);
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent filter semicolon
@@ -4419,24 +4566,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_filter = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4446,6 +4593,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_filter,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent location [^semicolon]+ semicolon
@@ -4462,27 +4610,33 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut __rustylr_data_2 = __data_stack.__stack17.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 2usize);
-        __location_stack.truncate(__location_stack.len() - 4usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __rustylr_data_2 = Self::custom_reduce_action_0(
             __rustylr_data_2,
             data,
@@ -4492,6 +4646,7 @@ impl GrammarDataStack {
         {
             data.location_typename = Some(RustCode);
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent location semicolon
@@ -4508,25 +4663,27 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut location = __data_stack.__terminals.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_location = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        let mut location = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4536,6 +4693,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_location,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///Directive -> percent error semicolon
@@ -4552,24 +4710,24 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.error_recovered
                 .push(RecoveredError {
@@ -4579,6 +4737,7 @@ impl GrammarDataStack {
                     location: __rustylr_location_error,
                 });
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///GrammarLine -> Rule
@@ -4595,17 +4754,19 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant1(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        let mut Rule = __data_stack.__stack1.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut Rule = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
         {
             data.rules.push(Rule);
         };
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///TokenMapped+ -> TokenMapped
@@ -4622,21 +4783,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack6)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant6(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack11);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__stack6.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant6(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack11.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant11(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4654,29 +4814,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack6)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant6(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack11)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant11(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Ap = __data_stack.__stack11.pop().unwrap();
-        let mut A = __data_stack.__stack6.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant6(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant11(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack11.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant11(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4694,19 +4857,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack11)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant11(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token0 = __data_stack.__stack11.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant11(val) => val,
+            _ => unreachable!(),
+        };
         let __res = __token0;
         if __push_data {
-            __data_stack.__stack11.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant11(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4722,14 +4886,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack11);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { vec![] };
         if __push_data {
-            __data_stack.__stack11.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant11(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4747,21 +4908,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack5)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant5(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack12);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__stack5.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant5(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack12.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant12(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4779,29 +4939,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack5)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant5(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack12)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant12(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Ap = __data_stack.__stack12.pop().unwrap();
-        let mut A = __data_stack.__stack5.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant5(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant12(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack12.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant12(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4819,19 +4982,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack12)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant12(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token0 = __data_stack.__stack12.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant12(val) => val,
+            _ => unreachable!(),
+        };
         let __res = __token0;
         if __push_data {
-            __data_stack.__stack12.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant12(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4847,14 +5011,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack12);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { vec![] };
         if __push_data {
-            __data_stack.__stack12.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant12(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4872,21 +5033,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack13);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = Some(A);
         if __push_data {
-            __data_stack.__stack13.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant13(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4902,14 +5062,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack13);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { None };
         if __push_data {
-            __data_stack.__stack13.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant13(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4927,21 +5084,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack7)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant7(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack14);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__stack7.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant7(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack14.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant14(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4959,29 +5115,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack7)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant7(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack14)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant14(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Ap = __data_stack.__stack14.pop().unwrap();
-        let mut A = __data_stack.__stack7.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant7(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant14(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack14.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant14(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -4999,19 +5158,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack14)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant14(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token0 = __data_stack.__stack14.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant14(val) => val,
+            _ => unreachable!(),
+        };
         let __res = __token0;
         if __push_data {
-            __data_stack.__stack14.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant14(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5027,14 +5187,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack14);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { vec![] };
         if __push_data {
-            __data_stack.__stack14.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant14(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5052,21 +5209,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant9(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack15);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__stack9.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack15.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant15(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5084,29 +5240,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack9)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant9(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack15)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant15(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Ap = __data_stack.__stack15.pop().unwrap();
-        let mut A = __data_stack.__stack9.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant9(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant15(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack15.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant15(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5124,19 +5283,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack15)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant15(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token0 = __data_stack.__stack15.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant15(val) => val,
+            _ => unreachable!(),
+        };
         let __res = __token0;
         if __push_data {
-            __data_stack.__stack15.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant15(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5152,14 +5312,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack15);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { vec![] };
         if __push_data {
-            __data_stack.__stack15.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant15(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5177,21 +5334,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack15)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant15(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack16);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token0 = __data_stack.__stack15.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant15(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![__token0] };
         if __push_data {
-            __data_stack.__stack16.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant16(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5209,34 +5365,38 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack15)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant15(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                GrammarTags::__stack16)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& GrammarData::__variant16(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token1 = __data_stack.__stack15.pop().unwrap();
-        let mut __token0 = __data_stack.__stack16.pop().unwrap();
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut __token1 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant15(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant16(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             __token0.push(__token1);
             __token0
         };
         if __push_data {
-            __data_stack.__stack16.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant16(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5254,14 +5414,13 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        __data_stack.__tags.push(GrammarTags::Empty);
-        __data_stack.__terminals.truncate(__data_stack.__terminals.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///comma? ->
@@ -5276,7 +5435,7 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        __data_stack.__tags.push(GrammarTags::Empty);
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///[^semicolon]+ -> [^semicolon]
@@ -5293,21 +5452,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack17);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack17.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant17(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5325,29 +5483,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Ap = __data_stack.__stack17.pop().unwrap();
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack17.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant17(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5365,21 +5526,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack10)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant10(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack18);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__stack10.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant10(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack18.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant18(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5397,29 +5557,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack10)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant10(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack18)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant18(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__stack10.pop().unwrap();
-        let mut Ap = __data_stack.__stack18.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant10(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant18(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack18.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant18(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5437,21 +5600,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack17);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack17.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant17(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5469,29 +5631,32 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::__variant17(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut Ap = __data_stack.__stack17.pop().unwrap();
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack17.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant17(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5509,19 +5674,20 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::__stack17)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::__variant17(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
-        let mut __token0 = __data_stack.__stack17.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut __token0 = match __data_stack.__stack.pop().unwrap() {
+            GrammarData::__variant17(val) => val,
+            _ => unreachable!(),
+        };
         let __res = __token0;
         if __push_data {
-            __data_stack.__stack17.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant17(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5537,14 +5703,11 @@ impl GrammarDataStack {
         __rustylr_location0: &mut Location,
     ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        if __push_data {
-            __data_stack.__tags.push(GrammarTags::__stack17);
-        } else {
-            __data_stack.__tags.push(GrammarTags::Empty);
-        }
         let __res = { vec![] };
         if __push_data {
-            __data_stack.__stack17.push(__res);
+            __data_stack.__stack.push(GrammarData::__variant17(__res));
+        } else {
+            __data_stack.__stack.push(GrammarData::Empty);
         }
         Ok(())
     }
@@ -5562,11 +5725,13 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
         }
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
     ///GrammarLine+ -> GrammarLine GrammarLine+
@@ -5583,16 +5748,19 @@ impl GrammarDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& GrammarData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                GrammarTags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& GrammarData::Empty))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
 }
@@ -5612,237 +5780,37 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
     type StartType = ();
     type Location = Location;
     fn pop_start(&mut self) -> Option<Self::StartType> {
-        let tag = self.__tags.pop();
-        debug_assert!(tag == Some(GrammarTags::Empty));
-        Some(())
+        self.__stack.pop();
+        match self.__stack.pop() {
+            Some(GrammarData::Empty) => Some(()),
+            _ => None,
+        }
     }
     fn pop(&mut self) {
-        match self.__tags.pop().unwrap() {
-            GrammarTags::__terminals => {
-                self.__terminals.pop();
-            }
-            GrammarTags::__stack1 => {
-                self.__stack1.pop();
-            }
-            GrammarTags::__stack2 => {
-                self.__stack2.pop();
-            }
-            GrammarTags::__stack3 => {
-                self.__stack3.pop();
-            }
-            GrammarTags::__stack4 => {
-                self.__stack4.pop();
-            }
-            GrammarTags::__stack5 => {
-                self.__stack5.pop();
-            }
-            GrammarTags::__stack6 => {
-                self.__stack6.pop();
-            }
-            GrammarTags::__stack7 => {
-                self.__stack7.pop();
-            }
-            GrammarTags::__stack8 => {
-                self.__stack8.pop();
-            }
-            GrammarTags::__stack9 => {
-                self.__stack9.pop();
-            }
-            GrammarTags::__stack10 => {
-                self.__stack10.pop();
-            }
-            GrammarTags::__stack11 => {
-                self.__stack11.pop();
-            }
-            GrammarTags::__stack12 => {
-                self.__stack12.pop();
-            }
-            GrammarTags::__stack13 => {
-                self.__stack13.pop();
-            }
-            GrammarTags::__stack14 => {
-                self.__stack14.pop();
-            }
-            GrammarTags::__stack15 => {
-                self.__stack15.pop();
-            }
-            GrammarTags::__stack16 => {
-                self.__stack16.pop();
-            }
-            GrammarTags::__stack17 => {
-                self.__stack17.pop();
-            }
-            GrammarTags::__stack18 => {
-                self.__stack18.pop();
-            }
-            _ => {}
-        }
+        self.__stack.pop();
     }
     fn push_terminal(&mut self, term: Self::Term) {
-        self.__tags.push(GrammarTags::__terminals);
-        self.__terminals.push(term);
+        self.__stack.push(GrammarData::__terminals(term));
     }
     fn push_empty(&mut self) {
-        self.__tags.push(GrammarTags::Empty);
+        self.__stack.push(GrammarData::Empty);
     }
     fn clear(&mut self) {
-        self.__tags.clear();
-        self.__terminals.clear();
-        self.__stack1.clear();
-        self.__stack2.clear();
-        self.__stack3.clear();
-        self.__stack4.clear();
-        self.__stack5.clear();
-        self.__stack6.clear();
-        self.__stack7.clear();
-        self.__stack8.clear();
-        self.__stack9.clear();
-        self.__stack10.clear();
-        self.__stack11.clear();
-        self.__stack12.clear();
-        self.__stack13.clear();
-        self.__stack14.clear();
-        self.__stack15.clear();
-        self.__stack16.clear();
-        self.__stack17.clear();
-        self.__stack18.clear();
+        self.__stack.clear();
     }
     fn reserve(&mut self, additional: usize) {
-        self.__tags.reserve(additional);
+        self.__stack.reserve(additional);
     }
     fn split_off(&mut self, at: usize) -> Self {
-        let mut __counts: [u8; 19usize + 1] = [0; 19usize + 1];
-        let __other_tag_stack = self.__tags.split_off(at);
-        for &tag in &__other_tag_stack {
-            __counts[tag as usize] += 1;
-        }
-        let __other___terminals = self
-            .__terminals
-            .split_off(self.__terminals.len() - (__counts[0usize] as usize));
-        let __other___stack1 = self
-            .__stack1
-            .split_off(self.__stack1.len() - (__counts[1usize] as usize));
-        let __other___stack2 = self
-            .__stack2
-            .split_off(self.__stack2.len() - (__counts[2usize] as usize));
-        let __other___stack3 = self
-            .__stack3
-            .split_off(self.__stack3.len() - (__counts[3usize] as usize));
-        let __other___stack4 = self
-            .__stack4
-            .split_off(self.__stack4.len() - (__counts[4usize] as usize));
-        let __other___stack5 = self
-            .__stack5
-            .split_off(self.__stack5.len() - (__counts[5usize] as usize));
-        let __other___stack6 = self
-            .__stack6
-            .split_off(self.__stack6.len() - (__counts[6usize] as usize));
-        let __other___stack7 = self
-            .__stack7
-            .split_off(self.__stack7.len() - (__counts[7usize] as usize));
-        let __other___stack8 = self
-            .__stack8
-            .split_off(self.__stack8.len() - (__counts[8usize] as usize));
-        let __other___stack9 = self
-            .__stack9
-            .split_off(self.__stack9.len() - (__counts[9usize] as usize));
-        let __other___stack10 = self
-            .__stack10
-            .split_off(self.__stack10.len() - (__counts[10usize] as usize));
-        let __other___stack11 = self
-            .__stack11
-            .split_off(self.__stack11.len() - (__counts[11usize] as usize));
-        let __other___stack12 = self
-            .__stack12
-            .split_off(self.__stack12.len() - (__counts[12usize] as usize));
-        let __other___stack13 = self
-            .__stack13
-            .split_off(self.__stack13.len() - (__counts[13usize] as usize));
-        let __other___stack14 = self
-            .__stack14
-            .split_off(self.__stack14.len() - (__counts[14usize] as usize));
-        let __other___stack15 = self
-            .__stack15
-            .split_off(self.__stack15.len() - (__counts[15usize] as usize));
-        let __other___stack16 = self
-            .__stack16
-            .split_off(self.__stack16.len() - (__counts[16usize] as usize));
-        let __other___stack17 = self
-            .__stack17
-            .split_off(self.__stack17.len() - (__counts[17usize] as usize));
-        let __other___stack18 = self
-            .__stack18
-            .split_off(self.__stack18.len() - (__counts[18usize] as usize));
         Self {
-            __terminals: __other___terminals,
-            __stack1: __other___stack1,
-            __stack2: __other___stack2,
-            __stack3: __other___stack3,
-            __stack4: __other___stack4,
-            __stack5: __other___stack5,
-            __stack6: __other___stack6,
-            __stack7: __other___stack7,
-            __stack8: __other___stack8,
-            __stack9: __other___stack9,
-            __stack10: __other___stack10,
-            __stack11: __other___stack11,
-            __stack12: __other___stack12,
-            __stack13: __other___stack13,
-            __stack14: __other___stack14,
-            __stack15: __other___stack15,
-            __stack16: __other___stack16,
-            __stack17: __other___stack17,
-            __stack18: __other___stack18,
-            __tags: __other_tag_stack,
+            __stack: self.__stack.split_off(at),
         }
     }
     fn truncate(&mut self, at: usize) {
-        let mut __counts: [u8; 19usize + 1] = [0; 19usize + 1];
-        for &tag in &self.__tags[at..] {
-            __counts[tag as usize] += 1;
-        }
-        self.__tags.truncate(at);
-        self.__terminals.truncate(self.__terminals.len() - (__counts[0usize] as usize));
-        self.__stack1.truncate(self.__stack1.len() - (__counts[1usize] as usize));
-        self.__stack2.truncate(self.__stack2.len() - (__counts[2usize] as usize));
-        self.__stack3.truncate(self.__stack3.len() - (__counts[3usize] as usize));
-        self.__stack4.truncate(self.__stack4.len() - (__counts[4usize] as usize));
-        self.__stack5.truncate(self.__stack5.len() - (__counts[5usize] as usize));
-        self.__stack6.truncate(self.__stack6.len() - (__counts[6usize] as usize));
-        self.__stack7.truncate(self.__stack7.len() - (__counts[7usize] as usize));
-        self.__stack8.truncate(self.__stack8.len() - (__counts[8usize] as usize));
-        self.__stack9.truncate(self.__stack9.len() - (__counts[9usize] as usize));
-        self.__stack10.truncate(self.__stack10.len() - (__counts[10usize] as usize));
-        self.__stack11.truncate(self.__stack11.len() - (__counts[11usize] as usize));
-        self.__stack12.truncate(self.__stack12.len() - (__counts[12usize] as usize));
-        self.__stack13.truncate(self.__stack13.len() - (__counts[13usize] as usize));
-        self.__stack14.truncate(self.__stack14.len() - (__counts[14usize] as usize));
-        self.__stack15.truncate(self.__stack15.len() - (__counts[15usize] as usize));
-        self.__stack16.truncate(self.__stack16.len() - (__counts[16usize] as usize));
-        self.__stack17.truncate(self.__stack17.len() - (__counts[17usize] as usize));
-        self.__stack18.truncate(self.__stack18.len() - (__counts[18usize] as usize));
+        self.__stack.truncate(at);
     }
     fn append(&mut self, other: &mut Self) {
-        self.__tags.append(&mut other.__tags);
-        self.__terminals.append(&mut other.__terminals);
-        self.__stack1.append(&mut other.__stack1);
-        self.__stack2.append(&mut other.__stack2);
-        self.__stack3.append(&mut other.__stack3);
-        self.__stack4.append(&mut other.__stack4);
-        self.__stack5.append(&mut other.__stack5);
-        self.__stack6.append(&mut other.__stack6);
-        self.__stack7.append(&mut other.__stack7);
-        self.__stack8.append(&mut other.__stack8);
-        self.__stack9.append(&mut other.__stack9);
-        self.__stack10.append(&mut other.__stack10);
-        self.__stack11.append(&mut other.__stack11);
-        self.__stack12.append(&mut other.__stack12);
-        self.__stack13.append(&mut other.__stack13);
-        self.__stack14.append(&mut other.__stack14);
-        self.__stack15.append(&mut other.__stack15);
-        self.__stack16.append(&mut other.__stack16);
-        self.__stack17.append(&mut other.__stack17);
-        self.__stack18.append(&mut other.__stack18);
+        self.__stack.append(&mut other.__stack);
     }
     fn reduce_action(
         data_stack: &mut Self,

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -193,30 +193,23 @@ impl ::rusty_lr::parser::nonterminal::NonTerminal for ENonTerminals {
         *self as usize
     }
 }
-/// tag for token that represents which stack a token is using
+/// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum ETags {
-    __terminals,
-    __stack1,
+pub enum EData {
+    __terminals(Token),
+    __variant1(i32),
     Empty,
 }
 /// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
 pub struct EDataStack {
-    pub __tags: Vec<ETags>,
-    __terminals: Vec<Token>,
-    __stack1: Vec<i32>,
+    pub __stack: Vec<EData>,
 }
 impl Default for EDataStack {
     fn default() -> Self {
-        Self {
-            __tags: Vec::new(),
-            __terminals: Vec::new(),
-            __stack1: Vec::new(),
-        }
+        Self { __stack: Vec::new() }
     }
 }
 #[rustfmt::skip]
@@ -250,35 +243,42 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant1(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::__variant1(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut a2 = __data_stack.__stack1.pop().unwrap();
-        let mut A = __data_stack.__stack1.pop().unwrap();
-        let mut plus = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut a2 = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut plus = match __data_stack.__stack.pop().unwrap() {
+            EData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             println!("{:?} {:?} {:?}", A, plus, a2);
             *data += 1;
             A + a2
         };
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -296,19 +296,20 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant1(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut M = __data_stack.__stack1.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut M = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
         let __res = M;
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -326,27 +327,30 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant1(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::__variant1(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut __rustylr_data_2 = __data_stack.__stack1.pop().unwrap();
-        let mut __rustylr_data_0 = __data_stack.__stack1.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut __rustylr_data_0 = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
         let __rustylr_data_0 = Self::custom_reduce_action_0(
             __rustylr_data_0,
             data,
@@ -361,7 +365,9 @@ impl EDataStack {
         let mut m2 = __rustylr_data_2;
         let __res = { M_optim * m2 };
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -379,18 +385,15 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(ETags::__stack1);
-        } else {
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut num = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut num = match __data_stack.__stack.pop().unwrap() {
+            EData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             if let Token::Num(n) = num {
                 n
@@ -399,7 +402,9 @@ impl EDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -417,29 +422,32 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::__variant1(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::Empty))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(ETags::__stack1);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        }
-        let mut E = __data_stack.__stack1.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut E = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = E;
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -457,19 +465,20 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant1(_)))
             );
         }
-        if __push_data {} else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut A = __data_stack.__stack1.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
         let __res = A;
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -490,68 +499,37 @@ impl ::rusty_lr::parser::data_stack::DataStack for EDataStack {
     type StartType = i32;
     type Location = ::rusty_lr::DefaultLocation;
     fn pop_start(&mut self) -> Option<Self::StartType> {
-        self.__tags.pop();
-        let tag = self.__tags.pop();
-        debug_assert!(tag == Some(ETags::__stack1));
-        self.__stack1.pop()
+        self.__stack.pop();
+        match self.__stack.pop() {
+            Some(EData::__variant1(val)) => Some(val),
+            _ => None,
+        }
     }
     fn pop(&mut self) {
-        match self.__tags.pop().unwrap() {
-            ETags::__terminals => {
-                self.__terminals.pop();
-            }
-            ETags::__stack1 => {
-                self.__stack1.pop();
-            }
-            _ => {}
-        }
+        self.__stack.pop();
     }
     fn push_terminal(&mut self, term: Self::Term) {
-        self.__tags.push(ETags::__terminals);
-        self.__terminals.push(term);
+        self.__stack.push(EData::__terminals(term));
     }
     fn push_empty(&mut self) {
-        self.__tags.push(ETags::Empty);
+        self.__stack.push(EData::Empty);
     }
     fn clear(&mut self) {
-        self.__tags.clear();
-        self.__terminals.clear();
-        self.__stack1.clear();
+        self.__stack.clear();
     }
     fn reserve(&mut self, additional: usize) {
-        self.__tags.reserve(additional);
+        self.__stack.reserve(additional);
     }
     fn split_off(&mut self, at: usize) -> Self {
-        let mut __counts: [u8; 2usize + 1] = [0; 2usize + 1];
-        let __other_tag_stack = self.__tags.split_off(at);
-        for &tag in &__other_tag_stack {
-            __counts[tag as usize] += 1;
-        }
-        let __other___terminals = self
-            .__terminals
-            .split_off(self.__terminals.len() - (__counts[0usize] as usize));
-        let __other___stack1 = self
-            .__stack1
-            .split_off(self.__stack1.len() - (__counts[1usize] as usize));
         Self {
-            __terminals: __other___terminals,
-            __stack1: __other___stack1,
-            __tags: __other_tag_stack,
+            __stack: self.__stack.split_off(at),
         }
     }
     fn truncate(&mut self, at: usize) {
-        let mut __counts: [u8; 2usize + 1] = [0; 2usize + 1];
-        for &tag in &self.__tags[at..] {
-            __counts[tag as usize] += 1;
-        }
-        self.__tags.truncate(at);
-        self.__terminals.truncate(self.__terminals.len() - (__counts[0usize] as usize));
-        self.__stack1.truncate(self.__stack1.len() - (__counts[1usize] as usize));
+        self.__stack.truncate(at);
     }
     fn append(&mut self, other: &mut Self) {
-        self.__tags.append(&mut other.__tags);
-        self.__terminals.append(&mut other.__terminals);
-        self.__stack1.append(&mut other.__stack1);
+        self.__stack.append(&mut other.__stack);
     }
     fn reduce_action(
         data_stack: &mut Self,

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -222,36 +222,25 @@ impl ::rusty_lr::parser::nonterminal::NonTerminal for ENonTerminals {
         *self as usize
     }
 }
-/// tag for token that represents which stack a token is using
+/// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum ETags {
-    __terminals,
-    __stack1,
-    __stack2,
-    __stack3,
+pub enum EData {
+    __terminals(char),
+    __variant1(i32),
+    __variant2(f32),
+    __variant3(Vec<char>),
     Empty,
 }
 /// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
 pub struct EDataStack {
-    pub __tags: Vec<ETags>,
-    __terminals: Vec<char>,
-    __stack1: Vec<i32>,
-    __stack2: Vec<f32>,
-    __stack3: Vec<Vec<char>>,
+    pub __stack: Vec<EData>,
 }
 impl Default for EDataStack {
     fn default() -> Self {
-        Self {
-            __tags: Vec::new(),
-            __terminals: Vec::new(),
-            __stack1: Vec::new(),
-            __stack2: Vec::new(),
-            __stack3: Vec::new(),
-        }
+        Self { __stack: Vec::new() }
     }
 }
 #[rustfmt::skip]
@@ -278,18 +267,17 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::Empty))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-            __data_stack.__tags.push(ETags::__terminals);
-        } else {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = { '0' };
         if __push_data {
-            __data_stack.__terminals.push(__res);
+            __data_stack.__stack.push(EData::__terminals(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -307,29 +295,32 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::__stack3)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::__variant3(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::Empty))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(ETags::__stack1);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        }
-        let mut Digit = __data_stack.__stack3.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut Digit = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant3(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = { Digit.into_iter().collect::<String>().parse().unwrap() };
         if __push_data {
-            __data_stack.__stack1.push(__res);
+            __data_stack.__stack.push(EData::__variant1(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -347,21 +338,20 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack1)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant1(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(ETags::__stack2);
-        } else {
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut Number = __data_stack.__stack1.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut Number = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant1(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { Number as f32 };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(EData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -379,37 +369,44 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::__stack2)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::__variant2(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 3usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 4usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& EData::Empty))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 5usize);
-            __data_stack.__tags.push(ETags::__stack2);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 4usize);
-        }
-        let mut E = __data_stack.__stack2.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 5usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        let mut E = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = E;
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(EData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -427,28 +424,33 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack2)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant2(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::__stack2)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::__variant2(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut e2 = __data_stack.__stack2.pop().unwrap();
-        let mut E = __data_stack.__stack2.pop().unwrap();
-        let mut Op = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut e2 = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Op = match __data_stack.__stack.pop().unwrap() {
+            EData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut E = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             *data += 1;
             println!("{:?} {:?} {:?}", E, Op, e2);
@@ -459,7 +461,9 @@ impl EDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(EData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -477,29 +481,32 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__stack2)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant2(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 2usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::Empty))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 3usize);
-            __data_stack.__tags.push(ETags::__stack2);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-        }
-        let mut E = __data_stack.__stack2.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        __location_stack.pop().unwrap();
+        let mut E = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let __res = { -E };
         if __push_data {
-            __data_stack.__stack2.push(__res);
+            __data_stack.__stack.push(EData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -517,16 +524,19 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::Empty))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::Empty))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(EData::Empty);
         Ok(())
     }
     ///' '* -> ' '+
@@ -543,11 +553,13 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::Empty)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::Empty))
             );
         }
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(EData::Empty);
         Ok(())
     }
     ///' '* ->
@@ -562,7 +574,7 @@ impl EDataStack {
         __rustylr_location0: &mut ::rusty_lr::DefaultLocation,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
-        __data_stack.__tags.push(ETags::Empty);
+        __data_stack.__stack.push(EData::Empty);
         Ok(())
     }
     ///Digit+ -> Digit
@@ -579,21 +591,20 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__terminals(_)))
             );
         }
-        __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        if __push_data {
-            __data_stack.__tags.push(ETags::__stack3);
-        } else {
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            EData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
         let __res = { vec![A] };
         if __push_data {
-            __data_stack.__stack3.push(__res);
+            __data_stack.__stack.push(EData::__variant3(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -611,29 +622,32 @@ impl EDataStack {
         #[cfg(debug_assertions)]
         {
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 0usize) == Some(&
-                ETags::__terminals)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__terminals(_)))
             );
             debug_assert!(
-                __data_stack.__tags.get(__data_stack.__tags.len() - 1 - 1usize) == Some(&
-                ETags::__stack3)
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::__variant3(_)))
             );
         }
-        if __push_data {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 1usize);
-        } else {
-            __data_stack.__tags.truncate(__data_stack.__tags.len() - 2usize);
-            __data_stack.__tags.push(ETags::Empty);
-        }
-        let mut Ap = __data_stack.__stack3.pop().unwrap();
-        let mut A = __data_stack.__terminals.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        __location_stack.pop().unwrap();
+        let mut A = match __data_stack.__stack.pop().unwrap() {
+            EData::__terminals(val) => val,
+            _ => unreachable!(),
+        };
+        __location_stack.pop().unwrap();
+        let mut Ap = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant3(val) => val,
+            _ => unreachable!(),
+        };
         let __res = {
             Ap.push(A);
             Ap
         };
         if __push_data {
-            __data_stack.__stack3.push(__res);
+            __data_stack.__stack.push(EData::__variant3(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
         }
         Ok(())
     }
@@ -654,88 +668,37 @@ impl ::rusty_lr::parser::data_stack::DataStack for EDataStack {
     type StartType = f32;
     type Location = ::rusty_lr::DefaultLocation;
     fn pop_start(&mut self) -> Option<Self::StartType> {
-        self.__tags.pop();
-        let tag = self.__tags.pop();
-        debug_assert!(tag == Some(ETags::__stack2));
-        self.__stack2.pop()
+        self.__stack.pop();
+        match self.__stack.pop() {
+            Some(EData::__variant2(val)) => Some(val),
+            _ => None,
+        }
     }
     fn pop(&mut self) {
-        match self.__tags.pop().unwrap() {
-            ETags::__terminals => {
-                self.__terminals.pop();
-            }
-            ETags::__stack1 => {
-                self.__stack1.pop();
-            }
-            ETags::__stack2 => {
-                self.__stack2.pop();
-            }
-            ETags::__stack3 => {
-                self.__stack3.pop();
-            }
-            _ => {}
-        }
+        self.__stack.pop();
     }
     fn push_terminal(&mut self, term: Self::Term) {
-        self.__tags.push(ETags::__terminals);
-        self.__terminals.push(term);
+        self.__stack.push(EData::__terminals(term));
     }
     fn push_empty(&mut self) {
-        self.__tags.push(ETags::Empty);
+        self.__stack.push(EData::Empty);
     }
     fn clear(&mut self) {
-        self.__tags.clear();
-        self.__terminals.clear();
-        self.__stack1.clear();
-        self.__stack2.clear();
-        self.__stack3.clear();
+        self.__stack.clear();
     }
     fn reserve(&mut self, additional: usize) {
-        self.__tags.reserve(additional);
+        self.__stack.reserve(additional);
     }
     fn split_off(&mut self, at: usize) -> Self {
-        let mut __counts: [u8; 4usize + 1] = [0; 4usize + 1];
-        let __other_tag_stack = self.__tags.split_off(at);
-        for &tag in &__other_tag_stack {
-            __counts[tag as usize] += 1;
-        }
-        let __other___terminals = self
-            .__terminals
-            .split_off(self.__terminals.len() - (__counts[0usize] as usize));
-        let __other___stack1 = self
-            .__stack1
-            .split_off(self.__stack1.len() - (__counts[1usize] as usize));
-        let __other___stack2 = self
-            .__stack2
-            .split_off(self.__stack2.len() - (__counts[2usize] as usize));
-        let __other___stack3 = self
-            .__stack3
-            .split_off(self.__stack3.len() - (__counts[3usize] as usize));
         Self {
-            __terminals: __other___terminals,
-            __stack1: __other___stack1,
-            __stack2: __other___stack2,
-            __stack3: __other___stack3,
-            __tags: __other_tag_stack,
+            __stack: self.__stack.split_off(at),
         }
     }
     fn truncate(&mut self, at: usize) {
-        let mut __counts: [u8; 4usize + 1] = [0; 4usize + 1];
-        for &tag in &self.__tags[at..] {
-            __counts[tag as usize] += 1;
-        }
-        self.__tags.truncate(at);
-        self.__terminals.truncate(self.__terminals.len() - (__counts[0usize] as usize));
-        self.__stack1.truncate(self.__stack1.len() - (__counts[1usize] as usize));
-        self.__stack2.truncate(self.__stack2.len() - (__counts[2usize] as usize));
-        self.__stack3.truncate(self.__stack3.len() - (__counts[3usize] as usize));
+        self.__stack.truncate(at);
     }
     fn append(&mut self, other: &mut Self) {
-        self.__tags.append(&mut other.__tags);
-        self.__terminals.append(&mut other.__terminals);
-        self.__stack1.append(&mut other.__stack1);
-        self.__stack2.append(&mut other.__stack2);
-        self.__stack3.append(&mut other.__stack3);
+        self.__stack.append(&mut other.__stack);
     }
     fn reduce_action(
         data_stack: &mut Self,

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -500,10 +500,18 @@ impl ::rusty_lr::parser::nonterminal::NonTerminal for JsonNonTerminals {
 /// enum for each non-terminal and terminal symbol, that actually hold data
 #[rustfmt::skip]
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
-pub struct JsonDataStack {}
+pub enum JsonData {
+    Empty,
+}
+/// enum for each non-terminal and terminal symbol, that actually hold data
+#[rustfmt::skip]
+#[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
+pub struct JsonDataStack {
+    pub __stack: Vec<JsonData>,
+}
 impl Default for JsonDataStack {
     fn default() -> Self {
-        Self {}
+        Self { __stack: Vec::new() }
     }
 }
 #[rustfmt::skip]
@@ -527,8 +535,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Object -> '{' Members '}'
@@ -542,8 +570,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Object -> '{' error '}'
@@ -557,13 +605,31 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         let mut __rustylr_location_error = __location_stack.pop().unwrap();
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
         {
             data.push(__rustylr_location_error.clone());
         };
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Members -> Member
@@ -577,8 +643,16 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Members -> Member ',' Members
@@ -592,8 +666,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Member -> WS String WS ':' Element
@@ -607,8 +701,40 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 5usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Array -> '[' $sep(Element, ',', *) ']'
@@ -622,8 +748,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Element -> WS Value WS
@@ -637,8 +783,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///String -> '"' Character* '"'
@@ -652,8 +818,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Character -> '\\' Escape
@@ -667,8 +853,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Escape -> 'u' Hex Hex Hex Hex
@@ -682,8 +882,40 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 5usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Number -> Integer ('.', Digits)? Exponent
@@ -697,8 +929,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Integer -> ['1'-'9'] Digit+
@@ -712,8 +964,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Integer -> '-' ['0'-'9']
@@ -727,8 +993,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Integer -> '-' ['1'-'9'] Digit+
@@ -742,8 +1022,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Exponent -> 'E' Sign Digit+
@@ -757,8 +1057,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Exponent -> 'e' Sign Digit+
@@ -772,8 +1092,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///WS -> ' ' WS
@@ -787,8 +1127,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///WS -> ['\t', '\n', '\r'] WS
@@ -802,8 +1156,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///"true" -> 't' 'r' 'u' 'e'
@@ -817,8 +1185,34 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 4usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///"false" -> 'f' 'a' 'l' 's' 'e'
@@ -832,8 +1226,40 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 5usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                4usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///"null" -> 'n' 'u' 'l' 'l'
@@ -847,8 +1273,34 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 4usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                3usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///$sep(Element, ',', +) -> Element
@@ -862,8 +1314,16 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///$sep(Element, ',', +) -> Element ',' $sep(Element, ',', +)
@@ -877,8 +1337,28 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 3usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///$sep(Element, ',', *) ->
@@ -893,6 +1373,7 @@ impl JsonDataStack {
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Character+ -> Character
@@ -906,8 +1387,16 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Character+ -> Character Character+
@@ -921,8 +1410,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Character* ->
@@ -937,6 +1440,7 @@ impl JsonDataStack {
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Digit+ -> ['0'-'9']
@@ -950,8 +1454,16 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///Digit+ -> ['0'-'9'] Digit+
@@ -965,8 +1477,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///['0'-'9'] -> ['1'-'9']
@@ -980,8 +1506,16 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 1usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///('.', Digits) -> '.' Digit+
@@ -995,8 +1529,22 @@ impl JsonDataStack {
         data: &mut Vec<std::ops::Range<usize>>,
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
-        #[cfg(debug_assertions)] {}
-        __location_stack.truncate(__location_stack.len() - 2usize);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& JsonData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& JsonData::Empty))
+            );
+        }
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __location_stack.pop().unwrap();
+        __data_stack.__stack.pop().unwrap();
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///('.', Digits)? ->
@@ -1011,6 +1559,7 @@ impl JsonDataStack {
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
     ///"" ->
@@ -1025,6 +1574,7 @@ impl JsonDataStack {
         __rustylr_location0: &mut std::ops::Range<usize>,
     ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
         #[cfg(debug_assertions)] {}
+        __data_stack.__stack.push(JsonData::Empty);
         Ok(())
     }
 }
@@ -1044,20 +1594,38 @@ impl ::rusty_lr::parser::data_stack::DataStack for JsonDataStack {
     type StartType = ();
     type Location = std::ops::Range<usize>;
     fn pop_start(&mut self) -> Option<Self::StartType> {
-        Some(())
+        self.__stack.pop();
+        match self.__stack.pop() {
+            Some(JsonData::Empty) => Some(()),
+            _ => None,
+        }
     }
-    fn pop(&mut self) {}
+    fn pop(&mut self) {
+        self.__stack.pop();
+    }
     fn push_terminal(&mut self, term: Self::Term) {
-        unreachable!();
+        self.__stack.push(JsonData::Empty);
     }
-    fn push_empty(&mut self) {}
-    fn clear(&mut self) {}
-    fn reserve(&mut self, additional: usize) {}
+    fn push_empty(&mut self) {
+        self.__stack.push(JsonData::Empty);
+    }
+    fn clear(&mut self) {
+        self.__stack.clear();
+    }
+    fn reserve(&mut self, additional: usize) {
+        self.__stack.reserve(additional);
+    }
     fn split_off(&mut self, at: usize) -> Self {
-        Self {}
+        Self {
+            __stack: self.__stack.split_off(at),
+        }
     }
-    fn truncate(&mut self, at: usize) {}
-    fn append(&mut self, other: &mut Self) {}
+    fn truncate(&mut self, at: usize) {
+        self.__stack.truncate(at);
+    }
+    fn append(&mut self, other: &mut Self) {
+        self.__stack.append(&mut other.__stack);
+    }
     fn reduce_action(
         data_stack: &mut Self,
         location_stack: &mut Vec<std::ops::Range<usize>>,


### PR DESCRIPTION
This PR refactors the generated parser's `DataStack` implementation from using multiple type-specific vectors and a tracking tag vector to a single, unified vector containing all token/rule variants wrapped in a single generated enum. This significantly simplifies the generated parser code, reduces generated code size, and improves runtime management of stack operations.
Additionally, this PR adds a documentation section on optimizing memory usage for large rule types.
### Key Changes
1. **Unified Data Stack Enum (`emit.rs`)**:
   - Replaced individual type vectors (`__stack0`, `__stack1`, etc.) and the tracking tag vector (`__tags`) with a single enum (e.g., `GrammarData`) and a single stack vector (`__stack: Vec<GrammarData>`).
   - Simplified the generated `DataStack` trait methods (`pop`, `clear`, `reserve`, `split_off`, `truncate`, `append`) to directly delegate to the single underlying `__stack` vector.
   - Refactored reduce actions to pop from the single stack and destructure the rule values via pattern matching.
   - Adjusted `pop_start` to pop the trailing EOF (`Empty` token) before extracting the final parse result.
2. **Simplified Variant Tracking**:
   - Cleaned up generator helpers (`variant_names_for_nonterm` and `ruletype_variant_map`) to store and return `Ident` directly instead of wrapping them in `Option<Ident>`, mapping untyped symbols to the `Empty` variant.
3. **Documentation (`SYNTAX.md`)**:
   - Added a new subsection **Memory Optimization with Box** under the `RuleType` section. It clarifies that since all parser semantic values are stored in a single unified enum, wrapping large data types in a `Box` (e.g., `Box<MyLargeStruct>`) is recommended to prevent stack memory bloat.
### Verification
- Re-bootstrapped the parser generator locally.
- Verified that all generated parser modules (such as calculator, JSON, and GLR examples) build correctly and all automated unit tests pass successfully.