### PR TITLE
Variable substitution

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -28,6 +28,7 @@ This document provides a comprehensive guide to the grammar definition syntax us
 - [Disabling Table Optimization (`%nooptim`)](#no-optimization)
 - [Dense Parser Tables (`%dense`)](#dense-parser-table)
 - [Location Tracking (`%location`)](#location-tracking)
+- [Variable Substitution](#variable-substitution)
 
 ---
 
@@ -546,4 +547,44 @@ Expr(i32) : e1=Expr '+' e2=Expr {
     println!("Left operand position: {:?}", @e1);
     e1 + e2
 };
+```
+
+---
+
+## Variable Substitution
+
+You can use variables prefixed with `$` inside any RustCode block in the grammar. This includes:
+- `%tokentype`
+- `%location`
+- `%userdata`
+- `%errortype` (or `%error`)
+- `%moduleprefix`
+- `%filter`
+- `%token` terminal definitions
+- Non-terminal rule types
+- Reduce actions
+
+### Supported Variables
+- `$tokentype` -> Evaluates to the type defined by `%tokentype`.
+- `$location` -> Evaluates to the type defined by `%location` (defaults to `$moduleprefix::DefaultLocation`).
+- `$userdata` -> Evaluates to the type defined by `%userdata` (defaults to `()`).
+- `$error` or `$errortype` -> Evaluates to the type defined by `%errortype` / `%error` (defaults to `$moduleprefix::DefaultReduceActionError`).
+- `$moduleprefix` -> Evaluates to the path defined by `%moduleprefix` (defaults to `::rusty_lr`).
+- `$filter` -> Evaluates to the filter expression/function defined by `%filter`.
+- `$NonTerminalName` -> Evaluates to the `ruletype` defined for `NonTerminalName`.
+- `$terminal_name` -> Evaluates to the match pattern/definition of `<terminal_name>`.
+
+### Circular Dependency and Max Depth
+If you introduce circular dependencies among type/definition variables, a compile-time error (`CircularDependency`) is returned. A maximum recursion limit of `100` is enforced to prevent infinite compilation loops.
+
+### Example
+```rust
+%tokentype Token;
+%userdata MyUser;
+%error MyError;
+%token a Token::A;
+
+Expr($tokentype) : a { $tokentype };
+Term($location) : a { $location };
+Rule($userdata) : a { $userdata };
 ```

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -574,8 +574,10 @@ You can use variables prefixed with `$` inside any RustCode block in the grammar
 - `$NonTerminalName` -> Evaluates to the `ruletype` defined for `NonTerminalName`.
 - `$terminal_name` -> Evaluates to the match pattern/definition of `<terminal_name>`.
 
-### Circular Dependency and Max Depth
-If you introduce circular dependencies among type/definition variables, a compile-time error (`CircularDependency`) is returned. A maximum recursion limit of `100` is enforced to prevent infinite compilation loops.
+### Substitution Errors
+- **Circular Dependency**: If you introduce circular dependencies among type/definition variables, a compile-time error (`CircularDependency`) is returned.
+- **Max Depth Exceeded**: A maximum recursion limit of `100` is enforced to prevent infinite compilation loops. If exceeded, a compile-time error (`MaxSubstitutionDepthExceeded`) is returned.
+- **Filter Not Defined**: If `$filter` is used inside a reduce action block but `%filter` directive is not defined, a compile-time error (`FilterNotDefined`) is returned.
 
 ### Example
 ```rust

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -588,3 +588,35 @@ Expr($tokentype) : a { $tokentype };
 Term($location) : a { $location };
 Rule($userdata) : a { $userdata };
 ```
+
+### Extracting Terminal Values (Syntax Sugar)
+
+When defining a terminal token, you typically wrap it inside an enum variant. For example:
+```rust
+%tokentype Token;
+%token ident Token::Ident(ident);
+```
+
+Notice that the variable bound inside the pattern `Token::Ident(ident)` has the exact same name as the terminal symbol `ident`.
+
+Inside a reduce action, you can use variable substitution to easily match and extract this inner value into a local variable without writing out the full boilerplate `let Token::Ident(ident) = ...`:
+
+```rust
+Rule(ResultType) : ident {
+    let $ident = ident else {
+        unreachable!("Expected ident token");
+    };
+    // Now you can use the extracted `ident` value directly!
+    println!("Ident value: {}", ident);
+}
+```
+
+Because `$ident` expands directly to the terminal's pattern stream (`Token::Ident(ident)`), the line `let $ident = ident else { ... };` automatically expands to:
+
+```rust
+let Token::Ident(ident) = ident else {
+    unreachable!("Expected ident token");
+};
+```
+
+This syntax sugar is extremely useful for reducing boilerplate code when processing token streams in your compiler's parser rules.

--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -440,6 +440,50 @@ impl Builder {
                                 "Only one %tokentype definition is allowed".to_string()
                             ])
                     }
+                    ArgError::MultipleLocationDefinition(locs) => {
+                        let mut labels = Vec::new();
+                        for (i, loc) in locs.iter().enumerate() {
+                            let range = grammar_args
+                                .span_manager
+                                .get_byterange(&loc)
+                                .unwrap_or(0..0);
+                            let message = if i == 0 {
+                                "First definition"
+                            } else {
+                                "Other definition"
+                            };
+                            labels.push(Label::primary(file_id, range).with_message(message));
+                        }
+
+                        Diagnostic::error()
+                            .with_message("Multiple %location definition")
+                            .with_labels(labels)
+                            .with_notes(vec![
+                                "Only one %location definition is allowed".to_string()
+                            ])
+                    }
+                    ArgError::MultipleFilterDefinition(locs) => {
+                        let mut labels = Vec::new();
+                        for (i, loc) in locs.iter().enumerate() {
+                            let range = grammar_args
+                                .span_manager
+                                .get_byterange(&loc)
+                                .unwrap_or(0..0);
+                            let message = if i == 0 {
+                                "First definition"
+                            } else {
+                                "Other definition"
+                            };
+                            labels.push(Label::primary(file_id, range).with_message(message));
+                        }
+
+                        Diagnostic::error()
+                            .with_message("Multiple %filter definition")
+                            .with_labels(labels)
+                            .with_notes(vec![
+                                "Only one %filter definition is allowed".to_string()
+                            ])
+                    }
                     ArgError::MultipleEofDefinition(locs) => {
                         let mut labels = Vec::new();
                         for (i, loc) in locs.iter().enumerate() {
@@ -836,6 +880,46 @@ impl Builder {
                             .with_message("type inference failed: circular dependency or no identity action found")
                             .with_labels(vec![Label::primary(file_id, range)
                                 .with_message("failed to infer type for this placeholder")])
+                    }
+
+                    ParseError::CircularDependency { location, path } => {
+                        let range = span_manager.get_byterange(&location).unwrap_or(0..0);
+                        Diagnostic::error()
+                            .with_message(format!(
+                                "circular dependency detected: {}",
+                                path.join(" -> ")
+                            ))
+                            .with_labels(vec![Label::primary(file_id, range)
+                                .with_message("circular reference starts here")])
+                            .with_notes(vec![
+                                "refer to https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#substitution-errors".to_string(),
+                            ])
+                    }
+
+                    ParseError::MaxSubstitutionDepthExceeded { location, max_depth } => {
+                        let range = span_manager.get_byterange(&location).unwrap_or(0..0);
+                        Diagnostic::error()
+                            .with_message(format!(
+                                "maximum variable substitution depth ({}) exceeded",
+                                max_depth
+                            ))
+                            .with_labels(vec![Label::primary(file_id, range)
+                                .with_message("recursion depth limit reached here")])
+                            .with_notes(vec![
+                                "refer to https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#substitution-errors".to_string(),
+                            ])
+                    }
+
+                    ParseError::FilterNotDefined(loc) => {
+                        let range = span_manager.get_byterange(&loc).unwrap_or(0..0);
+                        Diagnostic::error()
+                            .with_message("Filter function not defined")
+                            .with_labels(vec![Label::primary(file_id, range)
+                                .with_message("referenced here")])
+                            .with_notes(vec![
+                                "Define the filter function using %filter <path>;".to_string(),
+                                "refer to https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#substitution-errors".to_string(),
+                            ])
                     }
 
                     _ => {

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -85,11 +85,7 @@ impl Grammar {
             &format!("{}TerminalClasses", self.start_rule_name),
             start_rule_span,
         );
-        let location_typename = self
-            .location_typename
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| quote! { #module_prefix::DefaultLocation });
+        let location_typename = &self.location_typename;
         let reduce_error_typename = &self.error_typename;
 
         let state_structname = if self.emit_dense {
@@ -899,11 +895,7 @@ impl Grammar {
         let user_data_parameter_name =
             Ident::new(utils::USER_DATA_PARAMETER_NAME, Span::call_site());
         let user_data_typename = &self.userdata_typename;
-        let location_typename = self
-            .location_typename
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| quote! { #module_prefix::DefaultLocation });
+        let location_typename = &self.location_typename;
 
         // empty tag name
         let empty_variant_name = format_ident!("Empty");

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -387,7 +387,7 @@ impl Grammar {
                     }
                 }
                 fn from_term(terminal: &Self::Term) -> Self {
-                    #[allow(unreachable_patterns)]
+                    #[allow(unreachable_patterns, unused_variables)]
                     match #match_terminal_filter_expression {
                         #from_term_match_stream
                     }

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -37,6 +37,10 @@ pub enum ArgError {
     MultiplePrecDefinition(Vec<Location>),
     /// multiple %dprec in the same rule
     MultipleDPrecDefinition(Vec<Location>),
+    /// multiple %location in the same grammar
+    MultipleLocationDefinition(Vec<Location>),
+    /// multiple %filter in the same grammar
+    MultipleFilterDefinition(Vec<Location>),
 
     StartNotDefined,
     EofNotDefined,
@@ -129,6 +133,21 @@ pub enum ParseError {
 
     /// type inference failed for NonTerminal's ruletype placeholder '_'
     TypeInferenceFailed(Location),
+
+    /// Circular dependency detected in variable substitution
+    CircularDependency {
+        location: Location,
+        path: Vec<String>,
+    },
+
+    /// Maximum variable substitution depth exceeded
+    MaxSubstitutionDepthExceeded {
+        location: Location,
+        max_depth: usize,
+    },
+
+    /// $filter was used in variable substitution but %filter function not defined
+    FilterNotDefined(Location),
 }
 #[allow(unused)]
 impl ArgError {
@@ -152,6 +171,8 @@ impl ArgError {
             | ArgError::MultipleUserDataDefinition(locs)
             | ArgError::MultipleErrorDefinition(locs)
             | ArgError::MultipleTokenTypeDefinition(locs)
+            | ArgError::MultipleLocationDefinition(locs)
+            | ArgError::MultipleFilterDefinition(locs)
             | ArgError::MultipleEofDefinition(locs)
             | ArgError::MultipleStartDefinition(locs)
             | ArgError::MultiplePrecDefinition(locs)
@@ -170,6 +191,8 @@ impl ArgError {
             ArgError::MultipleUserDataDefinition(_) => "Multiple %userdata definition".into(),
             ArgError::MultipleErrorDefinition(_) => "Multiple %error definition".into(),
             ArgError::MultipleTokenTypeDefinition(_) => "Multiple %tokentype definition".into(),
+            ArgError::MultipleLocationDefinition(_) => "Multiple %location definition".into(),
+            ArgError::MultipleFilterDefinition(_) => "Multiple %filter definition".into(),
             ArgError::MultipleEofDefinition(_) => "Multiple %eof definition".into(),
             ArgError::MultipleStartDefinition(_) => "Multiple %start definition".into(),
             ArgError::MultiplePrecDefinition(_) => "Multiple %prec definition".into(),
@@ -261,6 +284,9 @@ impl ParseError {
             ParseError::BisonVariableZero(loc) => vec![*loc],
             ParseError::BisonVariableOutOfRange { location, .. } => vec![*location],
             ParseError::TypeInferenceFailed(location) => vec![*location],
+            ParseError::CircularDependency { location, .. } => vec![*location],
+            ParseError::MaxSubstitutionDepthExceeded { location, .. } => vec![*location],
+            ParseError::FilterNotDefined(loc) => vec![*loc],
         }
     }
 
@@ -319,7 +345,22 @@ impl ParseError {
                 format!("bison variable {} is out of range (max: {})", name, max)
             }
             ParseError::TypeInferenceFailed(_) => {
-                "type inference failed: circular dependency or no identity action found".to_string()
+                "Type inference failed for NonTerminal rule type".to_string()
+            }
+            ParseError::CircularDependency { path, .. } => {
+                format!(
+                    "Circular dependency detected in variable substitutions: {}",
+                    path.join(" -> ")
+                )
+            }
+            ParseError::MaxSubstitutionDepthExceeded { max_depth, .. } => {
+                format!(
+                    "Maximum variable substitution depth ({}) exceeded",
+                    max_depth
+                )
+            }
+            ParseError::FilterNotDefined(_) => {
+                "Filter function not defined. Define it using %filter <path>;".to_string()
             }
         }
     }

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -613,6 +613,8 @@ impl Grammar {
                                 result.extend(resolved);
                                 continue;
                             } else if providers.contains_key(&format!("nonterm:{}", ident_name)) {
+                                // Direct non-terminal substitution ($NonTerminalName).
+                                // Resolves the variable to the rule type of the specified non-terminal.
                                 iter.next();
                                 let resolved = resolve_provider(
                                     &format!("nonterm:{}", ident_name),
@@ -626,6 +628,9 @@ impl Grammar {
                                 result.extend(resolved);
                                 continue;
                             } else {
+                                // Fallback: If the variable following '$' is not recognized as any known
+                                // configuration, terminal, or non-terminal, we do not throw a compile-time
+                                // error. Instead, we skip resolving and leave the token stream unchanged.
                                 // TODO: 이거 워닝으로 내면 좋을듯
                             }
                         }
@@ -845,6 +850,8 @@ impl Grammar {
             }
         }
 
+        // Resolve and substitute variables inside the %filter expression itself
+        // (e.g. if the user uses defined type/location variables in the filter signature).
         for (_, filter_stream) in &mut grammar_args.filter {
             *filter_stream = substitute_stream(
                 filter_stream.clone(),

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -512,10 +512,12 @@ impl Grammar {
                 match tt {
                     proc_macro2::TokenTree::Punct(punct) if punct.as_char() == '$' => {
                         let ref_span = punct.span();
-                        let ref_loc = Location::Range(
-                            span_manager.add_span(ref_span),
-                            span_manager.add_span(ref_span) + 1,
-                        );
+                        // We register this inner token span (e.g., '$') to the SpanManager
+                        // so that we can construct a valid Location index. This allows the buildscript
+                        // to query the exact byte range of the error for visual diagnostic reporting.
+                        // We only need to push the span once, creating a range of length 1.
+                        let idx = span_manager.add_span(ref_span);
+                        let ref_loc = Location::Range(idx, idx + 1);
 
                         if let Some(proc_macro2::TokenTree::Ident(ident)) = iter.peek() {
                             let ident_name = ident.to_string();

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -148,7 +148,7 @@ pub struct Grammar {
     pub filter: Option<TokenStream>,
 
     /// type for location
-    pub location_typename: Option<TokenStream>,
+    pub location_typename: TokenStream,
 
     /// precedence level of error token
     pub error_precedence: Option<usize>,
@@ -220,6 +220,30 @@ impl Grammar {
             return Err(ArgError::MultipleErrorDefinition(
                 grammar_args
                     .error_typename
+                    .iter()
+                    .map(|(loc, _)| loc)
+                    .cloned()
+                    .collect(),
+            ));
+        }
+
+        // %location
+        if grammar_args.location_typename.len() > 1 {
+            return Err(ArgError::MultipleLocationDefinition(
+                grammar_args
+                    .location_typename
+                    .iter()
+                    .map(|(loc, _)| loc)
+                    .cloned()
+                    .collect(),
+            ));
+        }
+
+        // %filter
+        if grammar_args.filter.len() > 1 {
+            return Err(ArgError::MultipleFilterDefinition(
+                grammar_args
+                    .filter
                     .iter()
                     .map(|(loc, _)| loc)
                     .cloned()
@@ -384,28 +408,475 @@ impl Grammar {
     }
 
     /// parse the input TokenStream and return a parsed Grammar
-    pub fn from_grammar_args(grammar_args: GrammarArgs) -> Result<Self, ParseError> {
-        let module_prefix =
-            if let Some(module_prefix) = grammar_args.module_prefix.into_iter().next() {
-                module_prefix.1
-            } else {
-                quote! { ::rusty_lr }
+    pub fn from_grammar_args(mut grammar_args: GrammarArgs) -> Result<Self, ParseError> {
+        #[derive(Clone)]
+        enum ResolveState {
+            Unresolved,
+            Resolving,
+            Resolved(TokenStream),
+        }
+
+        struct ProviderInfo {
+            #[allow(dead_code)]
+            name: String,
+            location: Location,
+            stream: Option<TokenStream>,
+            state: ResolveState,
+        }
+
+        fn resolve_provider(
+            name: &str,
+            providers: &mut std::collections::HashMap<String, ProviderInfo>,
+            span_manager: &mut crate::parser::location::SpanManager,
+            stack: &mut Vec<String>,
+            depth: usize,
+            max_depth: usize,
+            ref_loc: Location,
+        ) -> Result<TokenStream, ParseError> {
+            if depth > max_depth {
+                return Err(ParseError::MaxSubstitutionDepthExceeded {
+                    location: ref_loc,
+                    max_depth,
+                });
+            }
+
+            if stack.contains(&name.to_string()) {
+                let mut path = stack.clone();
+                path.push(name.to_string());
+                return Err(ParseError::CircularDependency {
+                    location: ref_loc,
+                    path,
+                });
+            }
+
+            if !providers.contains_key(name) {
+                if name == "filter" {
+                    return Err(ParseError::FilterNotDefined(ref_loc));
+                } else if name.starts_with("nonterm:") {
+                    return Err(ParseError::NonTerminalNotDefined(ref_loc));
+                } else if name.starts_with("term:") {
+                    return Err(ParseError::TerminalNotDefined(ref_loc));
+                } else {
+                    return Err(ParseError::TerminalNotDefined(ref_loc));
+                }
+            }
+
+            let state = providers.get(name).unwrap().state.clone();
+            match state {
+                ResolveState::Resolved(resolved_stream) => {
+                    return Ok(resolved_stream);
+                }
+                ResolveState::Resolving => {
+                    let mut path = stack.clone();
+                    path.push(name.to_string());
+                    return Err(ParseError::CircularDependency {
+                        location: ref_loc,
+                        path,
+                    });
+                }
+                ResolveState::Unresolved => {}
+            }
+
+            providers.get_mut(name).unwrap().state = ResolveState::Resolving;
+            stack.push(name.to_string());
+
+            let raw_stream = providers.get(name).unwrap().stream.clone();
+            let resolved_stream = match raw_stream {
+                Some(stream) => {
+                    substitute_stream(stream, providers, span_manager, stack, depth + 1, max_depth)?
+                }
+                None => {
+                    debug_assert!(name.starts_with("nonterm:"));
+                    quote! { () }
+                }
             };
-        let error_typename =
-            if let Some(error_typename) = grammar_args.error_typename.into_iter().next() {
-                error_typename.1
+
+            stack.pop();
+            providers.get_mut(name).unwrap().state = ResolveState::Resolved(resolved_stream.clone());
+
+            Ok(resolved_stream)
+        }
+
+        fn substitute_stream(
+            stream: TokenStream,
+            providers: &mut std::collections::HashMap<String, ProviderInfo>,
+            span_manager: &mut crate::parser::location::SpanManager,
+            stack: &mut Vec<String>,
+            depth: usize,
+            max_depth: usize,
+        ) -> Result<TokenStream, ParseError> {
+            let mut result = TokenStream::new();
+            let mut iter = stream.into_iter().peekable();
+
+            while let Some(tt) = iter.next() {
+                match tt {
+                    proc_macro2::TokenTree::Punct(punct) if punct.as_char() == '$' => {
+                        let ref_span = punct.span();
+                        let ref_loc = Location::Range(
+                            span_manager.add_span(ref_span),
+                            span_manager.add_span(ref_span) + 1,
+                        );
+
+                        if let Some(proc_macro2::TokenTree::Ident(ident)) = iter.peek() {
+                            let ident_name = ident.to_string();
+                            if ident_name == "tokentype" {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    "tokentype",
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if ident_name == "location" {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    "location",
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if ident_name == "filter" {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    "filter",
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if ident_name == "userdata" {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    "userdata",
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if ident_name == "error" || ident_name == "errortype" {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    "errortype",
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if ident_name == "moduleprefix" {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    "moduleprefix",
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if providers.contains_key(&format!("term:{}", ident_name)) {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    &format!("term:{}", ident_name),
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else if providers.contains_key(&format!("nonterm:{}", ident_name)) {
+                                iter.next();
+                                let resolved = resolve_provider(
+                                    &format!("nonterm:{}", ident_name),
+                                    providers,
+                                    span_manager,
+                                    stack,
+                                    depth,
+                                    max_depth,
+                                    ref_loc,
+                                )?;
+                                result.extend(resolved);
+                                continue;
+                            } else {
+                                // TODO: 이거 워닝으로 내면 좋을듯
+                            }
+                        }
+
+                        result.extend(std::iter::once(proc_macro2::TokenTree::Punct(punct)));
+                    }
+                    proc_macro2::TokenTree::Group(group) => {
+                        let substituted_stream = substitute_stream(
+                            group.stream(),
+                            providers,
+                            span_manager,
+                            stack,
+                            depth,
+                            max_depth,
+                        )?;
+                        let mut new_group = proc_macro2::Group::new(group.delimiter(), substituted_stream);
+                        new_group.set_span(group.span());
+                        result.extend(std::iter::once(proc_macro2::TokenTree::Group(new_group)));
+                    }
+                    other => {
+                        result.extend(std::iter::once(other));
+                    }
+                }
+            }
+
+            Ok(result)
+        }
+
+        // Initialize providers
+        let mut providers: std::collections::HashMap<String, ProviderInfo> = std::collections::HashMap::new();
+
+        let moduleprefix_loc = grammar_args.module_prefix.first().map(|(l, _)| *l).unwrap_or(Location::CallSite);
+        let moduleprefix_stream = grammar_args.module_prefix.first().map(|(_, s)| s.clone()).unwrap_or(quote! { ::rusty_lr });
+        providers.insert(
+            "moduleprefix".to_string(),
+            ProviderInfo {
+                name: "moduleprefix".to_string(),
+                location: moduleprefix_loc,
+                stream: Some(moduleprefix_stream),
+                state: ResolveState::Unresolved,
+            },
+        );
+
+        let userdata_loc = grammar_args.userdata_typename.first().map(|(l, _)| *l).unwrap_or(Location::CallSite);
+        let userdata_stream = grammar_args.userdata_typename.first().map(|(_, s)| s.clone()).unwrap_or(quote! { () });
+        providers.insert(
+            "userdata".to_string(),
+            ProviderInfo {
+                name: "userdata".to_string(),
+                location: userdata_loc,
+                stream: Some(userdata_stream),
+                state: ResolveState::Unresolved,
+            },
+        );
+
+        let errortype_loc = grammar_args.error_typename.first().map(|(l, _)| *l).unwrap_or(Location::CallSite);
+        let errortype_stream = grammar_args.error_typename.first().map(|(_, s)| s.clone()).unwrap_or(quote! { $moduleprefix::DefaultReduceActionError });
+        providers.insert(
+            "errortype".to_string(),
+            ProviderInfo {
+                name: "errortype".to_string(),
+                location: errortype_loc,
+                stream: Some(errortype_stream),
+                state: ResolveState::Unresolved,
+            },
+        );
+
+        if let Some((loc, stream)) = grammar_args.token_typename.first() {
+            providers.insert(
+                "tokentype".to_string(),
+                ProviderInfo {
+                    name: "tokentype".to_string(),
+                    location: *loc,
+                    stream: Some(stream.clone()),
+                    state: ResolveState::Unresolved,
+                },
+            );
+        }
+
+        let location_loc = grammar_args.location_typename.first().map(|(l, _)| *l).unwrap_or(Location::CallSite);
+        let location_stream = grammar_args.location_typename.first().map(|(_, s)| s.clone()).unwrap_or(quote! { $moduleprefix::DefaultLocation });
+        providers.insert(
+            "location".to_string(),
+            ProviderInfo {
+                name: "location".to_string(),
+                location: location_loc,
+                stream: Some(location_stream),
+                state: ResolveState::Unresolved,
+            },
+        );
+
+        if let Some((loc, stream)) = grammar_args.filter.first() {
+            providers.insert(
+                "filter".to_string(),
+                ProviderInfo {
+                    name: "filter".to_string(),
+                    location: *loc,
+                    stream: Some(stream.clone()),
+                    state: ResolveState::Unresolved,
+                },
+            );
+        }
+
+        for (ident, stream) in &grammar_args.terminals {
+            providers.insert(
+                format!("term:{}", ident.value()),
+                ProviderInfo {
+                    name: format!("term:{}", ident.value()),
+                    location: ident.location(),
+                    stream: Some(stream.clone()),
+                    state: ResolveState::Unresolved,
+                },
+            );
+        }
+
+        for rules_arg in &grammar_args.rules {
+            let stream = if is_placeholder_type(&rules_arg.typename) {
+                let placeholder_name = format_ident!("__rustylr_placeholder_{}", rules_arg.name.value());
+                Some(quote! { #placeholder_name })
             } else {
-                quote! { #module_prefix::DefaultReduceActionError }
+                rules_arg.typename.clone()
             };
+
+            providers.insert(
+                format!("nonterm:{}", rules_arg.name.value()),
+                ProviderInfo {
+                    name: format!("nonterm:{}", rules_arg.name.value()),
+                    location: rules_arg.name.location(),
+                    stream,
+                    state: ResolveState::Unresolved,
+                },
+            );
+        }
+
+        // Resolve providers
+        let provider_keys: Vec<String> = providers.keys().cloned().collect();
+        let mut stack = Vec::new();
+        for key in provider_keys {
+            let loc = providers[&key].location;
+            resolve_provider(
+                &key,
+                &mut providers,
+                &mut grammar_args.span_manager,
+                &mut stack,
+                0,
+                100,
+                loc,
+            )?;
+        }
+
+        // Write resolved streams back
+        if let Some(entry) = providers.get("moduleprefix") {
+            if let ResolveState::Resolved(resolved) = &entry.state {
+                if let Some(first) = grammar_args.module_prefix.first_mut() {
+                    first.1 = resolved.clone();
+                } else {
+                    grammar_args.module_prefix.push((Location::CallSite, resolved.clone()));
+                }
+            }
+        }
+
+        if let Some(entry) = providers.get("userdata") {
+            if let ResolveState::Resolved(resolved) = &entry.state {
+                if let Some(first) = grammar_args.userdata_typename.first_mut() {
+                    first.1 = resolved.clone();
+                } else {
+                    grammar_args.userdata_typename.push((Location::CallSite, resolved.clone()));
+                }
+            }
+        }
+
+        if let Some(entry) = providers.get("errortype") {
+            if let ResolveState::Resolved(resolved) = &entry.state {
+                if let Some(first) = grammar_args.error_typename.first_mut() {
+                    first.1 = resolved.clone();
+                } else {
+                    grammar_args.error_typename.push((Location::CallSite, resolved.clone()));
+                }
+            }
+        }
+
+        if let Some(entry) = providers.get("tokentype") {
+            if let ResolveState::Resolved(resolved) = &entry.state {
+                if let Some(first) = grammar_args.token_typename.first_mut() {
+                    first.1 = resolved.clone();
+                }
+            }
+        }
+
+        if let Some(entry) = providers.get("location") {
+            if let ResolveState::Resolved(resolved) = &entry.state {
+                if let Some(first) = grammar_args.location_typename.first_mut() {
+                    first.1 = resolved.clone();
+                } else {
+                    grammar_args.location_typename.push((Location::CallSite, resolved.clone()));
+                }
+            }
+        }
+
+        for (ident, stream) in &mut grammar_args.terminals {
+            if let Some(entry) = providers.get(&format!("term:{}", ident.value())) {
+                if let ResolveState::Resolved(resolved) = &entry.state {
+                    *stream = resolved.clone();
+                }
+            }
+        }
+
+        for rules_arg in &mut grammar_args.rules {
+            if rules_arg.typename.is_some() {
+                if let Some(entry) = providers.get(&format!("nonterm:{}", rules_arg.name.value())) {
+                    if let ResolveState::Resolved(resolved) = &entry.state {
+                        if !is_placeholder_type(&rules_arg.typename) {
+                            rules_arg.typename = Some(resolved.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        for (_, filter_stream) in &mut grammar_args.filter {
+            *filter_stream = substitute_stream(
+                filter_stream.clone(),
+                &mut providers,
+                &mut grammar_args.span_manager,
+                &mut stack,
+                0,
+                100,
+            )?;
+        }
+
+        for rules_arg in &mut grammar_args.rules {
+            for rule_line in &mut rules_arg.rule_lines {
+                if let Some(action_stream) = &mut rule_line.reduce_action {
+                    *action_stream = substitute_stream(
+                        action_stream.clone(),
+                        &mut providers,
+                        &mut grammar_args.span_manager,
+                        &mut stack,
+                        0,
+                        100,
+                    )?;
+                }
+            }
+        }
+
+        let module_prefix = grammar_args.module_prefix.into_iter().next().unwrap().1;
+        let error_typename = grammar_args.error_typename.into_iter().next().unwrap().1;
+        let location_typename = grammar_args.location_typename.into_iter().next().unwrap().1;
+
         let mut grammar = Grammar {
             module_prefix,
             token_typename: grammar_args.token_typename.into_iter().next().unwrap().1,
-            userdata_typename: grammar_args
-                .userdata_typename
-                .into_iter()
-                .next()
-                .map(|(_, stream)| stream)
-                .unwrap_or(quote! { () }),
+            userdata_typename: grammar_args.userdata_typename.into_iter().next().unwrap().1,
 
             error_typename,
             start_rule_name: grammar_args.start_rule_name.into_iter().next().unwrap(),
@@ -438,9 +909,9 @@ impl Grammar {
             range_resolver: RangeResolver::new(),
 
             emit_dense: grammar_args.dense,
-            filter: grammar_args.filter,
+            filter: grammar_args.filter.into_iter().next().map(|(_, s)| s),
 
-            location_typename: grammar_args.location_typename,
+            location_typename,
             error_precedence: None,
             custom_reduce_actions: Vec::new(),
 
@@ -2602,6 +3073,140 @@ mod tests {
         // Check that the Empty variant is present in the output
         let code_str = code.to_string();
         assert!(code_str.contains("Empty"), "Empty variant should be unconditionally included");
+    }
+
+    #[test]
+    fn test_variable_substitution_success() {
+        let input = quote! {
+            %tokentype MyToken;
+            %location MyLoc;
+            %userdata MyUser;
+            %error MyErr;
+            %moduleprefix ::my_prefix;
+            %token a MyToken::A;
+
+            %start Expr;
+            Expr($tokentype) : a { $tokentype };
+            Term($location) : a { $location };
+            Rule3($userdata) : a { $userdata };
+            Rule4($error) : a { $error };
+            Rule5($moduleprefix) : a { $moduleprefix };
+            Rule6($a) : a { $a };
+            Rule7($Expr) : a { $Expr };
+        };
+
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+
+        let expr_idx = grammar.nonterminals_index.get("Expr").unwrap();
+        assert_eq!(grammar.nonterminals[*expr_idx].ruletype.as_ref().unwrap().to_string(), "MyToken");
+
+        let term_idx = grammar.nonterminals_index.get("Term").unwrap();
+        assert_eq!(grammar.nonterminals[*term_idx].ruletype.as_ref().unwrap().to_string(), "MyLoc");
+
+        let rule3_idx = grammar.nonterminals_index.get("Rule3").unwrap();
+        assert_eq!(grammar.nonterminals[*rule3_idx].ruletype.as_ref().unwrap().to_string(), "MyUser");
+
+        let rule4_idx = grammar.nonterminals_index.get("Rule4").unwrap();
+        assert_eq!(grammar.nonterminals[*rule4_idx].ruletype.as_ref().unwrap().to_string(), "MyErr");
+
+        let rule5_idx = grammar.nonterminals_index.get("Rule5").unwrap();
+        assert_eq!(grammar.nonterminals[*rule5_idx].ruletype.as_ref().unwrap().to_string(), ":: my_prefix");
+
+        let rule6_idx = grammar.nonterminals_index.get("Rule6").unwrap();
+        assert_eq!(grammar.nonterminals[*rule6_idx].ruletype.as_ref().unwrap().to_string(), "MyToken :: A");
+
+        let rule7_idx = grammar.nonterminals_index.get("Rule7").unwrap();
+        assert_eq!(grammar.nonterminals[*rule7_idx].ruletype.as_ref().unwrap().to_string(), "MyToken");
+    }
+
+    #[test]
+    fn test_variable_substitution_circular_dependency() {
+        let input = quote! {
+            %tokentype Token;
+            %token a Token::A;
+            %token b Token::B;
+            %start Expr;
+            Expr($Term) : a;
+            Term($Expr) : b;
+        };
+
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args);
+        assert!(grammar.is_err());
+        let err = grammar.err().unwrap();
+        assert!(matches!(err, ParseError::CircularDependency { .. }));
+        if let ParseError::CircularDependency { path, .. } = err {
+            assert!(path.contains(&"nonterm:Expr".to_string()));
+            assert!(path.contains(&"nonterm:Term".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_variable_substitution_filter() {
+        // 1. Success case
+        let input = quote! {
+            %tokentype Token;
+            %filter my_filter;
+            %token a Token::A;
+            %start Expr;
+            Expr($filter) : a { $filter };
+        };
+
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+
+        let expr_idx = grammar.nonterminals_index.get("Expr").unwrap();
+        assert_eq!(grammar.nonterminals[*expr_idx].ruletype.as_ref().unwrap().to_string(), "my_filter");
+
+        // 2. Filter not defined error
+        let input_err = quote! {
+            %tokentype Token;
+            %token a Token::A;
+            %start Expr;
+            Expr($filter) : a { $filter };
+        };
+
+        let grammar_args_err = Grammar::parse_args(input_err).expect("Failed to parse grammar args");
+        let grammar_err = Grammar::from_grammar_args(grammar_args_err);
+        assert!(grammar_err.is_err());
+        assert!(matches!(grammar_err.err().unwrap(), ParseError::FilterNotDefined(_)));
+
+        // 3. Multiple filter definitions error
+        let input_mult = quote! {
+            %tokentype Token;
+            %filter filter1;
+            %filter filter2;
+            %token a Token::A;
+            %start Expr;
+            Expr : a;
+        };
+
+        let grammar_args_mult = Grammar::parse_args(input_mult).expect("Failed to parse grammar args");
+        let check_res = Grammar::arg_check_error(&grammar_args_mult);
+        assert!(check_res.is_err());
+        assert!(matches!(check_res.err().unwrap(), ArgError::MultipleFilterDefinition(_)));
+    }
+
+    #[test]
+    fn test_variable_substitution_unknown_fallback() {
+        let input = quote! {
+            %tokentype Token;
+            %token a Token::A;
+            %start Expr;
+            Expr : a { $unknown_var };
+        };
+
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+
+        // The reduce action of the rule should preserve $unknown_var unchanged
+        let rule = &grammar.nonterminals[*grammar.nonterminals_index.get("Expr").unwrap()].rules[0];
+        let action = match rule.reduce_action.as_ref().unwrap() {
+            ReduceAction::Custom(custom) => custom.body.to_string(),
+            _ => panic!("Expected Custom reduce action"),
+        };
+        assert!(action.contains("$ unknown_var"));
     }
 }
 

--- a/rusty_lr_parser/src/parser/args.rs
+++ b/rusty_lr_parser/src/parser/args.rs
@@ -666,8 +666,8 @@ pub struct GrammarArgs {
     pub no_optim: bool,
     pub dense: bool,
     pub traces: Vec<Located<String>>,
-    pub filter: Option<TokenStream>,
-    pub location_typename: Option<TokenStream>,
+    pub filter: Vec<(Location, TokenStream)>,
+    pub location_typename: Vec<(Location, TokenStream)>,
 
     pub error_recovered: Vec<RecoveredError>,
     pub span_manager: crate::parser::location::SpanManager,
@@ -689,8 +689,8 @@ impl Default for GrammarArgs {
             no_optim: false,
             dense: false,
             traces: Vec::new(),
-            filter: None,
-            location_typename: None,
+            filter: Vec::new(),
+            location_typename: Vec::new(),
             error_recovered: Vec::new(),
             span_manager: crate::parser::location::SpanManager::default(),
         }

--- a/rusty_lr_parser/src/parser/parser.rs
+++ b/rusty_lr_parser/src/parser/parser.rs
@@ -32,7 +32,7 @@ use rusty_lr_core::rule::ReduceType;
 %location Location;
 
 %tokentype Lexed;
-%token ident Lexed::Ident(_);
+%token ident Lexed::Ident(ident);
 %token colon Lexed::Colon(_);
 %token semicolon Lexed::Semicolon(_);
 %token pipe Lexed::Pipe(_);
@@ -57,8 +57,8 @@ use rusty_lr_core::rule::ReduceType;
 %token other_literal Lexed::OtherLiteral(_);
 
 
-%token parengroup Lexed::ParenGroup(_);
-%token bracegroup Lexed::BraceGroup(_);
+%token parengroup Lexed::ParenGroup(parengroup);
+%token bracegroup Lexed::BraceGroup(bracegroup);
 
 %token lparen Lexed::LParen;
 %token rparen Lexed::RParen;
@@ -87,7 +87,7 @@ use rusty_lr_core::rule::ReduceType;
 %start Grammar;
 
 Rule(RuleDefArgs) : ident RuleType colon RuleLines semicolon {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else { // "$ident" replaced with "$ident" in the macro expansion
         unreachable!( "Rule-Ident" );
     };
     if let Some(fisrt) = RuleLines.first_mut() {
@@ -102,10 +102,10 @@ Rule(RuleDefArgs) : ident RuleType colon RuleLines semicolon {
 ;
 
 RuleType(Option<Group>): parengroup {
-    let Lexed::ParenGroup(group) = parengroup else {
+    let $parengroup = parengroup else {
         unreachable!( "RuleType - Group" );
     };
-    Some(group)
+    Some(parengroup)
 }
 | {
     None
@@ -173,7 +173,7 @@ TokenMapped((Option<Located<String>>, PatternArgs)): Pattern {
     ( None, Pattern )
 }
 | ident equal Pattern {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Token-Ident" );
     };
     ( Some(Located::new(ident.to_string(), @ident)), Pattern )
@@ -181,7 +181,7 @@ TokenMapped((Option<Located<String>>, PatternArgs)): Pattern {
 ;
 
 TerminalSetItem(TerminalSetItem): ident {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "TerminalSetItem-Range1" );
     };
     TerminalSetItem::Terminal( Located::new(ident.to_string(), @ident) )
@@ -276,7 +276,7 @@ TerminalSet(TerminalSet): lbracket caret? TerminalSetItem* rbracket {
 %left star plus question exclamation;
 
 Pattern(PatternArgs): ident {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Pattern-Ident" );
     };
     PatternArgs::Ident( Located::new(ident.to_string(), @ident) )
@@ -341,7 +341,7 @@ Pattern(PatternArgs): ident {
     PatternArgs::Minus { base: Box::new(p1), exclude: Box::new(p2) }
 }
 | dollar ident lparen base=Pattern comma del=Pattern comma? rparen {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Pattern-Sep-Ident" );
     };
     if ident != "sep" {
@@ -359,7 +359,7 @@ Pattern(PatternArgs): ident {
     }
 }
 | dollar ident lparen base=Pattern comma del=Pattern comma plus rparen {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Pattern-Sep-Ident" );
     };
     if ident != "sep" {
@@ -377,7 +377,7 @@ Pattern(PatternArgs): ident {
     }
 }
 | dollar ident lparen base=Pattern comma del=Pattern comma star rparen {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Pattern-Sep-Ident" );
     };
     if ident != "sep" {
@@ -395,7 +395,7 @@ Pattern(PatternArgs): ident {
     }
 }
 | dollar ident lparen base=Pattern comma del=Pattern error rparen {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Pattern-Sep-Ident" );
     };
     if ident != "sep" {
@@ -419,7 +419,7 @@ Pattern(PatternArgs): ident {
     }
 }
 | dollar ident lparen base=Pattern comma del=Pattern comma error rparen {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "Pattern-Sep-Ident" );
     };
     if ident != "sep" {
@@ -453,16 +453,16 @@ Pattern(PatternArgs): ident {
 ;
 
 Action(Option<Group>): bracegroup {
-    let Lexed::BraceGroup(group) = bracegroup else {
+    let $bracegroup = bracegroup else {
         unreachable!( "Action0" );
     };
-    Some(group)
+    Some(bracegroup)
 }
 | { None }
 ;
 
 IdentOrLiteral(IdentOrLiteral): ident {
-    let Lexed::Ident(ident) = ident else {
+    let $ident = ident else {
         unreachable!( "IdentOrLiteral-Ident" );
     };
     IdentOrLiteral::Ident( Located::new(ident.to_string(), @ident) )
@@ -491,7 +491,7 @@ RustCode(TokenStream): t=[^semicolon]+ {
 
 Directive
     : percent token ident RustCode semicolon {
-        let Lexed::Ident(ident) = ident else {
+        let $ident = ident else {
             unreachable!( "TokenDef-Ident" );
         };
         data.terminals.push( (Located::new(ident.to_string(), @ident), RustCode) );
@@ -511,7 +511,7 @@ Directive
         });
     }
     | percent start ident semicolon {
-        let Lexed::Ident(ident) = ident else {
+        let $ident = ident else {
             unreachable!( "StartDef-Ident" );
         };
         data.start_rule_name.push(Located::new(ident.to_string(), @ident));
@@ -635,7 +635,7 @@ Directive
     }
     | percent trace ident* semicolon {
         let idents = ident.into_iter().map(|t| {
-            let Lexed::Ident(ident) = t else {
+            let $ident = t else {
                 unreachable!( "Trace-Ident" );
             };
             Located::new(ident.to_string(), @ident)

--- a/rusty_lr_parser/src/parser/parser.rs
+++ b/rusty_lr_parser/src/parser/parser.rs
@@ -650,7 +650,7 @@ Directive
         });
     }
     | percent filter! RustCode semicolon! {
-        data.filter = Some(RustCode);
+        data.filter.push((@filter, RustCode));
     }
     | percent filter! semicolon! {
         data.error_recovered.push( RecoveredError {
@@ -660,7 +660,7 @@ Directive
         });
     }
     | percent location! RustCode semicolon! {
-        data.location_typename = Some(RustCode);
+        data.location_typename.push((@location, RustCode));
     }
     | percent location! semicolon! {
         data.error_recovered.push( RecoveredError {

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -4533,7 +4533,7 @@ impl GrammarDataStack {
             GrammarData::__variant17(val) => val,
             _ => unreachable!(),
         };
-        __location_stack.pop().unwrap();
+        let mut __rustylr_location_filter = __location_stack.pop().unwrap();
         let mut filter = match __data_stack.__stack.pop().unwrap() {
             GrammarData::__terminals(val) => val,
             _ => unreachable!(),
@@ -4547,7 +4547,7 @@ impl GrammarDataStack {
         )?;
         let mut RustCode = __rustylr_data_2;
         {
-            data.filter = Some(RustCode);
+            data.filter.push((__rustylr_location_filter, RustCode));
         };
         __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
@@ -4633,7 +4633,7 @@ impl GrammarDataStack {
             GrammarData::__variant17(val) => val,
             _ => unreachable!(),
         };
-        __location_stack.pop().unwrap();
+        let mut __rustylr_location_location = __location_stack.pop().unwrap();
         __data_stack.__stack.pop().unwrap();
         __location_stack.pop().unwrap();
         __data_stack.__stack.pop().unwrap();
@@ -4644,7 +4644,7 @@ impl GrammarDataStack {
         )?;
         let mut RustCode = __rustylr_data_2;
         {
-            data.location_typename = Some(RustCode);
+            data.location_typename.push((__rustylr_location_location, RustCode));
         };
         __data_stack.__stack.push(GrammarData::Empty);
         Ok(())

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -359,9 +359,9 @@ impl ::rusty_lr_core::parser::terminalclass::TerminalClass for GrammarTerminalCl
         }
     }
     fn from_term(terminal: &Self::Term) -> Self {
-        #[allow(unreachable_patterns)]
+        #[allow(unreachable_patterns, unused_variables)]
         match terminal {
-            Lexed::Ident(_) => GrammarTerminalClasses::ident,
+            Lexed::Ident(ident) => GrammarTerminalClasses::ident,
             Lexed::Colon(_) => GrammarTerminalClasses::colon,
             Lexed::Pipe(_) => GrammarTerminalClasses::pipe,
             Lexed::Percent(_) => GrammarTerminalClasses::percent,
@@ -375,8 +375,8 @@ impl ::rusty_lr_core::parser::terminalclass::TerminalClass for GrammarTerminalCl
             Lexed::ByteStrLiteral(_) => GrammarTerminalClasses::byte_str_literal,
             Lexed::CharLiteral(_) => GrammarTerminalClasses::char_literal,
             Lexed::StrLiteral(_) => GrammarTerminalClasses::str_literal,
-            Lexed::ParenGroup(_) => GrammarTerminalClasses::parengroup,
-            Lexed::BraceGroup(_) => GrammarTerminalClasses::bracegroup,
+            Lexed::ParenGroup(parengroup) => GrammarTerminalClasses::parengroup,
+            Lexed::BraceGroup(bracegroup) => GrammarTerminalClasses::bracegroup,
             Lexed::LParen => GrammarTerminalClasses::lparen,
             Lexed::RParen => GrammarTerminalClasses::rparen,
             Lexed::LBracket => GrammarTerminalClasses::lbracket,
@@ -786,10 +786,10 @@ impl GrammarDataStack {
             _ => unreachable!(),
         };
         let __res = {
-            let Lexed::ParenGroup(group) = parengroup else {
+            let Lexed::ParenGroup(parengroup) = parengroup else {
                 unreachable!("RuleType - Group");
             };
-            Some(group)
+            Some(parengroup)
         };
         if __push_data {
             __data_stack.__stack.push(GrammarData::__variant2(__res));
@@ -2929,10 +2929,10 @@ impl GrammarDataStack {
             _ => unreachable!(),
         };
         let __res = {
-            let Lexed::BraceGroup(group) = bracegroup else {
+            let Lexed::BraceGroup(bracegroup) = bracegroup else {
                 unreachable!("Action0");
             };
-            Some(group)
+            Some(bracegroup)
         };
         if __push_data {
             __data_stack.__stack.push(GrammarData::__variant2(__res));

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -106,7 +106,7 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for ETerminalClasses {
         }
     }
     fn from_term(terminal: &Self::Term) -> Self {
-        #[allow(unreachable_patterns)]
+        #[allow(unreachable_patterns, unused_variables)]
         match filter(terminal) {
             Token::Num(_) => ETerminalClasses::num,
             Token::Plus => ETerminalClasses::plus,

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -110,7 +110,7 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for ETerminalClasses {
         }
     }
     fn from_term(terminal: &Self::Term) -> Self {
-        #[allow(unreachable_patterns)]
+        #[allow(unreachable_patterns, unused_variables)]
         match terminal {
             ' ' => ETerminalClasses::TermClass0,
             '(' => ETerminalClasses::TermClass2,

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -237,7 +237,7 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for JsonTerminalClasses {
         }
     }
     fn from_term(terminal: &Self::Term) -> Self {
-        #[allow(unreachable_patterns)]
+        #[allow(unreachable_patterns, unused_variables)]
         match terminal {
             '\t'..='\n' | '\r' => JsonTerminalClasses::TermClass0,
             ' ' => JsonTerminalClasses::TermClass1,


### PR DESCRIPTION
# Description
This Pull Request introduces `$filter` variable substitution within `RustCode` blocks, simplifies the non-terminal substitution syntax to `$NonTerminalName` (replacing the bracketed `$<NonTerminal>` syntax), implements fallback preservation for unknown variables, and enhances compile-time diagnostics inside `rusty_lr_buildscript`.
## Changes
### 1. Simplified Variable Substitution & Fallback Behavior
- **Non-Terminal Syntax Sugar**: Changed the non-terminal variable syntax to `$NonTerminalName` instead of `$<NonTerminal>`. Updated `substitute_stream` in `grammar.rs` to support lookup directly.
- **Fallback for Unknown Variables**: If a `$` is followed by an unknown identifier, it is preserved in the token stream unchanged (along with a `// TODO: 이거 워닝으로 내면 좋을듯` comment) instead of producing an error.
- **`$filter` Substitution**: Resolved `$filter` to evaluate to the user-defined filter function if `%filter` is specified.
### 2. Diagnostics inside `rusty_lr_buildscript`
- Added structural compile-time diagnostics for the following errors:
  - `ArgError::MultipleLocationDefinition(locs)`
  - `ArgError::MultipleFilterDefinition(locs)`
  - `ParseError::CircularDependency { location, path }`
  - `ParseError::MaxSubstitutionDepthExceeded { location, max_depth }`
  - `ParseError::FilterNotDefined(loc)`
- For substitution errors (`CircularDependency`, `MaxSubstitutionDepthExceeded`, and `FilterNotDefined`), added warning notes containing links pointing directly to the `#substitution-errors` section in `SYNTAX.md` on GitHub.
### 3. Error Definition Cleanup & Documentation
- Removed the dead `LocationTypeNotDefined` and `TokenTypeNotDefined` parse errors since their validations occur earlier inside argument checks.
- Updated `SYNTAX.md` to document the new `$filter` variable, the simplified `$NonTerminalName` syntax, and the three variable substitution error types (`CircularDependency`, `MaxSubstitutionDepthExceeded`, and `FilterNotDefined`).
