### PR TITLE
Support `box` Keyword in `%tokentype` and NonTerminal `RuleType`s

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -211,12 +211,24 @@ Expr(_): Term;
 > [!WARNING]
 > If a circular dependency exists (e.g., two rules trying to infer their types from one another without a base type), RustyLR will fail with a compilation error.
 
-### Memory Optimization with `Box`
+### Memory Optimization with `Box` / `box` keyword
 Internally, the generated parser stores all semantic values (the `%tokentype` and all non-terminals' `RuleType`s) in a single unified `enum` representing the parser's data stack.
 
 Because the memory footprint of a Rust `enum` is dictated by its largest variant, if even one `RuleType` is exceptionally large (e.g., a large AST struct), the size of *every* stack slot will inflate. This can result in significant memory waste and performance degradation.
 
-To avoid this, wrap large AST nodes or structures in a `Box` (e.g., `Box<MyLargeNode>`). This ensures the enum variant only takes up the size of a single pointer, optimizing stack memory usage.
+To avoid this, you can write the `box` keyword in front of `%tokentype` or any non-terminal's `RuleType` (inside the parentheses, e.g. `(box Type)`). The parser generator will automatically box that type in the data enum (generating `Box<Type>`), and will automatically wrap (`Box::new(...)`) or unwrap (`*val`) it in reduce actions so that you do not have to write `Box::new` or dereference it yourself:
+
+```rust
+%tokentype box MyToken;
+
+Expr (box MyLargeASTNode)
+    : left=Expr '+' right=Term {
+        // `left` and `right` are automatically unboxed (of type `MyLargeASTNode`),
+        // and the returned value is automatically wrapped in a `Box::new`.
+        MyLargeASTNode::Binary(left, right)
+    }
+    ;
+```
 
 ---
 

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -905,12 +905,16 @@ impl Grammar {
         // variant name for each non-terminal
         let mut variant_names_for_nonterm = Vec::with_capacity(self.nonterminals.len());
 
+        fn remove_whitespaces(s: String) -> String {
+            s.chars().filter(|c| !c.is_whitespace()).collect()
+        }
+
         // Map containing (<RuleType as ToString>, variant_name).
         // This maps each rule type to its enum variant name (e.g. __variant0, __variant1), merging identical types.
         let mut ruletype_variant_map: rusty_lr_core::hash::HashMap<String, Ident> =
             Default::default();
 
-        // (variant_name, TokenStream for typename) sorted in insertion order
+        // (variant_name, TokenStream for typename, is_boxed) sorted in insertion order
         // for consistent output
         let mut variant_names_in_order = Vec::new();
 
@@ -919,28 +923,27 @@ impl Grammar {
         // insert variant for terminal token type
         if self.terminal_classes.iter().any(|c| c.data_used) {
             terminal_data_used = true;
+            let terminal_boxed = self.is_tokentype_boxed;
+            let key = format!("{}_boxed:{}", remove_whitespaces(self.token_typename.to_string()), terminal_boxed);
             ruletype_variant_map.insert(
-                self.token_typename.to_string(),
+                key,
                 terminal_variant_name.clone(),
             );
             variant_names_in_order
-                .push((terminal_variant_name.clone(), self.token_typename.clone()));
-        }
-
-        fn remove_whitespaces(s: String) -> String {
-            s.chars().filter(|c| !c.is_whitespace()).collect()
+                .push((terminal_variant_name.clone(), self.token_typename.clone(), terminal_boxed));
         }
 
         // iterates through nonterminals
         for nonterm in self.nonterminals.iter() {
             if let Some(ruletype_stream) = nonterm.ruletype.as_ref().cloned() {
                 let cur_len = ruletype_variant_map.len();
+                let key = format!("{}_boxed:{}", remove_whitespaces(ruletype_stream.to_string()), nonterm.ruletype_boxed);
                 let variant_name = ruletype_variant_map
-                    .entry(remove_whitespaces(ruletype_stream.to_string()))
+                    .entry(key)
                     .or_insert_with(|| {
                         let new_variant_name = format_ident!("__variant{}", cur_len);
                         variant_names_in_order
-                            .push((new_variant_name.clone(), ruletype_stream.clone()));
+                            .push((new_variant_name.clone(), ruletype_stream.clone(), nonterm.ruletype_boxed));
                         new_variant_name
                     })
                     .clone();
@@ -1163,9 +1166,18 @@ impl Grammar {
 
                         if variant_name != &empty_variant_name && mapto.is_some() {
                             let data_mapto = mapto.unwrap();
+                            let is_boxed = match token.token {
+                                Token::Term(_) => self.is_tokentype_boxed,
+                                Token::NonTerm(nonterm_idx) => self.nonterminals[nonterm_idx].ruletype_boxed,
+                            };
+                            let val_extracted = if is_boxed {
+                                quote! { *val }
+                            } else {
+                                quote! { val }
+                            };
                             extract_data_stream.extend(quote! {
                                 let mut #data_mapto = match __data_stack.__stack.pop().unwrap() {
-                                    #data_enum_typename::#variant_name(val) => val,
+                                    #data_enum_typename::#variant_name(val) => #val_extracted,
                                     _ => unreachable!(),
                                 };
                             });
@@ -1317,6 +1329,11 @@ impl Grammar {
                         } else {
                             quote! { #reduce_action_body }
                         };
+                        let push_val = if nonterm.ruletype_boxed {
+                            quote! { ::std::boxed::Box::new(__res) }
+                        } else {
+                            quote! { __res }
+                        };
                         fn_reduce_for_each_rule_stream.extend(quote! {
                             #[doc = #rule_debug_str]
                             #[inline]
@@ -1340,7 +1357,7 @@ impl Grammar {
 
                                 let __res = #res_expr;
                                 if __push_data {
-                                    __data_stack.__stack.push(#data_enum_typename::#variant_name(__res));
+                                    __data_stack.__stack.push(#data_enum_typename::#variant_name(#push_val));
                                 } else {
                                     __data_stack.__stack.push(#data_enum_typename::Empty);
                                 }
@@ -1402,12 +1419,19 @@ impl Grammar {
                 .unwrap()
                 .clone();
 
+            let is_start_boxed = self.nonterminals[start_idx].ruletype_boxed;
+            let val_expr = if is_start_boxed {
+                quote! { *val }
+            } else {
+                quote! { val }
+            };
+
             (
                 ruletype,
                 quote! {
                     self.__stack.pop();
                     match self.__stack.pop() {
-                        Some(#data_enum_typename::#start_variant_name(val)) => Some(val),
+                        Some(#data_enum_typename::#start_variant_name(val)) => Some(#val_expr),
                         _ => None,
                     }
                 },
@@ -1432,8 +1456,13 @@ impl Grammar {
         };
 
         let push_terminal_body_stream = if terminal_data_used {
+            let push_val = if self.is_tokentype_boxed {
+                quote! { ::std::boxed::Box::new(term) }
+            } else {
+                quote! { term }
+            };
             quote! {
-                self.__stack.push(#data_enum_typename::#terminal_variant_name(term));
+                self.__stack.push(#data_enum_typename::#terminal_variant_name(#push_val));
             }
         } else {
             quote! {
@@ -1446,10 +1475,16 @@ impl Grammar {
 
         let data_enum_definition = {
             let mut variants = TokenStream::new();
-            for (variant_name, typename) in &variant_names_in_order {
-                variants.extend(quote! {
-                    #variant_name(#typename),
-                });
+            for (variant_name, typename, boxed) in &variant_names_in_order {
+                if *boxed {
+                    variants.extend(quote! {
+                        #variant_name(::std::boxed::Box<#typename>),
+                    });
+                } else {
+                    variants.extend(quote! {
+                        #variant_name(#typename),
+                    });
+                }
             }
             variants.extend(quote! {
                 Empty,

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -74,6 +74,7 @@ pub struct Grammar {
 
     /// %tokentype
     pub(crate) token_typename: TokenStream,
+    pub(crate) is_tokentype_boxed: bool,
 
     /// %userdata
     pub(crate) userdata_typename: TokenStream,
@@ -882,9 +883,16 @@ impl Grammar {
         let error_typename = grammar_args.error_typename.into_iter().next().unwrap().1;
         let location_typename = grammar_args.location_typename.into_iter().next().unwrap().1;
 
+        let (is_tokentype_boxed, token_typename) = {
+            let stream = grammar_args.token_typename.into_iter().next().unwrap().1;
+            let (boxed, stripped) = check_and_strip_box(stream);
+            (boxed, stripped)
+        };
+
         let mut grammar = Grammar {
             module_prefix,
-            token_typename: grammar_args.token_typename.into_iter().next().unwrap().1,
+            token_typename,
+            is_tokentype_boxed,
             userdata_typename: grammar_args.userdata_typename.into_iter().next().unwrap().1,
 
             error_typename,
@@ -1019,16 +1027,28 @@ impl Grammar {
 
         // insert rule typenames first, since it will be used when inserting rule definitions below
         for (rule_idx, rules_arg) in grammar_args.rules.iter().enumerate() {
-            let ruletype = if is_placeholder_type(&rules_arg.typename) {
+            let is_boxed = if let Some(rt) = &rules_arg.typename {
+                let (boxed, _) = check_and_strip_box(rt.clone());
+                boxed
+            } else {
+                false
+            };
+
+            let ruletype = if rules_arg.typename.is_none() {
+                None
+            } else if is_placeholder_type(&rules_arg.typename) {
                 let placeholder_name = format_ident!("__rustylr_placeholder_{}", rules_arg.name.value());
                 Some(quote! { #placeholder_name })
             } else {
-                rules_arg.typename.clone()
+                let (_, stripped) = check_and_strip_box(rules_arg.typename.clone().unwrap());
+                Some(stripped)
             };
+
             let nonterminal = NonTerminalInfo {
                 name: rules_arg.name.clone(),
                 pretty_name: rules_arg.name.value().clone(),
                 ruletype,
+                ruletype_boxed: is_boxed,
                 rules: Vec::new(), // production rules will be added later
                 root_location: None,
                 trace: false,
@@ -1734,6 +1754,7 @@ impl Grammar {
                 name: augmented_name.clone(),
                 pretty_name: utils::AUGMENTED_NAME.to_string(),
                 ruletype: None,
+                ruletype_boxed: false,
                 root_location: None,
                 rules: vec![augmented_rule],
                 trace: false,
@@ -2736,9 +2757,23 @@ impl Grammar {
     }
 }
 
+/// Checks if the first token in the token stream is the identifier `box`.
+/// If it is, returns `(true, stripped_stream)`. Otherwise, returns `(false, original_stream)`.
+pub(crate) fn check_and_strip_box(stream: TokenStream) -> (bool, TokenStream) {
+    let mut iter = stream.clone().into_iter();
+    if let Some(proc_macro2::TokenTree::Ident(ident)) = iter.next() {
+        if ident.to_string() == "box" {
+            let rest: TokenStream = iter.collect();
+            return (true, rest);
+        }
+    }
+    (false, stream)
+}
+
 fn is_placeholder_type(ruletype: &Option<TokenStream>) -> bool {
     if let Some(ts) = ruletype {
-        let mut it = ts.clone().into_iter();
+        let (_, stripped) = check_and_strip_box(ts.clone());
+        let mut it = stripped.into_iter();
         if let Some(proc_macro2::TokenTree::Ident(ident)) = it.next() {
             if ident.to_string() == "_" && it.next().is_none() {
                 return true;
@@ -3216,6 +3251,37 @@ mod tests {
             _ => panic!("Expected Custom reduce action"),
         };
         assert!(action.contains("$ unknown_var"));
+    }
+
+    #[test]
+    fn test_box_keyword_parsing() {
+        let input = quote! {
+            %tokentype box MyToken;
+            %token a MyToken::A;
+            %start Expr;
+            Expr(box MyType) : a { MyType };
+        };
+
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
+        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
+
+        assert!(grammar.is_tokentype_boxed);
+        assert_eq!(grammar.token_typename.to_string(), "MyToken");
+
+        let expr_idx = grammar.nonterminals_index.get("Expr").unwrap();
+        assert!(grammar.nonterminals[*expr_idx].ruletype_boxed);
+        assert_eq!(grammar.nonterminals[*expr_idx].ruletype.as_ref().unwrap().to_string(), "MyType");
+
+        let code = grammar.emit_compiletime();
+        let code_str = code.to_string();
+
+        // Ensure the data enum wraps in Box
+        assert!(code_str.contains("Box < MyType >") || code_str.contains("Box<MyType>") || code_str.contains("Box"), "Data enum variant should hold Boxed MyType");
+        assert!(code_str.contains("Box < MyToken >") || code_str.contains("Box<MyToken>") || code_str.contains("Box"), "Data enum variant should hold Boxed MyToken");
+        
+        // Ensure auto-wrap Box::new and auto-unwrap *val are emitted
+        assert!(code_str.contains("Box :: new") || code_str.contains("Box::new"), "Box::new should be generated to wrap reduce result");
+        assert!(code_str.contains("* val") || code_str.contains("*val"), "Dereference should be generated to extract boxed value");
     }
 }
 

--- a/rusty_lr_parser/src/nonterminal_info.rs
+++ b/rusty_lr_parser/src/nonterminal_info.rs
@@ -106,6 +106,9 @@ pub struct NonTerminalInfo {
     /// The rule type of this non-terminal
     pub ruletype: Option<TokenStream>,
 
+    /// Whether the rule type of this non-terminal should be boxed in the Data enum
+    pub ruletype_boxed: bool,
+
     /// Every set of production rules
     pub rules: Vec<Rule>,
 

--- a/rusty_lr_parser/src/parser/parser.rs
+++ b/rusty_lr_parser/src/parser/parser.rs
@@ -86,7 +86,7 @@ use rusty_lr_core::rule::ReduceType;
 
 %start Grammar;
 
-Rule(RuleDefArgs) : ident RuleType colon RuleLines semicolon {
+Rule(box RuleDefArgs) : ident RuleType colon RuleLines semicolon {
     let $ident = ident else { // "$ident" replaced with "$ident" in the macro expansion
         unreachable!( "Rule-Ident" );
     };
@@ -122,7 +122,7 @@ RuleLines(Vec<RuleLineArgs>): RuleLines pipe RuleLine {
 }
 ;
 
-RuleLine(RuleLineArgs): TokenMapped* PrecDef* Action
+RuleLine(box RuleLineArgs): TokenMapped* PrecDef* Action
 {
     RuleLineArgs {
         tokens: TokenMapped,
@@ -133,7 +133,7 @@ RuleLine(RuleLineArgs): TokenMapped* PrecDef* Action
 }
 ;
 
-PrecDef(PrecDPrecArgs)
+PrecDef(box PrecDPrecArgs)
     : percent! prec! IdentOrLiteral {
         PrecDPrecArgs::Prec(IdentOrLiteral)
     }
@@ -169,7 +169,7 @@ PrecDef(PrecDPrecArgs)
     }
     ;
 
-TokenMapped((Option<Located<String>>, PatternArgs)): Pattern {
+TokenMapped(box (Option<Located<String>>, PatternArgs)): Pattern {
     ( None, Pattern )
 }
 | ident equal Pattern {

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -635,12 +635,12 @@ impl ::rusty_lr_core::parser::nonterminal::NonTerminal for GrammarNonTerminals {
 #[allow(unused_braces, unused_parens, non_snake_case, non_camel_case_types)]
 pub enum GrammarData {
     __terminals(Lexed),
-    __variant1(RuleDefArgs),
+    __variant1(::std::boxed::Box<RuleDefArgs>),
     __variant2(Option<Group>),
     __variant3(Vec<RuleLineArgs>),
-    __variant4(RuleLineArgs),
-    __variant5(PrecDPrecArgs),
-    __variant6((Option<Located<String>>, PatternArgs)),
+    __variant4(::std::boxed::Box<RuleLineArgs>),
+    __variant5(::std::boxed::Box<PrecDPrecArgs>),
+    __variant6(::std::boxed::Box<(Option<Located<String>>, PatternArgs)>),
     __variant7(TerminalSetItem),
     __variant8(TerminalSet),
     __variant9(PatternArgs),
@@ -756,7 +756,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant1(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant1(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -846,7 +848,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut RuleLine = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant4(val) => val,
+            GrammarData::__variant4(val) => *val,
             _ => unreachable!(),
         };
         let mut __rustylr_location_pipe = __location_stack.pop().unwrap();
@@ -888,7 +890,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut RuleLine = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant4(val) => val,
+            GrammarData::__variant4(val) => *val,
             _ => unreachable!(),
         };
         let __res = { vec![RuleLine] };
@@ -949,7 +951,9 @@ impl GrammarDataStack {
             }
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant4(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant4(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -992,7 +996,9 @@ impl GrammarDataStack {
         __data_stack.__stack.pop().unwrap();
         let __res = { PrecDPrecArgs::Prec(IdentOrLiteral) };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant5(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant5(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -1041,7 +1047,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::None
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant5(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant5(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -1089,7 +1097,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::DPrec(Located::new(i, __rustylr_location_int_literal))
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant5(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant5(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -1138,7 +1148,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::None
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant5(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant5(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -1181,7 +1193,9 @@ impl GrammarDataStack {
             PrecDPrecArgs::None
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant5(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant5(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -1212,7 +1226,9 @@ impl GrammarDataStack {
         };
         let __res = { (None, Pattern) };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant6(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant6(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -1263,7 +1279,9 @@ impl GrammarDataStack {
             (Some(Located::new(ident.to_string(), __rustylr_location_ident)), Pattern)
         };
         if __push_data {
-            __data_stack.__stack.push(GrammarData::__variant6(__res));
+            __data_stack
+                .__stack
+                .push(GrammarData::__variant6(::std::boxed::Box::new(__res)));
         } else {
             __data_stack.__stack.push(GrammarData::Empty);
         }
@@ -4760,7 +4778,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut Rule = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant1(val) => val,
+            GrammarData::__variant1(val) => *val,
             _ => unreachable!(),
         };
         {
@@ -4789,7 +4807,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut A = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant6(val) => val,
+            GrammarData::__variant6(val) => *val,
             _ => unreachable!(),
         };
         let __res = { vec![A] };
@@ -4824,7 +4842,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut A = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant6(val) => val,
+            GrammarData::__variant6(val) => *val,
             _ => unreachable!(),
         };
         __location_stack.pop().unwrap();
@@ -4914,7 +4932,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut A = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant5(val) => val,
+            GrammarData::__variant5(val) => *val,
             _ => unreachable!(),
         };
         let __res = { vec![A] };
@@ -4949,7 +4967,7 @@ impl GrammarDataStack {
         }
         __location_stack.pop().unwrap();
         let mut A = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant5(val) => val,
+            GrammarData::__variant5(val) => *val,
             _ => unreachable!(),
         };
         __location_stack.pop().unwrap();

--- a/rusty_lr_parser/src/pattern.rs
+++ b/rusty_lr_parser/src/pattern.rs
@@ -192,7 +192,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: Some(quote! { Vec<#base_typename> }),
@@ -254,7 +254,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: None,
@@ -322,7 +322,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: Some(quote! { Vec<#base_typename> }),
@@ -370,7 +370,7 @@ impl Pattern {
                         dprec: None,
                         is_used: true,
                     };
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: None,
@@ -431,7 +431,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: Some(quote! {Option<#base_typename>}),
@@ -480,7 +480,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: None,
@@ -547,7 +547,7 @@ impl Pattern {
                     };
                     rules.push(rule);
                 }
-                let nonterm_info = NonTerminalInfo {
+                let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                     name: newrule_name.clone(),
                     pretty_name: self.pretty_name.clone(),
                     ruletype: Some(grammar.token_typename.clone()),
@@ -599,7 +599,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: Some(base_typename.clone()),
@@ -636,7 +636,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: None,
@@ -770,7 +770,7 @@ impl Pattern {
                 }
                 let newrule_idx = grammar.nonterminals.len();
                 let newrule_name = Located::new(format!("_Group{}", newrule_idx), root_location);
-                let nonterm_info = NonTerminalInfo {
+                let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                     name: newrule_name.clone(),
                     pretty_name: self.pretty_name.clone(),
                     ruletype: ruletype.clone(),
@@ -833,7 +833,7 @@ impl Pattern {
                 };
 
                 let newrule_name = Located::new(newrule_name_str, str_loc);
-                let nonterm_info = NonTerminalInfo {
+                let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                     name: newrule_name.clone(),
                     pretty_name: syn::LitByteStr::new(s.value(), proc_macro2::Span::call_site())
                         .to_token_stream()
@@ -896,7 +896,7 @@ impl Pattern {
                 };
 
                 let newrule_name = Located::new(newrule_name_str, str_loc);
-                let nonterm_info = NonTerminalInfo {
+                let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                     name: newrule_name.clone(),
                     pretty_name: s.to_token_stream().to_string(),
                     ruletype: None,
@@ -985,7 +985,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: Some(quote! { Vec<#base_typename> }),
@@ -1050,7 +1050,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: None,
@@ -1119,7 +1119,7 @@ impl Pattern {
                         is_used: true,
                     };
 
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: Some(quote! { Vec<#base_typename> }),
@@ -1167,7 +1167,7 @@ impl Pattern {
                         dprec: None,
                         is_used: true,
                     };
-                    let nonterm_info = NonTerminalInfo {
+                    let nonterm_info = NonTerminalInfo { ruletype_boxed: false,
                         name: newrule_name.clone(),
                         pretty_name: self.pretty_name.clone(),
                         ruletype: None,


### PR DESCRIPTION
## Description
This PR introduces support for the `box` keyword in front of `%tokentype` and NonTerminal `RuleType` definitions (e.g., `%tokentype box MyToken;` or `Expr(box MyLargeASTNode)`). 
### Motivation
In RustyLR, all semantic values are stored in a single unified `Data` enum representing the parser's stack. Because a Rust `enum`'s size is dictated by its largest variant, any large type inflated the footprint of all stack slots, leading to performance and memory overhead. Wrapping those types in `Box` manually solved this but was tedious to write since it required manually wrapping/unwrapping `Box` inside reduce actions.
This change automates the process:
- Marking `%tokentype` or a rule's return type with `box` generates `::std::boxed::Box<Type>` internally in the `Data` stack enum.
- Popped values are automatically dereferenced (`*val`), exposing the raw unboxed types to reduce actions.
- Reduced action results are automatically wrapped in `::std::boxed::Box::new(...)` when pushed back onto the stack.
- The parser's final return value (`pop_start`) is also automatically unboxed.
This achieves minimal data stack enum layout size with zero manual boilerplate code.
---
## Changes
### `rusty_lr_parser`
- **`nonterminal_info.rs`**: Added the `ruletype_boxed` flag to `NonTerminalInfo`.
- **`grammar.rs`**:
  - Added `is_tokentype_boxed` to `Grammar`.
  - Implemented `check_and_strip_box` helper to detect and strip the `box` keyword from types.
  - Modified `Grammar::from_grammar_args` and `is_placeholder_type` to parse and strip the `box` prefix.
  - Added `test_box_keyword_parsing` to verify metadata parsing and code emission assertions.
- **`pattern.rs`**: Updated `NonTerminalInfo` helper rules to default `ruletype_boxed` to `false`.
- **`emit.rs`**:
  - Wrapped boxed types in `::std::boxed::Box<Type>` within the generated `Data` enum.
  - Generated automatic dereferences (`*val`) when popping boxed data stack values.
  - Generated automatic wrapping (`::std::boxed::Box::new(...)`) when pushing boxed rule outputs.
  - Handled terminal token box wrapping on push and start symbol unboxing on pop.
### Documentation
- **`SYNTAX.md`**: Updated the **Memory Optimization with Box** section to document the new `box` keyword syntax and provide usage examples.
