### PR TITLE
add `box` prefix support for auto-boxing stack types in `DataEnum`

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -215,7 +215,20 @@ Internally, the generated parser stores all semantic values (the `%tokentype` an
 
 Because the memory footprint of a Rust `enum` is dictated by its largest variant, if even one `RuleType` is exceptionally large (e.g., a large AST struct), the size of *every* stack slot will inflate. This can result in significant memory waste and performance degradation.
 
-To avoid this, wrap large AST nodes or structures in a `Box` (e.g., `Box<MyLargeNode>`). This ensures the enum variant only takes up the size of a single pointer, optimizing stack memory usage.
+To avoid this, you can prefix the type with the `box` keyword:
+```rust
+%tokentype box Token;
+// or
+Expr(box MyLargeNode) : ... ;
+```
+
+When the `box` keyword is prefixed:
+1. The value is automatically stored as `Box<Type>` in the internal stack enum to optimize stack memory footprint.
+2. Inside reduce actions, variable bindings (e.g., `e=Expr`) automatically dereference the popped value so you receive the unboxed type `MyLargeNode` (not `Box<MyLargeNode>`).
+3. You return the unboxed type `MyLargeNode` from reduce actions; the parser generator automatically wraps the returned value in `Box::new(...)` when pushing it back to the stack.
+4. When feeding tokens to the parser, you feed the unboxed type `Token` directly; the parser wraps it in `Box::new` internally.
+
+Alternatively, you can manually use Rust's `Box` type (e.g., `Box<MyLargeNode>`), but you will need to manually call `Box::new` in reduce actions and manually dereference variables. The `box` keyword prefix provides a clean, automatic syntax sugar for this.
 
 ---
 

--- a/rusty_lr_parser/Cargo.toml
+++ b/rusty_lr_parser/Cargo.toml
@@ -15,7 +15,7 @@ quote = "1.0"
 rusty_lr_core = { version = "3.42.0", path = "../rusty_lr_core", features = [
     "builder",
 ] }
-syn = { version = "2.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 
 [features]
 default = []

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -97,7 +97,7 @@ impl Grammar {
         } else {
             format_ident!("SparseState")
         };
-        let token_typename = &self.token_typename;
+        let token_typename = crate::utils::strip_box_prefix(self.token_typename.clone());
 
         let state_index_typename = if self.states.len() <= u8::MAX as usize {
             quote! { u8 }
@@ -180,7 +180,7 @@ impl Grammar {
         let module_prefix = &self.module_prefix;
         let error_name = format_ident!("{}", utils::ERROR_NAME);
         let eof_name = format_ident!("{}", utils::EOF_NAME);
-        let token_typename = &self.token_typename;
+        let token_typename = crate::utils::strip_box_prefix(self.token_typename.clone());
 
         let mut class_variants = Vec::with_capacity(self.terminal_classes.len());
         let mut as_str_match_stream = TokenStream::new();
@@ -526,7 +526,7 @@ impl Grammar {
         let rule_typename = format_ident!("{}Rule", start_rule_ident);
         let state_typename = format_ident!("{}State", start_rule_ident);
         let parser_struct_name = format_ident!("{}Parser", start_rule_ident);
-        let token_typename = &self.token_typename;
+        let token_typename = crate::utils::strip_box_prefix(self.token_typename.clone());
         let termclass_typename = format_ident!("{}TerminalClasses", &start_rule_ident);
 
         let mut class_variants = Vec::with_capacity(self.terminal_classes.len());
@@ -895,7 +895,7 @@ impl Grammar {
         let reduce_error_typename = &self.error_typename;
         let data_stack_typename = format_ident!("{}DataStack", start_rule_ident);
         let data_enum_typename = format_ident!("{}Data", &start_rule_ident);
-        let token_typename = &self.token_typename;
+        let token_typename = crate::utils::strip_box_prefix(self.token_typename.clone());
         let user_data_parameter_name =
             Ident::new(utils::USER_DATA_PARAMETER_NAME, Span::call_site());
         let user_data_typename = &self.userdata_typename;
@@ -927,12 +927,18 @@ impl Grammar {
         // insert variant for terminal token type
         if self.terminal_classes.iter().any(|c| c.data_used) {
             terminal_data_used = true;
+            let storage_type = if crate::utils::has_box_prefix(&self.token_typename) {
+                let unboxed = crate::utils::strip_box_prefix(self.token_typename.clone());
+                quote! { Box<#unboxed> }
+            } else {
+                self.token_typename.clone()
+            };
             ruletype_variant_map.insert(
-                self.token_typename.to_string(),
+                crate::utils::remove_whitespaces(storage_type.to_string()),
                 terminal_variant_name.clone(),
             );
             variant_names_in_order
-                .push((terminal_variant_name.clone(), self.token_typename.clone()));
+                .push((terminal_variant_name.clone(), storage_type));
         }
 
         fn remove_whitespaces(s: String) -> String {
@@ -942,13 +948,21 @@ impl Grammar {
         // iterates through nonterminals
         for nonterm in self.nonterminals.iter() {
             if let Some(ruletype_stream) = nonterm.ruletype.as_ref().cloned() {
+                let is_boxed = crate::utils::has_box_prefix(&ruletype_stream);
+                let unboxed_type = crate::utils::strip_box_prefix(ruletype_stream.clone());
+                let storage_type = if is_boxed {
+                    quote! { Box<#unboxed_type> }
+                } else {
+                    unboxed_type.clone()
+                };
+
                 let cur_len = ruletype_variant_map.len();
                 let variant_name = ruletype_variant_map
-                    .entry(remove_whitespaces(ruletype_stream.to_string()))
+                    .entry(remove_whitespaces(storage_type.to_string()))
                     .or_insert_with(|| {
                         let new_variant_name = format_ident!("__variant{}", cur_len);
                         variant_names_in_order
-                            .push((new_variant_name.clone(), ruletype_stream.clone()));
+                            .push((new_variant_name.clone(), storage_type));
                         new_variant_name
                     })
                     .clone();
@@ -1171,9 +1185,24 @@ impl Grammar {
 
                         if variant_name != &empty_variant_name && mapto.is_some() {
                             let data_mapto = mapto.unwrap();
+                            let is_token_boxed = match token.token {
+                                Token::Term(_) => crate::utils::has_box_prefix(&self.token_typename),
+                                Token::NonTerm(nonterm_idx) => {
+                                    if let Some(ruletype) = &self.nonterminals[nonterm_idx].ruletype {
+                                        crate::utils::has_box_prefix(ruletype)
+                                    } else {
+                                        false
+                                    }
+                                }
+                            };
+                            let val_expr = if is_token_boxed {
+                                quote! { *val }
+                            } else {
+                                quote! { val }
+                            };
                             extract_data_stream.extend(quote! {
                                 let mut #data_mapto = match __data_stack.__stack.pop().unwrap() {
-                                    #data_enum_typename::#variant_name(val) => val,
+                                    #data_enum_typename::#variant_name(val) => #val_expr,
                                     _ => unreachable!(),
                                 };
                             });
@@ -1325,6 +1354,16 @@ impl Grammar {
                         } else {
                             quote! { #reduce_action_body }
                         };
+                        let is_nonterm_boxed = if let Some(ruletype) = &self.nonterminals[nonterm_idx].ruletype {
+                            crate::utils::has_box_prefix(ruletype)
+                        } else {
+                            false
+                        };
+                        let push_val_expr = if is_nonterm_boxed {
+                            quote! { Box::new(__res) }
+                        } else {
+                            quote! { __res }
+                        };
                         fn_reduce_for_each_rule_stream.extend(quote! {
                             #[doc = #rule_debug_str]
                             #[inline]
@@ -1348,7 +1387,7 @@ impl Grammar {
 
                                 let __res = #res_expr;
                                 if __push_data {
-                                    __data_stack.__stack.push(#data_enum_typename::#variant_name(__res));
+                                    __data_stack.__stack.push(#data_enum_typename::#variant_name(#push_val_expr));
                                 } else {
                                     __data_stack.__stack.push(#data_enum_typename::Empty);
                                 }
@@ -1409,13 +1448,20 @@ impl Grammar {
                 .as_ref()
                 .unwrap()
                 .clone();
+            let is_start_boxed = crate::utils::has_box_prefix(&ruletype);
+            let unboxed_typename = crate::utils::strip_box_prefix(ruletype);
+            let val_expr = if is_start_boxed {
+                quote! { *val }
+            } else {
+                quote! { val }
+            };
 
             (
-                ruletype,
+                unboxed_typename,
                 quote! {
                     self.__stack.pop();
                     match self.__stack.pop() {
-                        Some(#data_enum_typename::#start_variant_name(val)) => Some(val),
+                        Some(#data_enum_typename::#start_variant_name(val)) => Some(#val_expr),
                         _ => None,
                     }
                 },
@@ -1440,8 +1486,14 @@ impl Grammar {
         };
 
         let push_terminal_body_stream = if terminal_data_used {
+            let is_term_boxed = crate::utils::has_box_prefix(&self.token_typename);
+            let push_expr = if is_term_boxed {
+                quote! { Box::new(term) }
+            } else {
+                quote! { term }
+            };
             quote! {
-                self.__stack.push(#data_enum_typename::#terminal_variant_name(term));
+                self.__stack.push(#data_enum_typename::#terminal_variant_name(#push_expr));
             }
         } else {
             quote! {

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -446,8 +446,9 @@ impl Grammar {
 
             span_manager: grammar_args.span_manager,
         };
-        grammar.is_char = grammar.token_typename.to_string() == "char";
-        grammar.is_u8 = grammar.token_typename.to_string() == "u8";
+        let unboxed_token_typename = crate::utils::strip_box_prefix(grammar.token_typename.clone());
+        grammar.is_char = unboxed_token_typename.to_string() == "char";
+        grammar.is_u8 = unboxed_token_typename.to_string() == "u8";
 
         // add char ranges to resolver
         // iterate over all rules, reduce_type or precedence definitions,
@@ -541,7 +542,11 @@ impl Grammar {
         for (rule_idx, rules_arg) in grammar_args.rules.iter().enumerate() {
             let ruletype = if is_placeholder_type(&rules_arg.typename) {
                 let placeholder_name = format_ident!("__rustylr_placeholder_{}", rules_arg.name.value());
-                Some(quote! { #placeholder_name })
+                if crate::utils::has_box_prefix(rules_arg.typename.as_ref().unwrap()) {
+                    Some(quote! { box #placeholder_name })
+                } else {
+                    Some(quote! { #placeholder_name })
+                }
             } else {
                 rules_arg.typename.clone()
             };
@@ -1069,7 +1074,7 @@ impl Grammar {
                     let mut nonterm_idx = None;
                     for (idx, nonterm) in grammar.nonterminals.iter().enumerate() {
                         if let Some(name) = &nonterm.ruletype {
-                            if name.to_string() == *p_name {
+                            if crate::utils::strip_box_prefix(name.clone()).to_string() == *p_name {
                                 nonterm_idx = Some(idx);
                                 break;
                             }
@@ -1125,7 +1130,7 @@ impl Grammar {
                 let mut loc = Location::CallSite;
                 for nonterm in &grammar.nonterminals {
                     if let Some(name) = &nonterm.ruletype {
-                        if name.to_string() == *first_p_name {
+                        if crate::utils::strip_box_prefix(name.clone()).to_string() == *first_p_name {
                             loc = nonterm.name.location();
                             break;
                         }
@@ -2258,7 +2263,8 @@ impl Grammar {
 
 fn is_placeholder_type(ruletype: &Option<TokenStream>) -> bool {
     if let Some(ts) = ruletype {
-        let mut it = ts.clone().into_iter();
+        let stripped = crate::utils::strip_box_prefix(ts.clone());
+        let mut it = stripped.into_iter();
         if let Some(proc_macro2::TokenTree::Ident(ident)) = it.next() {
             if ident.to_string() == "_" && it.next().is_none() {
                 return true;
@@ -2602,6 +2608,49 @@ mod tests {
         // Check that the Empty variant is present in the output
         let code_str = code.to_string();
         assert!(code_str.contains("Empty"), "Empty variant should be unconditionally included");
+    }
+
+    #[test]
+    fn test_type_inference_with_box() {
+        let input = quote! {
+            %tokentype box MyToken;
+            %start Expr;
+            %token a MyToken::A;
+            Expr(box _) : Term;
+            Term(i32) : a;
+        };
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+        let expr_idx = grammar.nonterminals_index.get("Expr").unwrap();
+        assert_eq!(
+            grammar.nonterminals[*expr_idx].ruletype.as_ref().unwrap().to_string(),
+            "box i32"
+        );
+    }
+
+    #[test]
+    fn test_codegen_with_box() {
+        let input = quote! {
+            %tokentype box MyToken;
+            %start Expr;
+            %token a MyToken::A;
+            Expr(box i32) : a { 1 };
+        };
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+        let code = grammar.emit_compiletime();
+        
+        let parsed = syn::parse2::<syn::File>(code.clone());
+        if let Err(_e) = &parsed {
+            println!("Generated code:\n{}", code.to_string());
+        }
+        assert!(parsed.is_ok(), "Generated code failed to parse: {:?}", parsed.err());
+        
+        let code_str = code.to_string();
+        assert!(code_str.contains("Box < MyToken >"), "Data enum should box the token type");
+        assert!(code_str.contains("Box < i32 >"), "Data enum should box the Expr type");
+        assert!(code_str.contains("type Term = MyToken ;"), "Public Term type should be unboxed");
+        assert!(code_str.contains("type StartType = i32 ;"), "Public StartType should be unboxed");
     }
 }
 

--- a/rusty_lr_parser/src/utils.rs
+++ b/rusty_lr_parser/src/utils.rs
@@ -28,14 +28,10 @@ pub(crate) fn ident_from_located(
 pub(crate) fn has_box_prefix(ts: &proc_macro2::TokenStream) -> bool {
     let mut iter = ts.clone().into_iter();
     if let Some(proc_macro2::TokenTree::Ident(ident)) = iter.next() {
-        if ident.to_string() == "box" {
-            let remaining: proc_macro2::TokenStream = iter.collect();
-            if !remaining.is_empty() {
-                return syn::parse2::<syn::Type>(remaining).is_ok();
-            }
-        }
+        ident.to_string() == "box" && iter.next().is_some()
+    } else {
+        false
     }
-    false
 }
 
 pub(crate) fn strip_box_prefix(ts: proc_macro2::TokenStream) -> proc_macro2::TokenStream {

--- a/rusty_lr_parser/src/utils.rs
+++ b/rusty_lr_parser/src/utils.rs
@@ -24,3 +24,31 @@ pub(crate) fn ident_from_located(
     let span = span_manager.get_span_in_location(location);
     Ident::new(name, span)
 }
+
+pub(crate) fn has_box_prefix(ts: &proc_macro2::TokenStream) -> bool {
+    let mut iter = ts.clone().into_iter();
+    if let Some(proc_macro2::TokenTree::Ident(ident)) = iter.next() {
+        if ident.to_string() == "box" {
+            let remaining: proc_macro2::TokenStream = iter.collect();
+            if !remaining.is_empty() {
+                return syn::parse2::<syn::Type>(remaining).is_ok();
+            }
+        }
+    }
+    false
+}
+
+pub(crate) fn strip_box_prefix(ts: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    if has_box_prefix(&ts) {
+        let mut iter = ts.into_iter();
+        let _ = iter.next(); // Consume 'box'
+        iter.collect()
+    } else {
+        ts
+    }
+}
+
+pub(crate) fn remove_whitespaces(s: String) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
+}
+


### PR DESCRIPTION
# Description
This PR introduces the `box` keyword prefix syntax sugar for `%tokentype` and NonTerminal `RuleType` definitions.
Previously, to prevent parser data stack enum inflation from large AST nodes, users had to manually wrap types in `Box<...>` and write boilerplate code to package/unbox values inside reduce actions. With this change, prefixing a type definition with `box` automatically compiles it into a `Box` wrapper in the internal `Data` stack enum, while presenting clean, unboxed values directly to user-defined reduce actions and the public parser APIs.
To ensure zero overhead on the parser generator compilation phase, type prefix checking is optimized to run in $O(1)$ time by verifying token structure directly rather than doing full syntax parsing.
## Key Changes
- **Type Checking Utilities** (`utils.rs`): Added highly efficient $O(1)$ `has_box_prefix` and `strip_box_prefix` checks to identify and strip the `box` keyword from token streams when followed by a type definition.
- **Placeholder Resolution** (`grammar.rs`): Supported placeholder type inference for boxed structures (e.g., `box _`), resolving types while maintaining the boxed keyword structure.
- **Auto-boxing and Auto-dereferencing Codegen** (`emit.rs`):
  - Automatically wraps data enum variant fields in `Box<T>` if defined with the `box` prefix.
  - Automatically dereferences (`*val`) when popping variables in reduce actions, making the popped binding unboxed.
  - Automatically wraps pushed variables in `Box::new(...)` during rule reduction returns and token feed actions.
  - Kept public traits and API definitions (such as `type Term` and `type StartType`) using the unboxed types.
- **Documentation**: Updated `SYNTAX.md` under the `Memory Optimization with Box` section to document the usage and mechanics of the new syntax sugar.