### PR TITLE
remove unused `%filter` directives and update token matching documentation

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -8,7 +8,6 @@ This document provides a comprehensive guide to the grammar definition syntax us
 
 - [Token Type (`%tokentype`)](#token-type-must-defined)
 - [Token Definition (`%token`)](#token-definition-must-defined)
-- [Filter Directive (`%filter`)](#filter-directive)
 - [Production Rules](#production-rules)
 - [Patterns](#patterns)
 - [RuleType (Non-Terminal Types)](#ruletype-optional)
@@ -69,23 +68,34 @@ pub enum Token {
 %token name <MatchPattern> ;
 ```
 
-Binds a grammar terminal symbol (`name`) to a pattern (`<MatchPattern>`) used to classify tokens. Under the hood, RustyLR generates a `match` statement to identify the token:
+Binds a grammar terminal symbol (`name`) to a pattern (`<MatchPattern>`) used to classify input tokens. 
+
+### How it works under the hood
+Under the hood, RustyLR generates a standard Rust `match` statement where each `<MatchPattern>` is used directly as a match arm pattern to identify the token:
 
 ```rust
 match terminal_token {
-    <MatchPattern> => { /* Classified as `name` */ },
+    // The <MatchPattern> you wrote is placed here verbatim:
+    <MatchPattern> => { /* Classified as terminal `name` */ },
     ...
 }
 ```
 
-### Example
+Because of this direct translation, **any pattern that is valid in a Rust `match` arm is valid as a `<MatchPattern>`**. This gives you full control and flexibility without requiring separate adapter functions or external filter layers.
+
+---
+
+### Simple Example: Enum Tokens
+If your token type is a simple flat enum:
+
 ```rust
 %tokentype Token;
 
-%token id Token::Ident(_);   // Matches Token::Ident("foo")
-%token num Token::Num(_);     // Matches Token::Num(42)
-%token plus Token::Plus;       // Matches Token::Plus
-%token minus Token::Minus;     // Matches Token::Minus
+// Simple patterns matching enum variants
+%token id    Token::Ident(_); // Matches Token::Ident("foo")
+%token num   Token::Num(_);   // Matches Token::Num(42)
+%token plus  Token::Plus;     // Matches Token::Plus
+%token minus Token::Minus;    // Matches Token::Minus
 
 Expr
     : id plus num
@@ -93,44 +103,52 @@ Expr
     ;
 ```
 
+---
+
+### Complex Example: Struct/Wrapped Tokens (Structural Pattern Matching)
+If you wrap your tokens inside a metadata struct (for example, to carry location spans, comments, or line numbers), you can perform **structural pattern matching** (destructuring) directly inside the `%token` definitions. 
+
+Simply write the pattern that matches the struct's fields exactly as you would in a Rust `match` arm:
+
+1. **Define the Types in Rust:**
+   ```rust
+   pub struct WrappedToken {
+       pub value: Token,
+       pub span: Span,
+   }
+
+   pub enum Token {
+       Num(i32),
+       Plus,
+   }
+   ```
+
+2. **Define the `%token` patterns in the grammar:**
+   ```rust
+   %tokentype WrappedToken;
+
+   // Think of how you would write the match arm pattern for WrappedToken.
+   // You want to destructure the 'value' field and ignore the rest using `..`.
+   %token num  WrappedToken { value: Token::Num(_), .. };
+   %token plus WrappedToken { value: Token::Plus, .. };
+   ```
+
+Under the hood, this translates directly to:
+```rust
+match terminal_token {
+    WrappedToken { value: Token::Num(_), .. } => TerminalClasses::num,
+    WrappedToken { value: Token::Plus, .. } => TerminalClasses::plus,
+    _ => ...
+}
+```
+
+Using this approach:
+- The entire `WrappedToken` is pushed onto the parser stack, so it is fully accessible inside your `ReduceAction` blocks (allowing you to read `span` or other metadata).
+- Complex matching is achieved purely through native Rust pattern matching, avoiding any runtime overhead or intermediate conversion boilerplate.
+
 ### Notes
 - **Literal Tokens:** If `%tokentype` is set to `char` or `u8`, you do not need to define tokens using `%token`. Instead, use character literals (`'+'`, `'a'`) or byte literals (`b'+'`, `b'a'`) directly in the grammar.
 - **Incomplete Token Space:** You do not need to exhaustively define every single possible enum variant. Any tokens not explicitly matched can still be captured using negation sets (e.g., `[^ plus minus]`).
-
----
-
-## %filter Directive
-
-```
-%filter <Path> ;
-```
-
-When your `%tokentype` cannot be matched directly in a simple Rust `match` pattern (e.g., if it contains generic parameters, references, or requires complex validation), you can define a custom filter function.
-
-When specified, the generated classification `match` will wrap the input terminal in the filter function:
-
-```rust
-match filter_fn(terminal_token) {
-    <MatchPattern> => { /* ... */ }
-    ...
-}
-```
-
-The filter function signature must be: `fn(&Terminal) -> MatchType` or `fn(Terminal) -> MatchType` depending on your wrapper design.
-
-### Example
-```rust
-fn my_filter(token: &Token) -> TokenKind {
-    match token {
-        Token::Ident(_) => TokenKind::Ident,
-        Token::Num(_) => TokenKind::Num,
-        Token::Plus => TokenKind::Plus,
-    }
-}
-
-// In the grammar:
-%filter my_filter;
-```
 
 ---
 
@@ -563,7 +581,6 @@ You can use variables prefixed with `$` inside any RustCode block in the grammar
 - `%userdata`
 - `%errortype` (or `%error`)
 - `%moduleprefix`
-- `%filter`
 - `%token` terminal definitions
 - Non-terminal rule types
 - Reduce actions
@@ -574,14 +591,12 @@ You can use variables prefixed with `$` inside any RustCode block in the grammar
 - `$userdata` -> Evaluates to the type defined by `%userdata` (defaults to `()`).
 - `$error` or `$errortype` -> Evaluates to the type defined by `%errortype` / `%error` (defaults to `$moduleprefix::DefaultReduceActionError`).
 - `$moduleprefix` -> Evaluates to the path defined by `%moduleprefix` (defaults to `::rusty_lr`).
-- `$filter` -> Evaluates to the filter expression/function defined by `%filter`.
 - `$NonTerminalName` -> Evaluates to the `ruletype` defined for `NonTerminalName`.
 - `$terminal_name` -> Evaluates to the match pattern/definition of `<terminal_name>`.
 
 ### Substitution Errors
 - **Circular Dependency**: If you introduce circular dependencies among type/definition variables, a compile-time error (`CircularDependency`) is returned.
 - **Max Depth Exceeded**: A maximum recursion limit of `100` is enforced to prevent infinite compilation loops. If exceeded, a compile-time error (`MaxSubstitutionDepthExceeded`) is returned.
-- **Filter Not Defined**: If `$filter` is used inside a reduce action block but `%filter` directive is not defined, a compile-time error (`FilterNotDefined`) is returned.
 
 ### Example
 ```rust

--- a/example/calculator/src/parser.rs
+++ b/example/calculator/src/parser.rs
@@ -7,9 +7,7 @@ pub enum Token {
     RParen,
 }
 
-fn filter( term: &Token ) -> &Token {
-    term
-}
+
 
 %%
 
@@ -41,7 +39,6 @@ fn filter( term: &Token ) -> &Token {
 %left plus;
 %left star;
 
-%filter filter;
 
 // data that each token holds can be accessed by its name
 // s is slice of shifted terminal symbols captured by current rule

--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -450,26 +450,7 @@ impl Builder {
                                 vec!["Only one %location definition is allowed".to_string()],
                             )
                     }
-                    ArgError::MultipleFilterDefinition(locs) => {
-                        let mut labels = Vec::new();
-                        for (i, loc) in locs.iter().enumerate() {
-                            let range = grammar_args
-                                .span_manager
-                                .get_byterange(&loc)
-                                .unwrap_or(0..0);
-                            let message = if i == 0 {
-                                "First definition"
-                            } else {
-                                "Other definition"
-                            };
-                            labels.push(Label::primary(file_id, range).with_message(message));
-                        }
 
-                        Diagnostic::error()
-                            .with_message("Multiple %filter definition")
-                            .with_labels(labels)
-                            .with_notes(vec!["Only one %filter definition is allowed".to_string()])
-                    }
                     ArgError::MultipleEofDefinition(locs) => {
                         let mut labels = Vec::new();
                         for (i, loc) in locs.iter().enumerate() {
@@ -883,18 +864,6 @@ impl Builder {
                             .with_labels(vec![Label::primary(file_id, range)
                                 .with_message("recursion depth limit reached here")])
                             .with_notes(vec![
-                                "refer to https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#substitution-errors".to_string(),
-                            ])
-                    }
-
-                    ParseError::FilterNotDefined(loc) => {
-                        let range = span_manager.get_byterange(&loc).unwrap_or(0..0);
-                        Diagnostic::error()
-                            .with_message("Filter function not defined")
-                            .with_labels(vec![Label::primary(file_id, range)
-                                .with_message("referenced here")])
-                            .with_notes(vec![
-                                "Define the filter function using %filter <path>;".to_string(),
                                 "refer to https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#substitution-errors".to_string(),
                             ])
                     }

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -251,11 +251,6 @@ impl Grammar {
 
         let other_class_id = self.other_terminal_class_id;
 
-        let match_terminal_filter_expression = if let Some(filter) = &self.filter {
-            quote! { #filter(terminal) }
-        } else {
-            quote! {terminal}
-        };
         let mut from_term_match_stream = TokenStream::new();
 
         // building terminal-class_id map
@@ -404,7 +399,7 @@ impl Grammar {
                 }
                 fn from_term(terminal: &Self::Term) -> Self {
                     #[allow(unreachable_patterns, unused_variables)]
-                    match #match_terminal_filter_expression {
+                    match terminal {
                         #from_term_match_stream
                     }
                 }

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -34,8 +34,6 @@ pub enum ArgError {
     MultipleDPrecDefinition(Vec<Location>),
     /// multiple %location in the same grammar
     MultipleLocationDefinition(Vec<Location>),
-    /// multiple %filter in the same grammar
-    MultipleFilterDefinition(Vec<Location>),
 
     StartNotDefined,
     EofNotDefined,
@@ -135,9 +133,6 @@ pub enum ParseError {
         location: Location,
         max_depth: usize,
     },
-
-    /// $filter was used in variable substitution but %filter function not defined
-    FilterNotDefined(Location),
 }
 impl ArgError {
     pub fn to_compile_error(
@@ -164,7 +159,6 @@ impl ArgError {
             | ArgError::MultipleErrorDefinition(locs)
             | ArgError::MultipleTokenTypeDefinition(locs)
             | ArgError::MultipleLocationDefinition(locs)
-            | ArgError::MultipleFilterDefinition(locs)
             | ArgError::MultipleEofDefinition(locs)
             | ArgError::MultipleStartDefinition(locs)
             | ArgError::MultiplePrecDefinition(locs)
@@ -184,7 +178,6 @@ impl ArgError {
             ArgError::MultipleErrorDefinition(_) => "Multiple %error definition".into(),
             ArgError::MultipleTokenTypeDefinition(_) => "Multiple %tokentype definition".into(),
             ArgError::MultipleLocationDefinition(_) => "Multiple %location definition".into(),
-            ArgError::MultipleFilterDefinition(_) => "Multiple %filter definition".into(),
             ArgError::MultipleEofDefinition(_) => "Multiple %eof definition".into(),
             ArgError::MultipleStartDefinition(_) => "Multiple %start definition".into(),
             ArgError::MultiplePrecDefinition(_) => "Multiple %prec definition".into(),
@@ -283,7 +276,6 @@ impl ParseError {
             ParseError::TypeInferenceFailed(location) => vec![*location],
             ParseError::CircularDependency { location, .. } => vec![*location],
             ParseError::MaxSubstitutionDepthExceeded { location, .. } => vec![*location],
-            ParseError::FilterNotDefined(loc) => vec![*loc],
         }
     }
 
@@ -358,9 +350,6 @@ impl ParseError {
                     "Maximum variable substitution depth ({}) exceeded",
                     max_depth
                 )
-            }
-            ParseError::FilterNotDefined(_) => {
-                "Filter function not defined. Define it using %filter <path>;".to_string()
             }
         }
     }

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -137,16 +137,6 @@ pub struct Grammar {
     /// in the generated parser, the dense table `Vec` will be used instead of the sparse table `HashMap`.
     pub emit_dense: bool,
 
-    /// the filter function for the parser feed();
-    /// every terminal will be filtered by this function on classification.
-    /// the actual code will be:
-    /// ```text
-    /// let terminal_class: usize = match filter( terminal ) {
-    ///     ...
-    /// };
-    /// ```
-    pub filter: Option<TokenStream>,
-
     /// type for location
     pub location_typename: TokenStream,
 
@@ -230,18 +220,6 @@ impl Grammar {
             return Err(ArgError::MultipleLocationDefinition(
                 grammar_args
                     .location_typename
-                    .iter()
-                    .map(|(loc, _)| loc)
-                    .cloned()
-                    .collect(),
-            ));
-        }
-
-        // %filter
-        if grammar_args.filter.len() > 1 {
-            return Err(ArgError::MultipleFilterDefinition(
-                grammar_args
-                    .filter
                     .iter()
                     .map(|(loc, _)| loc)
                     .cloned()
@@ -448,9 +426,7 @@ impl Grammar {
             }
 
             if !providers.contains_key(name) {
-                if name == "filter" {
-                    return Err(ParseError::FilterNotDefined(ref_loc));
-                } else if name.starts_with("nonterm:") {
+                if name.starts_with("nonterm:") {
                     return Err(ParseError::NonTerminalNotDefined(ref_loc));
                 } else if name.starts_with("term:") {
                     return Err(ParseError::TerminalNotDefined(ref_loc));
@@ -537,19 +513,6 @@ impl Grammar {
                                 iter.next();
                                 let resolved = resolve_provider(
                                     "location",
-                                    providers,
-                                    span_manager,
-                                    stack,
-                                    depth,
-                                    max_depth,
-                                    ref_loc,
-                                )?;
-                                result.extend(resolved);
-                                continue;
-                            } else if ident_name == "filter" {
-                                iter.next();
-                                let resolved = resolve_provider(
-                                    "filter",
                                     providers,
                                     span_manager,
                                     stack,
@@ -755,18 +718,6 @@ impl Grammar {
             },
         );
 
-        if let Some((loc, stream)) = grammar_args.filter.first() {
-            providers.insert(
-                "filter".to_string(),
-                ProviderInfo {
-                    name: "filter".to_string(),
-                    location: *loc,
-                    stream: Some(stream.clone()),
-                    state: ResolveState::Unresolved,
-                },
-            );
-        }
-
         for (ident, stream) in &grammar_args.terminals {
             providers.insert(
                 format!("term:{}", ident.value()),
@@ -892,19 +843,6 @@ impl Grammar {
             }
         }
 
-        // Resolve and substitute variables inside the %filter expression itself
-        // (e.g. if the user uses defined type/location variables in the filter signature).
-        for (_, filter_stream) in &mut grammar_args.filter {
-            *filter_stream = substitute_stream(
-                filter_stream.clone(),
-                &mut providers,
-                &mut grammar_args.span_manager,
-                &mut stack,
-                0,
-                100,
-            )?;
-        }
-
         for rules_arg in &mut grammar_args.rules {
             for rule_line in &mut rules_arg.rule_lines {
                 if let Some(action_stream) = &mut rule_line.reduce_action {
@@ -967,7 +905,6 @@ impl Grammar {
             range_resolver: RangeResolver::new(),
 
             emit_dense: grammar_args.dense,
-            filter: grammar_args.filter.into_iter().next().map(|(_, s)| s),
 
             location_typename,
             error_precedence: None,
@@ -3324,67 +3261,6 @@ mod tests {
             assert!(path.contains(&"nonterm:Expr".to_string()));
             assert!(path.contains(&"nonterm:Term".to_string()));
         }
-    }
-
-    #[test]
-    fn test_variable_substitution_filter() {
-        // 1. Success case
-        let input = quote! {
-            %tokentype Token;
-            %filter my_filter;
-            %token a Token::A;
-            %start Expr;
-            Expr($filter) : a { $filter };
-        };
-
-        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar args");
-        let grammar = Grammar::from_grammar_args(grammar_args).expect("Failed to build grammar");
-
-        let expr_idx = grammar.nonterminals_index.get("Expr").unwrap();
-        assert_eq!(
-            grammar.nonterminals[*expr_idx]
-                .ruletype
-                .as_ref()
-                .unwrap()
-                .to_string(),
-            "my_filter"
-        );
-
-        // 2. Filter not defined error
-        let input_err = quote! {
-            %tokentype Token;
-            %token a Token::A;
-            %start Expr;
-            Expr($filter) : a { $filter };
-        };
-
-        let grammar_args_err =
-            Grammar::parse_args(input_err).expect("Failed to parse grammar args");
-        let grammar_err = Grammar::from_grammar_args(grammar_args_err);
-        assert!(grammar_err.is_err());
-        assert!(matches!(
-            grammar_err.err().unwrap(),
-            ParseError::FilterNotDefined(_)
-        ));
-
-        // 3. Multiple filter definitions error
-        let input_mult = quote! {
-            %tokentype Token;
-            %filter filter1;
-            %filter filter2;
-            %token a Token::A;
-            %start Expr;
-            Expr : a;
-        };
-
-        let grammar_args_mult =
-            Grammar::parse_args(input_mult).expect("Failed to parse grammar args");
-        let check_res = Grammar::arg_check_error(&grammar_args_mult);
-        assert!(check_res.is_err());
-        assert!(matches!(
-            check_res.err().unwrap(),
-            ArgError::MultipleFilterDefinition(_)
-        ));
     }
 
     #[test]

--- a/rusty_lr_parser/src/parser/args.rs
+++ b/rusty_lr_parser/src/parser/args.rs
@@ -665,7 +665,6 @@ pub struct GrammarArgs {
     pub glr: bool,
     pub no_optim: bool,
     pub dense: bool,
-    pub filter: Vec<(Location, TokenStream)>,
     pub location_typename: Vec<(Location, TokenStream)>,
 
     pub error_recovered: Vec<RecoveredError>,
@@ -687,7 +686,6 @@ impl Default for GrammarArgs {
             glr: false,
             no_optim: false,
             dense: false,
-            filter: Vec::new(),
             location_typename: Vec::new(),
             error_recovered: Vec::new(),
             span_manager: crate::parser::location::SpanManager::default(),

--- a/rusty_lr_parser/src/parser/lexer.rs
+++ b/rusty_lr_parser/src/parser/lexer.rs
@@ -67,7 +67,6 @@ pub enum Lexed {
     NoOptim(Ident),      // %nooptim
     Dense(Ident),        // %dense
     DPrec(Ident),        // %dprec
-    Filter(Ident),       // %filter
     Location(Ident),     // %location
 }
 impl Lexed {
@@ -155,9 +154,6 @@ impl Lexed {
             Lexed::DPrec(ident) => {
                 stream.append(ident);
             }
-            Lexed::Filter(ident) => {
-                stream.append(ident);
-            }
             Lexed::Location(ident) => {
                 stream.append(ident);
             }
@@ -217,7 +213,6 @@ impl std::fmt::Display for Lexed {
             Lexed::NoOptim(_) => write!(f, "nooptim"),
             Lexed::Dense(_) => write!(f, "dense"),
             Lexed::DPrec(_) => write!(f, "dprec"),
-            Lexed::Filter(_) => write!(f, "filter"),
             Lexed::Location(_) => write!(f, "location"),
         }
     }
@@ -240,7 +235,6 @@ fn ident_to_keyword(ident: Ident) -> Option<Lexed> {
         "nooptim" => Some(Lexed::NoOptim(ident)),
         "dense" => Some(Lexed::Dense(ident)),
         "dprec" => Some(Lexed::DPrec(ident)),
-        "filter" => Some(Lexed::Filter(ident)),
         "location" => Some(Lexed::Location(ident)),
         _ => None,
     }

--- a/rusty_lr_parser/src/parser/parser.rs
+++ b/rusty_lr_parser/src/parser/parser.rs
@@ -80,7 +80,6 @@ use rusty_lr_core::rule::ReduceType;
 %token nooptim Lexed::NoOptim(_);
 %token dense Lexed::Dense(_);
 %token dprec Lexed::DPrec(_);
-%token filter Lexed::Filter(_);
 %token location Lexed::Location(_);
 
 %start Grammar;
@@ -633,16 +632,7 @@ Directive
         });
     }
 
-    | percent filter! RustCode semicolon! {
-        data.filter.push((@filter, RustCode));
-    }
-    | percent filter! semicolon! {
-        data.error_recovered.push( RecoveredError {
-            message: "Expected filter definition".to_string(),
-            link: "https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#filter-directive".to_string(),
-            location: @filter,
-        });
-    }
+
     | percent location! RustCode semicolon! {
         data.location_typename.push((@location, RustCode));
     }

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -25,8 +25,8 @@ use std::boxed::Box;
 /*
 ====================================Grammar=====================================
 
-# of terminal classes: 45
-# of states: 177
+# of terminal classes: 44
+# of states: 173
 
 0: Rule -> ident RuleType colon RuleLines semicolon
 1: RuleType -> parengroup
@@ -103,87 +103,84 @@ use std::boxed::Box;
 72: Directive -> percent nooptim error semicolon
 73: Directive -> percent dense semicolon
 74: Directive -> percent dense error semicolon
-75: Directive -> percent filter [^semicolon]+ semicolon
-76: Directive -> percent filter semicolon
-77: Directive -> percent location [^semicolon]+ semicolon
-78: Directive -> percent location semicolon
-79: Directive -> percent error semicolon
-80: GrammarLine -> Rule
-81: GrammarLine -> Directive
-82: Grammar -> GrammarLine+
-83: TokenMapped+ -> TokenMapped
-84: TokenMapped+ -> TokenMapped+ TokenMapped
-85: TokenMapped* -> TokenMapped+
-86: TokenMapped* ->
-87: PrecDef+ -> PrecDef
-88: PrecDef+ -> PrecDef+ PrecDef
-89: PrecDef* -> PrecDef+
-90: PrecDef* ->
-91: caret? -> caret
-92: caret? ->
-93: TerminalSetItem+ -> TerminalSetItem
-94: TerminalSetItem+ -> TerminalSetItem+ TerminalSetItem
-95: TerminalSetItem* -> TerminalSetItem+
-96: TerminalSetItem* ->
-97: Pattern+ -> Pattern
-98: Pattern+ -> Pattern+ Pattern
-99: Pattern* -> Pattern+
-100: Pattern* ->
-101: $sep(Pattern*, pipe, +) -> Pattern*
-102: $sep(Pattern*, pipe, +) -> $sep(Pattern*, pipe, +) pipe Pattern*
-103: comma? -> comma
-104: comma? ->
-105: [^semicolon] -> ident
-106: [^semicolon] -> colon
-107: [^semicolon] -> pipe
-108: [^semicolon] -> percent
-109: [^semicolon] -> equal
-110: [^semicolon] -> plus
-111: [^semicolon] -> star
-112: [^semicolon] -> question
-113: [^semicolon] -> caret
-114: [^semicolon] -> minus
-115: [^semicolon] -> exclamation
-116: [^semicolon] -> slash
-117: [^semicolon] -> dot
-118: [^semicolon] -> dollar
-119: [^semicolon] -> comma
-120: [^semicolon] -> int_literal
-121: [^semicolon] -> byte_literal
-122: [^semicolon] -> byte_str_literal
-123: [^semicolon] -> char_literal
-124: [^semicolon] -> str_literal
-125: [^semicolon] -> [other_literal, <Others>]
-126: [^semicolon] -> parengroup
-127: [^semicolon] -> bracegroup
-128: [^semicolon] -> lparen
-129: [^semicolon] -> rparen
-130: [^semicolon] -> lbracket
-131: [^semicolon] -> rbracket
-132: [^semicolon] -> left
-133: [^semicolon] -> right
-134: [^semicolon] -> token
-135: [^semicolon] -> start
-136: [^semicolon] -> tokentype
-137: [^semicolon] -> userdata
-138: [^semicolon] -> errortype
-139: [^semicolon] -> moduleprefix
-140: [^semicolon] -> lalr
-141: [^semicolon] -> glr
-142: [^semicolon] -> prec
-143: [^semicolon] -> precedence
-144: [^semicolon] -> nooptim
-145: [^semicolon] -> dense
-146: [^semicolon] -> dprec
-147: [^semicolon] -> filter
-148: [^semicolon] -> location
-149: [^semicolon]+ -> [^semicolon]
-150: [^semicolon]+ -> [^semicolon]+ [^semicolon]
-151: IdentOrLiteral+ -> IdentOrLiteral
-152: IdentOrLiteral+ -> IdentOrLiteral+ IdentOrLiteral
-153: GrammarLine+ -> GrammarLine
-154: GrammarLine+ -> GrammarLine GrammarLine+
-155: Augmented -> Grammar eof
+75: Directive -> percent location [^semicolon]+ semicolon
+76: Directive -> percent location semicolon
+77: Directive -> percent error semicolon
+78: GrammarLine -> Rule
+79: GrammarLine -> Directive
+80: Grammar -> GrammarLine+
+81: TokenMapped+ -> TokenMapped
+82: TokenMapped+ -> TokenMapped+ TokenMapped
+83: TokenMapped* -> TokenMapped+
+84: TokenMapped* ->
+85: PrecDef+ -> PrecDef
+86: PrecDef+ -> PrecDef+ PrecDef
+87: PrecDef* -> PrecDef+
+88: PrecDef* ->
+89: caret? -> caret
+90: caret? ->
+91: TerminalSetItem+ -> TerminalSetItem
+92: TerminalSetItem+ -> TerminalSetItem+ TerminalSetItem
+93: TerminalSetItem* -> TerminalSetItem+
+94: TerminalSetItem* ->
+95: Pattern+ -> Pattern
+96: Pattern+ -> Pattern+ Pattern
+97: Pattern* -> Pattern+
+98: Pattern* ->
+99: $sep(Pattern*, pipe, +) -> Pattern*
+100: $sep(Pattern*, pipe, +) -> $sep(Pattern*, pipe, +) pipe Pattern*
+101: comma? -> comma
+102: comma? ->
+103: [^semicolon] -> ident
+104: [^semicolon] -> colon
+105: [^semicolon] -> pipe
+106: [^semicolon] -> percent
+107: [^semicolon] -> equal
+108: [^semicolon] -> plus
+109: [^semicolon] -> star
+110: [^semicolon] -> question
+111: [^semicolon] -> caret
+112: [^semicolon] -> minus
+113: [^semicolon] -> exclamation
+114: [^semicolon] -> slash
+115: [^semicolon] -> dot
+116: [^semicolon] -> dollar
+117: [^semicolon] -> comma
+118: [^semicolon] -> int_literal
+119: [^semicolon] -> byte_literal
+120: [^semicolon] -> byte_str_literal
+121: [^semicolon] -> char_literal
+122: [^semicolon] -> str_literal
+123: [^semicolon] -> [other_literal, <Others>]
+124: [^semicolon] -> parengroup
+125: [^semicolon] -> bracegroup
+126: [^semicolon] -> lparen
+127: [^semicolon] -> rparen
+128: [^semicolon] -> lbracket
+129: [^semicolon] -> rbracket
+130: [^semicolon] -> left
+131: [^semicolon] -> right
+132: [^semicolon] -> token
+133: [^semicolon] -> start
+134: [^semicolon] -> tokentype
+135: [^semicolon] -> userdata
+136: [^semicolon] -> errortype
+137: [^semicolon] -> moduleprefix
+138: [^semicolon] -> lalr
+139: [^semicolon] -> glr
+140: [^semicolon] -> prec
+141: [^semicolon] -> precedence
+142: [^semicolon] -> nooptim
+143: [^semicolon] -> dense
+144: [^semicolon] -> dprec
+145: [^semicolon] -> location
+146: [^semicolon]+ -> [^semicolon]
+147: [^semicolon]+ -> [^semicolon]+ [^semicolon]
+148: IdentOrLiteral+ -> IdentOrLiteral
+149: IdentOrLiteral+ -> IdentOrLiteral+ IdentOrLiteral
+150: GrammarLine+ -> GrammarLine
+151: GrammarLine+ -> GrammarLine GrammarLine+
+152: Augmented -> Grammar eof
 
 */
 // =============================Generated Codes Begin==============================
@@ -259,7 +256,6 @@ pub enum GrammarTerminalClasses {
     nooptim,
     dense,
     dprec,
-    filter,
     location,
     semicolon,
     plus,
@@ -275,10 +271,10 @@ impl GrammarTerminalClasses {
     #[inline]
     pub fn from_usize(value: usize) -> Self {
         debug_assert!(
-            value < 47usize,
+            value < 46usize,
             "Terminal class index {} is out of bounds (max {})",
             value,
-            47usize
+            46usize
         );
         unsafe { ::std::mem::transmute(value) }
     }
@@ -325,7 +321,6 @@ impl ::rusty_lr_core::parser::terminalclass::TerminalClass for GrammarTerminalCl
             GrammarTerminalClasses::nooptim => "nooptim",
             GrammarTerminalClasses::dense => "dense",
             GrammarTerminalClasses::dprec => "dprec",
-            GrammarTerminalClasses::filter => "filter",
             GrammarTerminalClasses::location => "location",
             GrammarTerminalClasses::semicolon => "semicolon",
             GrammarTerminalClasses::plus => "plus",
@@ -393,7 +388,6 @@ impl ::rusty_lr_core::parser::terminalclass::TerminalClass for GrammarTerminalCl
             Lexed::NoOptim(_) => GrammarTerminalClasses::nooptim,
             Lexed::Dense(_) => GrammarTerminalClasses::dense,
             Lexed::DPrec(_) => GrammarTerminalClasses::dprec,
-            Lexed::Filter(_) => GrammarTerminalClasses::filter,
             Lexed::Location(_) => GrammarTerminalClasses::location,
             Lexed::Semicolon(_) => GrammarTerminalClasses::semicolon,
             Lexed::Plus(_) => GrammarTerminalClasses::plus,
@@ -4231,106 +4225,9 @@ impl GrammarDataStack {
         __data_stack.__stack.push(GrammarData::Empty);
         Ok(())
     }
-    ///Directive -> percent filter [^semicolon]+ semicolon
-    #[inline]
-    fn reduce_Directive_27(
-        __data_stack: &mut Self,
-        __location_stack: &mut Vec<Location>,
-        __push_data: bool,
-        shift: &mut bool,
-        lookahead: &::rusty_lr_core::TerminalSymbol<Lexed>,
-        data: &mut GrammarArgs,
-        __rustylr_location0: &mut Location,
-    ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                0usize), Some(& GrammarData::Empty))
-            );
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                1usize), Some(& GrammarData::__variant17(_)))
-            );
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                2usize), Some(& GrammarData::__terminals(_)))
-            );
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                3usize), Some(& GrammarData::__terminals(_)))
-            );
-        }
-        __location_stack.truncate(__location_stack.len() - 2);
-        let mut __rustylr_location_filter = __location_stack.pop().unwrap();
-        __location_stack.pop();
-        __data_stack.__stack.pop();
-        let mut __rustylr_data_2 = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__variant17(val) => val,
-            _ => unreachable!(),
-        };
-        let mut filter = match __data_stack.__stack.pop().unwrap() {
-            GrammarData::__terminals(val) => val,
-            _ => unreachable!(),
-        };
-        __data_stack.__stack.pop();
-        let __rustylr_data_2 = Self::custom_reduce_action_0(
-            __rustylr_data_2,
-            data,
-            __rustylr_location0,
-        )?;
-        let mut RustCode = __rustylr_data_2;
-        {
-            data.filter.push((__rustylr_location_filter, RustCode));
-        };
-        __data_stack.__stack.push(GrammarData::Empty);
-        Ok(())
-    }
-    ///Directive -> percent filter semicolon
-    #[inline]
-    fn reduce_Directive_28(
-        __data_stack: &mut Self,
-        __location_stack: &mut Vec<Location>,
-        __push_data: bool,
-        shift: &mut bool,
-        lookahead: &::rusty_lr_core::TerminalSymbol<Lexed>,
-        data: &mut GrammarArgs,
-        __rustylr_location0: &mut Location,
-    ) -> Result<(), ::rusty_lr_core::DefaultReduceActionError> {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                0usize), Some(& GrammarData::Empty))
-            );
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                1usize), Some(& GrammarData::__terminals(_)))
-            );
-            debug_assert!(
-                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                2usize), Some(& GrammarData::__terminals(_)))
-            );
-        }
-        __location_stack.pop();
-        let mut __rustylr_location_filter = __location_stack.pop().unwrap();
-        __location_stack.pop();
-        __data_stack.__stack.truncate(__data_stack.__stack.len() - 3);
-        {
-            data.error_recovered
-                .push(RecoveredError {
-                    message: "Expected filter definition".to_string(),
-                    link: "https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#filter-directive"
-                        .to_string(),
-                    location: __rustylr_location_filter,
-                });
-        };
-        __data_stack.__stack.push(GrammarData::Empty);
-        Ok(())
-    }
     ///Directive -> percent location [^semicolon]+ semicolon
     #[inline]
-    fn reduce_Directive_29(
+    fn reduce_Directive_27(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<Location>,
         __push_data: bool,
@@ -4381,7 +4278,7 @@ impl GrammarDataStack {
     }
     ///Directive -> percent location semicolon
     #[inline]
-    fn reduce_Directive_30(
+    fn reduce_Directive_28(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<Location>,
         __push_data: bool,
@@ -4428,7 +4325,7 @@ impl GrammarDataStack {
     }
     ///Directive -> percent error semicolon
     #[inline]
-    fn reduce_Directive_31(
+    fn reduce_Directive_29(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<Location>,
         __push_data: bool,
@@ -6275,28 +6172,6 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                 )
             }
             78usize => {
-                Self::reduce_Directive_30(
-                    data_stack,
-                    location_stack,
-                    push_data,
-                    shift,
-                    lookahead,
-                    user_data,
-                    location0,
-                )
-            }
-            79usize => {
-                Self::reduce_Directive_31(
-                    data_stack,
-                    location_stack,
-                    push_data,
-                    shift,
-                    lookahead,
-                    user_data,
-                    location0,
-                )
-            }
-            80usize => {
                 Self::reduce_GrammarLine_0(
                     data_stack,
                     location_stack,
@@ -6307,7 +6182,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            83usize => {
+            81usize => {
                 Self::reduce__TokenMappedPlus15_0(
                     data_stack,
                     location_stack,
@@ -6318,7 +6193,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            84usize => {
+            82usize => {
                 Self::reduce__TokenMappedPlus15_1(
                     data_stack,
                     location_stack,
@@ -6329,7 +6204,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            85usize => {
+            83usize => {
                 Self::reduce__TokenMappedStar16_0(
                     data_stack,
                     location_stack,
@@ -6340,7 +6215,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            86usize => {
+            84usize => {
                 Self::reduce__TokenMappedStar16_1(
                     data_stack,
                     location_stack,
@@ -6351,7 +6226,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            87usize => {
+            85usize => {
                 Self::reduce__PrecDefPlus17_0(
                     data_stack,
                     location_stack,
@@ -6362,7 +6237,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            88usize => {
+            86usize => {
                 Self::reduce__PrecDefPlus17_1(
                     data_stack,
                     location_stack,
@@ -6373,7 +6248,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            89usize => {
+            87usize => {
                 Self::reduce__PrecDefStar18_0(
                     data_stack,
                     location_stack,
@@ -6384,7 +6259,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            90usize => {
+            88usize => {
                 Self::reduce__PrecDefStar18_1(
                     data_stack,
                     location_stack,
@@ -6395,7 +6270,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            91usize => {
+            89usize => {
                 Self::reduce__caretQuestion19_0(
                     data_stack,
                     location_stack,
@@ -6406,7 +6281,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            92usize => {
+            90usize => {
                 Self::reduce__caretQuestion19_1(
                     data_stack,
                     location_stack,
@@ -6417,7 +6292,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            93usize => {
+            91usize => {
                 Self::reduce__TerminalSetItemPlus20_0(
                     data_stack,
                     location_stack,
@@ -6428,7 +6303,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            94usize => {
+            92usize => {
                 Self::reduce__TerminalSetItemPlus20_1(
                     data_stack,
                     location_stack,
@@ -6439,7 +6314,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            95usize => {
+            93usize => {
                 Self::reduce__TerminalSetItemStar21_0(
                     data_stack,
                     location_stack,
@@ -6450,7 +6325,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            96usize => {
+            94usize => {
                 Self::reduce__TerminalSetItemStar21_1(
                     data_stack,
                     location_stack,
@@ -6461,7 +6336,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            97usize => {
+            95usize => {
                 Self::reduce__PatternPlus22_0(
                     data_stack,
                     location_stack,
@@ -6472,7 +6347,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            98usize => {
+            96usize => {
                 Self::reduce__PatternPlus22_1(
                     data_stack,
                     location_stack,
@@ -6483,7 +6358,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            99usize => {
+            97usize => {
                 Self::reduce__PatternStar23_0(
                     data_stack,
                     location_stack,
@@ -6494,7 +6369,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            100usize => {
+            98usize => {
                 Self::reduce__PatternStar23_1(
                     data_stack,
                     location_stack,
@@ -6505,7 +6380,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            101usize => {
+            99usize => {
                 Self::reduce___PatternStar23SepPlus24_0(
                     data_stack,
                     location_stack,
@@ -6516,7 +6391,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            102usize => {
+            100usize => {
                 Self::reduce___PatternStar23SepPlus24_1(
                     data_stack,
                     location_stack,
@@ -6527,7 +6402,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            103usize => {
+            101usize => {
                 Self::reduce__commaQuestion25_0(
                     data_stack,
                     location_stack,
@@ -6538,7 +6413,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            104usize => {
+            102usize => {
                 Self::reduce__commaQuestion25_1(
                     data_stack,
                     location_stack,
@@ -6549,7 +6424,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            149usize => {
+            146usize => {
                 Self::reduce___TermSet26Plus27_0(
                     data_stack,
                     location_stack,
@@ -6560,7 +6435,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            150usize => {
+            147usize => {
                 Self::reduce___TermSet26Plus27_1(
                     data_stack,
                     location_stack,
@@ -6571,7 +6446,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            151usize => {
+            148usize => {
                 Self::reduce__IdentOrLiteralPlus28_0(
                     data_stack,
                     location_stack,
@@ -6582,7 +6457,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            152usize => {
+            149usize => {
                 Self::reduce__IdentOrLiteralPlus28_1(
                     data_stack,
                     location_stack,
@@ -6593,7 +6468,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            153usize => {
+            150usize => {
                 Self::reduce__GrammarLinePlus29_0(
                     data_stack,
                     location_stack,
@@ -6604,7 +6479,7 @@ impl ::rusty_lr_core::parser::data_stack::DataStack for GrammarDataStack {
                     location0,
                 )
             }
-            154usize => {
+            151usize => {
                 Self::reduce__GrammarLinePlus29_1(
                     data_stack,
                     location_stack,
@@ -6662,15 +6537,14 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     9u32, 10u32, 10u32, 10u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32,
                     11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32,
                     11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 11u32,
-                    11u32, 11u32, 11u32, 11u32, 11u32, 11u32, 12u32, 12u32, 13u32, 14u32,
-                    14u32, 15u32, 15u32, 16u32, 16u32, 17u32, 17u32, 18u32, 18u32, 19u32,
-                    19u32, 20u32, 20u32, 21u32, 21u32, 22u32, 22u32, 23u32, 23u32, 24u32,
-                    24u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32,
+                    11u32, 11u32, 11u32, 11u32, 12u32, 12u32, 13u32, 14u32, 14u32, 15u32,
+                    15u32, 16u32, 16u32, 17u32, 17u32, 18u32, 18u32, 19u32, 19u32, 20u32,
+                    20u32, 21u32, 21u32, 22u32, 22u32, 23u32, 23u32, 24u32, 24u32, 25u32,
                     25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32,
                     25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32,
                     25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32,
-                    25u32, 25u32, 25u32, 25u32, 25u32, 26u32, 26u32, 27u32, 27u32, 28u32,
-                    28u32, 29u32,
+                    25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32, 25u32,
+                    25u32, 25u32, 26u32, 26u32, 27u32, 27u32, 28u32, 28u32, 29u32,
                 ];
                 static RULE_PRECEDENCES: &[u32] = &[
                     0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32,
@@ -6686,43 +6560,41 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32,
                     0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32,
                     0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32,
-                    0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32,
-                    0u32, 0u32,
+                    0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32,
                 ];
                 static RULE_TOKENS_DATA: &[u32] = &[
-                    0u32, 3u32, 4u32, 5u32, 76u32, 30u32, 5u32, 6u32, 7u32, 7u32, 31u32,
-                    35u32, 19u32, 8u32, 62u32, 21u32, 8u32, 62u32, 90u32, 8u32, 70u32,
-                    20u32, 8u32, 70u32, 90u32, 8u32, 90u32, 17u32, 0u32, 10u32, 17u32,
-                    0u32, 0u32, 86u32, 0u32, 0u32, 86u32, 90u32, 26u32, 26u32, 86u32,
-                    26u32, 26u32, 86u32, 90u32, 22u32, 22u32, 86u32, 22u32, 22u32, 86u32,
-                    90u32, 38u32, 37u32, 41u32, 40u32, 14u32, 0u32, 17u32, 78u32, 17u32,
-                    80u32, 17u32, 82u32, 17u32, 84u32, 15u32, 17u32, 88u32, 17u32, 34u32,
-                    47u32, 36u32, 34u32, 90u32, 36u32, 22u32, 24u32, 26u32, 28u32, 17u32,
-                    86u32, 17u32, 16u32, 0u32, 34u32, 17u32, 18u32, 17u32, 49u32, 36u32,
-                    16u32, 0u32, 34u32, 17u32, 18u32, 17u32, 18u32, 78u32, 36u32, 16u32,
-                    0u32, 34u32, 17u32, 18u32, 17u32, 18u32, 80u32, 36u32, 16u32, 0u32,
-                    34u32, 17u32, 18u32, 17u32, 90u32, 36u32, 16u32, 0u32, 34u32, 17u32,
-                    18u32, 17u32, 18u32, 90u32, 36u32, 32u32, 0u32, 22u32, 26u32, 8u32,
-                    46u32, 0u32, 53u32, 76u32, 8u32, 46u32, 0u32, 76u32, 8u32, 46u32,
-                    90u32, 76u32, 8u32, 48u32, 0u32, 76u32, 8u32, 48u32, 90u32, 76u32,
-                    8u32, 50u32, 53u32, 76u32, 8u32, 50u32, 76u32, 8u32, 52u32, 53u32,
-                    76u32, 8u32, 52u32, 76u32, 8u32, 42u32, 55u32, 76u32, 8u32, 42u32,
-                    90u32, 76u32, 8u32, 44u32, 55u32, 76u32, 8u32, 44u32, 90u32, 76u32,
-                    8u32, 64u32, 55u32, 76u32, 8u32, 64u32, 90u32, 76u32, 8u32, 54u32,
-                    53u32, 76u32, 8u32, 54u32, 76u32, 8u32, 56u32, 53u32, 76u32, 8u32,
-                    56u32, 76u32, 8u32, 60u32, 76u32, 8u32, 60u32, 90u32, 76u32, 8u32,
-                    58u32, 76u32, 8u32, 58u32, 90u32, 76u32, 8u32, 66u32, 76u32, 8u32,
-                    66u32, 90u32, 76u32, 8u32, 68u32, 76u32, 8u32, 68u32, 90u32, 76u32,
-                    8u32, 72u32, 53u32, 76u32, 8u32, 72u32, 76u32, 8u32, 74u32, 53u32,
-                    76u32, 8u32, 74u32, 76u32, 8u32, 90u32, 76u32, 1u32, 23u32, 57u32,
-                    11u32, 29u32, 11u32, 29u32, 9u32, 33u32, 9u32, 33u32, 12u32, 13u32,
-                    39u32, 13u32, 39u32, 17u32, 43u32, 17u32, 43u32, 45u32, 47u32, 6u32,
-                    45u32, 18u32, 0u32, 4u32, 6u32, 8u32, 10u32, 78u32, 80u32, 82u32,
-                    12u32, 86u32, 84u32, 88u32, 14u32, 16u32, 18u32, 20u32, 22u32, 24u32,
-                    26u32, 28u32, 2u32, 30u32, 32u32, 34u32, 36u32, 38u32, 40u32, 42u32,
-                    44u32, 46u32, 48u32, 50u32, 52u32, 54u32, 56u32, 58u32, 60u32, 62u32,
-                    64u32, 66u32, 68u32, 70u32, 72u32, 74u32, 51u32, 53u32, 51u32, 21u32,
-                    55u32, 21u32, 25u32, 25u32, 57u32, 27u32, 92u32,
+                    0u32, 3u32, 4u32, 5u32, 74u32, 30u32, 5u32, 6u32, 7u32, 7u32, 31u32,
+                    35u32, 19u32, 8u32, 62u32, 21u32, 8u32, 62u32, 88u32, 8u32, 70u32,
+                    20u32, 8u32, 70u32, 88u32, 8u32, 88u32, 17u32, 0u32, 10u32, 17u32,
+                    0u32, 0u32, 84u32, 0u32, 0u32, 84u32, 88u32, 26u32, 26u32, 84u32,
+                    26u32, 26u32, 84u32, 88u32, 22u32, 22u32, 84u32, 22u32, 22u32, 84u32,
+                    88u32, 38u32, 37u32, 41u32, 40u32, 14u32, 0u32, 17u32, 76u32, 17u32,
+                    78u32, 17u32, 80u32, 17u32, 82u32, 15u32, 17u32, 86u32, 17u32, 34u32,
+                    47u32, 36u32, 34u32, 88u32, 36u32, 22u32, 24u32, 26u32, 28u32, 17u32,
+                    84u32, 17u32, 16u32, 0u32, 34u32, 17u32, 18u32, 17u32, 49u32, 36u32,
+                    16u32, 0u32, 34u32, 17u32, 18u32, 17u32, 18u32, 76u32, 36u32, 16u32,
+                    0u32, 34u32, 17u32, 18u32, 17u32, 18u32, 78u32, 36u32, 16u32, 0u32,
+                    34u32, 17u32, 18u32, 17u32, 88u32, 36u32, 16u32, 0u32, 34u32, 17u32,
+                    18u32, 17u32, 18u32, 88u32, 36u32, 32u32, 0u32, 22u32, 26u32, 8u32,
+                    46u32, 0u32, 53u32, 74u32, 8u32, 46u32, 0u32, 74u32, 8u32, 46u32,
+                    88u32, 74u32, 8u32, 48u32, 0u32, 74u32, 8u32, 48u32, 88u32, 74u32,
+                    8u32, 50u32, 53u32, 74u32, 8u32, 50u32, 74u32, 8u32, 52u32, 53u32,
+                    74u32, 8u32, 52u32, 74u32, 8u32, 42u32, 55u32, 74u32, 8u32, 42u32,
+                    88u32, 74u32, 8u32, 44u32, 55u32, 74u32, 8u32, 44u32, 88u32, 74u32,
+                    8u32, 64u32, 55u32, 74u32, 8u32, 64u32, 88u32, 74u32, 8u32, 54u32,
+                    53u32, 74u32, 8u32, 54u32, 74u32, 8u32, 56u32, 53u32, 74u32, 8u32,
+                    56u32, 74u32, 8u32, 60u32, 74u32, 8u32, 60u32, 88u32, 74u32, 8u32,
+                    58u32, 74u32, 8u32, 58u32, 88u32, 74u32, 8u32, 66u32, 74u32, 8u32,
+                    66u32, 88u32, 74u32, 8u32, 68u32, 74u32, 8u32, 68u32, 88u32, 74u32,
+                    8u32, 72u32, 53u32, 74u32, 8u32, 72u32, 74u32, 8u32, 88u32, 74u32,
+                    1u32, 23u32, 57u32, 11u32, 29u32, 11u32, 29u32, 9u32, 33u32, 9u32,
+                    33u32, 12u32, 13u32, 39u32, 13u32, 39u32, 17u32, 43u32, 17u32, 43u32,
+                    45u32, 47u32, 6u32, 45u32, 18u32, 0u32, 4u32, 6u32, 8u32, 10u32,
+                    76u32, 78u32, 80u32, 12u32, 84u32, 82u32, 86u32, 14u32, 16u32, 18u32,
+                    20u32, 22u32, 24u32, 26u32, 28u32, 2u32, 30u32, 32u32, 34u32, 36u32,
+                    38u32, 40u32, 42u32, 44u32, 46u32, 48u32, 50u32, 52u32, 54u32, 56u32,
+                    58u32, 60u32, 62u32, 64u32, 66u32, 68u32, 70u32, 72u32, 51u32, 53u32,
+                    51u32, 21u32, 55u32, 21u32, 25u32, 25u32, 57u32, 27u32, 90u32,
                 ];
                 static RULE_TOKENS_OFFSETS: &[u32] = &[
                     0u32, 5u32, 6u32, 6u32, 9u32, 10u32, 13u32, 16u32, 19u32, 22u32,
@@ -6733,19 +6605,19 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     130u32, 135u32, 139u32, 143u32, 147u32, 151u32, 155u32, 158u32,
                     162u32, 165u32, 169u32, 173u32, 177u32, 181u32, 185u32, 189u32,
                     193u32, 196u32, 200u32, 203u32, 206u32, 210u32, 213u32, 217u32,
-                    220u32, 224u32, 227u32, 231u32, 235u32, 238u32, 242u32, 245u32,
-                    248u32, 249u32, 250u32, 251u32, 252u32, 254u32, 255u32, 255u32,
-                    256u32, 258u32, 259u32, 259u32, 260u32, 260u32, 261u32, 263u32,
-                    264u32, 264u32, 265u32, 267u32, 268u32, 268u32, 269u32, 272u32,
-                    273u32, 273u32, 274u32, 275u32, 276u32, 277u32, 278u32, 279u32,
-                    280u32, 281u32, 282u32, 283u32, 284u32, 285u32, 286u32, 287u32,
-                    288u32, 289u32, 290u32, 291u32, 292u32, 293u32, 294u32, 295u32,
-                    296u32, 297u32, 298u32, 299u32, 300u32, 301u32, 302u32, 303u32,
-                    304u32, 305u32, 306u32, 307u32, 308u32, 309u32, 310u32, 311u32,
-                    312u32, 313u32, 314u32, 315u32, 316u32, 317u32, 318u32, 320u32,
-                    321u32, 323u32, 324u32, 326u32, 328u32,
+                    220u32, 224u32, 227u32, 231u32, 235u32, 238u32, 241u32, 242u32,
+                    243u32, 244u32, 245u32, 247u32, 248u32, 248u32, 249u32, 251u32,
+                    252u32, 252u32, 253u32, 253u32, 254u32, 256u32, 257u32, 257u32,
+                    258u32, 260u32, 261u32, 261u32, 262u32, 265u32, 266u32, 266u32,
+                    267u32, 268u32, 269u32, 270u32, 271u32, 272u32, 273u32, 274u32,
+                    275u32, 276u32, 277u32, 278u32, 279u32, 280u32, 281u32, 282u32,
+                    283u32, 284u32, 285u32, 286u32, 287u32, 288u32, 289u32, 290u32,
+                    291u32, 292u32, 293u32, 294u32, 295u32, 296u32, 297u32, 298u32,
+                    299u32, 300u32, 301u32, 302u32, 303u32, 304u32, 305u32, 306u32,
+                    307u32, 308u32, 309u32, 310u32, 312u32, 313u32, 315u32, 316u32,
+                    318u32, 320u32,
                 ];
-                let num_rules = 156usize;
+                let num_rules = 153usize;
                 let mut rules = Vec::with_capacity(num_rules);
                 for i in 0..num_rules {
                     let name = GrammarNonTerminals::from_usize(RULE_NAMES[i] as usize);
@@ -6811,66 +6683,65 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     2147876875u32, 2147909644u32, 2147942413u32, 2147975182u32,
                     2148007953u32, 2148040723u32, 2147713024u32, 2147745799u32,
                     2147778568u32, 2147876875u32, 2147909644u32, 2147942413u32,
-                    2147975182u32, 2148007953u32, 2148040723u32, 2148794413u32,
+                    2147975182u32, 2148007953u32, 2148040723u32, 2148794412u32,
                     2148073478u32, 2148139008u32, 2148270091u32, 2148401165u32,
-                    2148171819u32, 2148204544u32, 2148237357u32, 2148302891u32,
-                    2148335627u32, 2148368429u32, 2148433963u32, 2148466701u32,
-                    2148499501u32, 2148139008u32, 2148270091u32, 2148401165u32,
-                    2148663316u32, 2148761609u32, 2148892711u32, 2148925480u32,
-                    2148958249u32, 2148991018u32, 2149023787u32, 2149089324u32,
+                    2148171818u32, 2148204544u32, 2148237356u32, 2148302890u32,
+                    2148335627u32, 2148368428u32, 2148433962u32, 2148466701u32,
+                    2148499500u32, 2148139008u32, 2148270091u32, 2148401165u32,
+                    2148663316u32, 2148761609u32, 2148892710u32, 2148925479u32,
+                    2148958248u32, 2148991017u32, 2149023786u32, 2149089323u32,
                     2147713024u32, 2147745799u32, 2147778568u32, 2147876875u32,
                     2147909644u32, 2147942413u32, 2147975182u32, 2148007953u32,
-                    2148040723u32, 2148827154u32, 2148892711u32, 2148925480u32,
-                    2148958249u32, 2148991018u32, 2149023787u32, 2149089324u32,
+                    2148040723u32, 2148827154u32, 2148892710u32, 2148925479u32,
+                    2148958248u32, 2148991017u32, 2149023786u32, 2149089323u32,
                     2147713024u32, 2147745799u32, 2147778568u32, 2147876875u32,
                     2147909644u32, 2147942413u32, 2147975182u32, 2148007953u32,
-                    2148040723u32, 2148892711u32, 2148925480u32, 2148958249u32,
-                    2148991018u32, 2149089324u32, 2147713024u32, 2147745799u32,
+                    2148040723u32, 2148892710u32, 2148925479u32, 2148958248u32,
+                    2148991017u32, 2149089323u32, 2147713024u32, 2147745799u32,
                     2147778568u32, 2147876875u32, 2147909644u32, 2147942413u32,
-                    2147975182u32, 2148007953u32, 2148040723u32, 2148892711u32,
-                    2148925480u32, 2148958249u32, 2148991018u32, 2147713024u32,
+                    2147975182u32, 2148007953u32, 2148040723u32, 2148892710u32,
+                    2148925479u32, 2148958248u32, 2148991017u32, 2147713024u32,
                     2147745799u32, 2147778568u32, 2147876875u32, 2147909644u32,
                     2147942413u32, 2147975182u32, 2148007953u32, 2148040723u32,
-                    2148892711u32, 2148925480u32, 2148958249u32, 2148991018u32,
-                    2149023787u32, 2149089324u32, 2149285891u32, 2149351442u32,
+                    2148892710u32, 2148925479u32, 2148958248u32, 2148991017u32,
+                    2149023786u32, 2149089323u32, 2149285891u32, 2149351442u32,
                     2147713024u32, 2147745799u32, 2147778568u32, 2147876875u32,
                     2147909644u32, 2147942413u32, 2147975182u32, 2148007953u32,
-                    2148040723u32, 2149416969u32, 2148892711u32, 2148925480u32,
-                    2148958249u32, 2148991018u32, 2149023787u32, 2149089324u32,
-                    2149646381u32, 2149449767u32, 2149515304u32, 2149580845u32,
+                    2148040723u32, 2149416969u32, 2148892710u32, 2148925479u32,
+                    2148958248u32, 2148991017u32, 2149023786u32, 2149089323u32,
+                    2149646380u32, 2149449766u32, 2149515303u32, 2149580844u32,
                     2149482514u32, 2149548050u32, 2149613586u32, 2149679122u32,
-                    2149744658u32, 2148892711u32, 2148925480u32, 2148958249u32,
-                    2148991018u32, 2149023787u32, 2149089324u32, 2149842947u32,
-                    3145766u32, 2147647488u32, 2147745799u32, 2147778568u32,
+                    2149744658u32, 2148892710u32, 2148925479u32, 2148958248u32,
+                    2148991017u32, 2149023786u32, 2149089323u32, 2149842947u32,
+                    3145765u32, 2147647488u32, 2147745799u32, 2147778568u32,
                     2147876875u32, 2147909644u32, 2147942413u32, 2147975182u32,
-                    2148007953u32, 2148040723u32, 2148892711u32, 2148925480u32,
-                    2148958249u32, 2148991018u32, 2149023787u32, 2149089324u32,
+                    2148007953u32, 2148040723u32, 2148892710u32, 2148925479u32,
+                    2148958248u32, 2148991017u32, 2149023786u32, 2149089323u32,
                     2147647488u32, 2147745799u32, 2147778568u32, 2147876875u32,
                     2147909644u32, 2147942413u32, 2147975182u32, 2148007953u32,
                     2148040723u32, 2150072324u32, 2150105119u32, 2150301731u32,
-                    2150400045u32, 2150137856u32, 2150170635u32, 2150203405u32,
-                    2150236205u32, 2150334474u32, 2150367277u32, 2150072324u32,
+                    2150400044u32, 2150137856u32, 2150170635u32, 2150203405u32,
+                    2150236204u32, 2150334474u32, 2150367276u32, 2150072324u32,
                     2150563856u32, 2150727701u32, 2150957078u32, 2151120919u32,
                     2151415832u32, 2151579673u32, 2151710746u32, 2151841819u32,
                     2151972892u32, 2152103965u32, 2152235038u32, 2152366112u32,
-                    2152529953u32, 2152661026u32, 2152792100u32, 2152923173u32,
-                    2153054253u32, 2150137856u32, 2150170635u32, 2150203405u32,
-                    2150760493u32, 3309606u32, 2150137856u32, 2150170635u32,
-                    2150203405u32, 3407910u32, 2150137856u32, 2150170635u32,
-                    2150203405u32, 2150989869u32, 3538982u32, 2150137856u32,
-                    2150170635u32, 2150203405u32, 3604518u32, 2151153664u32,
-                    2151350317u32, 2151219200u32, 2151219201u32, 2151219202u32,
-                    2151219203u32, 2151219204u32, 2151219205u32, 2151219206u32,
-                    2151219207u32, 2151219208u32, 2151219209u32, 2151219210u32,
-                    2151219211u32, 2151219212u32, 2151219213u32, 2151219214u32,
-                    2151219215u32, 2151219216u32, 2151219217u32, 2151219218u32,
-                    2151219219u32, 2151219220u32, 2151219221u32, 2151219222u32,
-                    2151219223u32, 2151219224u32, 2151219225u32, 2151219226u32,
-                    2151219227u32, 2151219228u32, 2151219229u32, 2151219230u32,
-                    2151219231u32, 2151219232u32, 2151219233u32, 2151219234u32,
-                    2151219235u32, 2151219236u32, 2151219237u32, 3702822u32,
-                    2151219239u32, 2151219240u32, 2151219241u32, 2151219242u32,
-                    2151219243u32, 2151219244u32, 2151317504u32, 2151317505u32,
+                    2152529953u32, 2152661026u32, 2152792100u32, 2152923180u32,
+                    2150137856u32, 2150170635u32, 2150203405u32, 2150760492u32,
+                    3309605u32, 2150137856u32, 2150170635u32, 2150203405u32, 3407909u32,
+                    2150137856u32, 2150170635u32, 2150203405u32, 2150989868u32,
+                    3538981u32, 2150137856u32, 2150170635u32, 2150203405u32, 3604517u32,
+                    2151153664u32, 2151350316u32, 2151219200u32, 2151219201u32,
+                    2151219202u32, 2151219203u32, 2151219204u32, 2151219205u32,
+                    2151219206u32, 2151219207u32, 2151219208u32, 2151219209u32,
+                    2151219210u32, 2151219211u32, 2151219212u32, 2151219213u32,
+                    2151219214u32, 2151219215u32, 2151219216u32, 2151219217u32,
+                    2151219218u32, 2151219219u32, 2151219220u32, 2151219221u32,
+                    2151219222u32, 2151219223u32, 2151219224u32, 2151219225u32,
+                    2151219226u32, 2151219227u32, 2151219228u32, 2151219229u32,
+                    2151219230u32, 2151219231u32, 2151219232u32, 2151219233u32,
+                    2151219234u32, 2151219235u32, 2151219236u32, 3702821u32,
+                    2151219238u32, 2151219239u32, 2151219240u32, 2151219241u32,
+                    2151219242u32, 2151219243u32, 2151317504u32, 2151317505u32,
                     2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
                     2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
                     2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
@@ -6879,10 +6750,102 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
                     2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
                     2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
-                    2151317538u32, 2151317539u32, 2151317540u32, 2151317541u32,
-                    3801126u32, 2151317543u32, 2151317544u32, 2151317545u32,
-                    2151317546u32, 2151317547u32, 2151317548u32, 3899430u32,
-                    2151448576u32, 2151514157u32, 3997734u32, 4063270u32, 2151219200u32,
+                    2151317538u32, 2151317539u32, 2151317540u32, 3801125u32,
+                    2151317542u32, 2151317543u32, 2151317544u32, 2151317545u32,
+                    2151317546u32, 2151317547u32, 3899429u32, 2151448576u32,
+                    2151514156u32, 3997733u32, 4063269u32, 2151219200u32, 2151219201u32,
+                    2151219202u32, 2151219203u32, 2151219204u32, 2151219205u32,
+                    2151219206u32, 2151219207u32, 2151219208u32, 2151219209u32,
+                    2151219210u32, 2151219211u32, 2151219212u32, 2151219213u32,
+                    2151219214u32, 2151219215u32, 2151219216u32, 2151219217u32,
+                    2151219218u32, 2151219219u32, 2151219220u32, 2151219221u32,
+                    2151219222u32, 2151219223u32, 2151219224u32, 2151219225u32,
+                    2151219226u32, 2151219227u32, 2151219228u32, 2151219229u32,
+                    2151219230u32, 2151219231u32, 2151219232u32, 2151219233u32,
+                    2151219234u32, 2151219235u32, 2151219236u32, 4128805u32,
+                    2151219238u32, 2151219239u32, 2151219240u32, 2151219241u32,
+                    2151219242u32, 2151219243u32, 2151317504u32, 2151317505u32,
+                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
+                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
+                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
+                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
+                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
+                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
+                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
+                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
+                    2151317538u32, 2151317539u32, 2151317540u32, 4194341u32,
+                    2151317542u32, 2151317543u32, 2151317544u32, 2151317545u32,
+                    2151317546u32, 2151317547u32, 2151219200u32, 2151219201u32,
+                    2151219202u32, 2151219203u32, 2151219204u32, 2151219205u32,
+                    2151219206u32, 2151219207u32, 2151219208u32, 2151219209u32,
+                    2151219210u32, 2151219211u32, 2151219212u32, 2151219213u32,
+                    2151219214u32, 2151219215u32, 2151219216u32, 2151219217u32,
+                    2151219218u32, 2151219219u32, 2151219220u32, 2151219221u32,
+                    2151219222u32, 2151219223u32, 2151219224u32, 2151219225u32,
+                    2151219226u32, 2151219227u32, 2151219228u32, 2151219229u32,
+                    2151219230u32, 2151219231u32, 2151219232u32, 2151219233u32,
+                    2151219234u32, 2151219235u32, 2151219236u32, 4259877u32,
+                    2151219238u32, 2151219239u32, 2151219240u32, 2151219241u32,
+                    2151219242u32, 2151219243u32, 2151317504u32, 2151317505u32,
+                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
+                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
+                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
+                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
+                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
+                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
+                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
+                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
+                    2151317538u32, 2151317539u32, 2151317540u32, 4325413u32,
+                    2151317542u32, 2151317543u32, 2151317544u32, 2151317545u32,
+                    2151317546u32, 2151317547u32, 2151219200u32, 2151219201u32,
+                    2151219202u32, 2151219203u32, 2151219204u32, 2151219205u32,
+                    2151219206u32, 2151219207u32, 2151219208u32, 2151219209u32,
+                    2151219210u32, 2151219211u32, 2151219212u32, 2151219213u32,
+                    2151219214u32, 2151219215u32, 2151219216u32, 2151219217u32,
+                    2151219218u32, 2151219219u32, 2151219220u32, 2151219221u32,
+                    2151219222u32, 2151219223u32, 2151219224u32, 2151219225u32,
+                    2151219226u32, 2151219227u32, 2151219228u32, 2151219229u32,
+                    2151219230u32, 2151219231u32, 2151219232u32, 2151219233u32,
+                    2151219234u32, 2151219235u32, 2151219236u32, 4390949u32,
+                    2151219238u32, 2151219239u32, 2151219240u32, 2151219241u32,
+                    2151219242u32, 2151219243u32, 2151317504u32, 2151317505u32,
+                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
+                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
+                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
+                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
+                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
+                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
+                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
+                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
+                    2151317538u32, 2151317539u32, 2151317540u32, 4456485u32,
+                    2151317542u32, 2151317543u32, 2151317544u32, 2151317545u32,
+                    2151317546u32, 2151317547u32, 2151219200u32, 2151219201u32,
+                    2151219202u32, 2151219203u32, 2151219204u32, 2151219205u32,
+                    2151219206u32, 2151219207u32, 2151219208u32, 2151219209u32,
+                    2151219210u32, 2151219211u32, 2151219212u32, 2151219213u32,
+                    2151219214u32, 2151219215u32, 2151219216u32, 2151219217u32,
+                    2151219218u32, 2151219219u32, 2151219220u32, 2151219221u32,
+                    2151219222u32, 2151219223u32, 2151219224u32, 2151219225u32,
+                    2151219226u32, 2151219227u32, 2151219228u32, 2151219229u32,
+                    2151219230u32, 2151219231u32, 2151219232u32, 2151219233u32,
+                    2151219234u32, 2151219235u32, 2151219236u32, 4522021u32,
+                    2151219238u32, 2151219239u32, 2151219240u32, 2151219241u32,
+                    2151219242u32, 2151219243u32, 2151317504u32, 2151317505u32,
+                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
+                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
+                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
+                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
+                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
+                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
+                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
+                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
+                    2151317538u32, 2151317539u32, 2151317540u32, 4587557u32,
+                    2151317542u32, 2151317543u32, 2151317544u32, 2151317545u32,
+                    2151317546u32, 2151317547u32, 4653093u32, 2152169516u32, 4718629u32,
+                    4784165u32, 2152300588u32, 4849701u32, 2150137856u32, 2150170635u32,
+                    2150203405u32, 2152398892u32, 4948005u32, 2150137856u32,
+                    2150170635u32, 2150203405u32, 5013541u32, 5079077u32, 2152595500u32,
+                    5144613u32, 5210149u32, 2152726572u32, 5275685u32, 2151219200u32,
                     2151219201u32, 2151219202u32, 2151219203u32, 2151219204u32,
                     2151219205u32, 2151219206u32, 2151219207u32, 2151219208u32,
                     2151219209u32, 2151219210u32, 2151219211u32, 2151219212u32,
@@ -6892,138 +6855,20 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     2151219225u32, 2151219226u32, 2151219227u32, 2151219228u32,
                     2151219229u32, 2151219230u32, 2151219231u32, 2151219232u32,
                     2151219233u32, 2151219234u32, 2151219235u32, 2151219236u32,
-                    2151219237u32, 4128806u32, 2151219239u32, 2151219240u32,
-                    2151219241u32, 2151219242u32, 2151219243u32, 2151219244u32,
-                    2151317504u32, 2151317505u32, 2151317506u32, 2151317507u32,
-                    2151317508u32, 2151317509u32, 2151317510u32, 2151317511u32,
-                    2151317512u32, 2151317513u32, 2151317514u32, 2151317515u32,
-                    2151317516u32, 2151317517u32, 2151317518u32, 2151317519u32,
-                    2151317520u32, 2151317521u32, 2151317522u32, 2151317523u32,
-                    2151317524u32, 2151317525u32, 2151317526u32, 2151317527u32,
-                    2151317528u32, 2151317529u32, 2151317530u32, 2151317531u32,
-                    2151317532u32, 2151317533u32, 2151317534u32, 2151317535u32,
-                    2151317536u32, 2151317537u32, 2151317538u32, 2151317539u32,
-                    2151317540u32, 2151317541u32, 4194342u32, 2151317543u32,
-                    2151317544u32, 2151317545u32, 2151317546u32, 2151317547u32,
-                    2151317548u32, 2151219200u32, 2151219201u32, 2151219202u32,
-                    2151219203u32, 2151219204u32, 2151219205u32, 2151219206u32,
-                    2151219207u32, 2151219208u32, 2151219209u32, 2151219210u32,
-                    2151219211u32, 2151219212u32, 2151219213u32, 2151219214u32,
-                    2151219215u32, 2151219216u32, 2151219217u32, 2151219218u32,
-                    2151219219u32, 2151219220u32, 2151219221u32, 2151219222u32,
-                    2151219223u32, 2151219224u32, 2151219225u32, 2151219226u32,
-                    2151219227u32, 2151219228u32, 2151219229u32, 2151219230u32,
-                    2151219231u32, 2151219232u32, 2151219233u32, 2151219234u32,
-                    2151219235u32, 2151219236u32, 2151219237u32, 4259878u32,
-                    2151219239u32, 2151219240u32, 2151219241u32, 2151219242u32,
-                    2151219243u32, 2151219244u32, 2151317504u32, 2151317505u32,
-                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
-                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
-                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
-                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
-                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
-                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
-                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
-                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
-                    2151317538u32, 2151317539u32, 2151317540u32, 2151317541u32,
-                    4325414u32, 2151317543u32, 2151317544u32, 2151317545u32,
-                    2151317546u32, 2151317547u32, 2151317548u32, 2151219200u32,
-                    2151219201u32, 2151219202u32, 2151219203u32, 2151219204u32,
-                    2151219205u32, 2151219206u32, 2151219207u32, 2151219208u32,
-                    2151219209u32, 2151219210u32, 2151219211u32, 2151219212u32,
-                    2151219213u32, 2151219214u32, 2151219215u32, 2151219216u32,
-                    2151219217u32, 2151219218u32, 2151219219u32, 2151219220u32,
-                    2151219221u32, 2151219222u32, 2151219223u32, 2151219224u32,
-                    2151219225u32, 2151219226u32, 2151219227u32, 2151219228u32,
-                    2151219229u32, 2151219230u32, 2151219231u32, 2151219232u32,
-                    2151219233u32, 2151219234u32, 2151219235u32, 2151219236u32,
-                    2151219237u32, 4390950u32, 2151219239u32, 2151219240u32,
-                    2151219241u32, 2151219242u32, 2151219243u32, 2151219244u32,
-                    2151317504u32, 2151317505u32, 2151317506u32, 2151317507u32,
-                    2151317508u32, 2151317509u32, 2151317510u32, 2151317511u32,
-                    2151317512u32, 2151317513u32, 2151317514u32, 2151317515u32,
-                    2151317516u32, 2151317517u32, 2151317518u32, 2151317519u32,
-                    2151317520u32, 2151317521u32, 2151317522u32, 2151317523u32,
-                    2151317524u32, 2151317525u32, 2151317526u32, 2151317527u32,
-                    2151317528u32, 2151317529u32, 2151317530u32, 2151317531u32,
-                    2151317532u32, 2151317533u32, 2151317534u32, 2151317535u32,
-                    2151317536u32, 2151317537u32, 2151317538u32, 2151317539u32,
-                    2151317540u32, 2151317541u32, 4456486u32, 2151317543u32,
-                    2151317544u32, 2151317545u32, 2151317546u32, 2151317547u32,
-                    2151317548u32, 2151219200u32, 2151219201u32, 2151219202u32,
-                    2151219203u32, 2151219204u32, 2151219205u32, 2151219206u32,
-                    2151219207u32, 2151219208u32, 2151219209u32, 2151219210u32,
-                    2151219211u32, 2151219212u32, 2151219213u32, 2151219214u32,
-                    2151219215u32, 2151219216u32, 2151219217u32, 2151219218u32,
-                    2151219219u32, 2151219220u32, 2151219221u32, 2151219222u32,
-                    2151219223u32, 2151219224u32, 2151219225u32, 2151219226u32,
-                    2151219227u32, 2151219228u32, 2151219229u32, 2151219230u32,
-                    2151219231u32, 2151219232u32, 2151219233u32, 2151219234u32,
-                    2151219235u32, 2151219236u32, 2151219237u32, 4522022u32,
-                    2151219239u32, 2151219240u32, 2151219241u32, 2151219242u32,
-                    2151219243u32, 2151219244u32, 2151317504u32, 2151317505u32,
-                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
-                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
-                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
-                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
-                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
-                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
-                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
-                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
-                    2151317538u32, 2151317539u32, 2151317540u32, 2151317541u32,
-                    4587558u32, 2151317543u32, 2151317544u32, 2151317545u32,
-                    2151317546u32, 2151317547u32, 2151317548u32, 4653094u32,
-                    2152169517u32, 4718630u32, 4784166u32, 2152300589u32, 4849702u32,
-                    2150137856u32, 2150170635u32, 2150203405u32, 2152398893u32,
-                    4948006u32, 2150137856u32, 2150170635u32, 2150203405u32, 5013542u32,
-                    5079078u32, 2152595501u32, 5144614u32, 5210150u32, 2152726573u32,
-                    5275686u32, 2151219200u32, 2151219201u32, 2151219202u32,
-                    2151219203u32, 2151219204u32, 2151219205u32, 2151219206u32,
-                    2151219207u32, 2151219208u32, 2151219209u32, 2151219210u32,
-                    2151219211u32, 2151219212u32, 2151219213u32, 2151219214u32,
-                    2151219215u32, 2151219216u32, 2151219217u32, 2151219218u32,
-                    2151219219u32, 2151219220u32, 2151219221u32, 2151219222u32,
-                    2151219223u32, 2151219224u32, 2151219225u32, 2151219226u32,
-                    2151219227u32, 2151219228u32, 2151219229u32, 2151219230u32,
-                    2151219231u32, 2151219232u32, 2151219233u32, 2151219234u32,
-                    2151219235u32, 2151219236u32, 2151219237u32, 5341222u32,
-                    2151219239u32, 2151219240u32, 2151219241u32, 2151219242u32,
-                    2151219243u32, 2151219244u32, 2151317504u32, 2151317505u32,
-                    2151317506u32, 2151317507u32, 2151317508u32, 2151317509u32,
-                    2151317510u32, 2151317511u32, 2151317512u32, 2151317513u32,
-                    2151317514u32, 2151317515u32, 2151317516u32, 2151317517u32,
-                    2151317518u32, 2151317519u32, 2151317520u32, 2151317521u32,
-                    2151317522u32, 2151317523u32, 2151317524u32, 2151317525u32,
-                    2151317526u32, 2151317527u32, 2151317528u32, 2151317529u32,
-                    2151317530u32, 2151317531u32, 2151317532u32, 2151317533u32,
-                    2151317534u32, 2151317535u32, 2151317536u32, 2151317537u32,
-                    2151317538u32, 2151317539u32, 2151317540u32, 2151317541u32,
-                    5406758u32, 2151317543u32, 2151317544u32, 2151317545u32,
-                    2151317546u32, 2151317547u32, 2151317548u32, 2151219200u32,
-                    2151219201u32, 2151219202u32, 2151219203u32, 2151219204u32,
-                    2151219205u32, 2151219206u32, 2151219207u32, 2151219208u32,
-                    2151219209u32, 2151219210u32, 2151219211u32, 2151219212u32,
-                    2151219213u32, 2151219214u32, 2151219215u32, 2151219216u32,
-                    2151219217u32, 2151219218u32, 2151219219u32, 2151219220u32,
-                    2151219221u32, 2151219222u32, 2151219223u32, 2151219224u32,
-                    2151219225u32, 2151219226u32, 2151219227u32, 2151219228u32,
-                    2151219229u32, 2151219230u32, 2151219231u32, 2151219232u32,
-                    2151219233u32, 2151219234u32, 2151219235u32, 2151219236u32,
-                    2151219237u32, 5472294u32, 2151219239u32, 2151219240u32,
-                    2151219241u32, 2151219242u32, 2151219243u32, 2151219244u32,
-                    2151317504u32, 2151317505u32, 2151317506u32, 2151317507u32,
-                    2151317508u32, 2151317509u32, 2151317510u32, 2151317511u32,
-                    2151317512u32, 2151317513u32, 2151317514u32, 2151317515u32,
-                    2151317516u32, 2151317517u32, 2151317518u32, 2151317519u32,
-                    2151317520u32, 2151317521u32, 2151317522u32, 2151317523u32,
-                    2151317524u32, 2151317525u32, 2151317526u32, 2151317527u32,
-                    2151317528u32, 2151317529u32, 2151317530u32, 2151317531u32,
-                    2151317532u32, 2151317533u32, 2151317534u32, 2151317535u32,
-                    2151317536u32, 2151317537u32, 2151317538u32, 2151317539u32,
-                    2151317540u32, 2151317541u32, 5537830u32, 2151317543u32,
-                    2151317544u32, 2151317545u32, 2151317546u32, 2151317547u32,
-                    2151317548u32, 5603366u32, 2147516416u32, 2150694916u32,
-                    2153250862u32,
+                    5341221u32, 2151219238u32, 2151219239u32, 2151219240u32,
+                    2151219241u32, 2151219242u32, 2151219243u32, 2151317504u32,
+                    2151317505u32, 2151317506u32, 2151317507u32, 2151317508u32,
+                    2151317509u32, 2151317510u32, 2151317511u32, 2151317512u32,
+                    2151317513u32, 2151317514u32, 2151317515u32, 2151317516u32,
+                    2151317517u32, 2151317518u32, 2151317519u32, 2151317520u32,
+                    2151317521u32, 2151317522u32, 2151317523u32, 2151317524u32,
+                    2151317525u32, 2151317526u32, 2151317527u32, 2151317528u32,
+                    2151317529u32, 2151317530u32, 2151317531u32, 2151317532u32,
+                    2151317533u32, 2151317534u32, 2151317535u32, 2151317536u32,
+                    2151317537u32, 2151317538u32, 2151317539u32, 2151317540u32,
+                    5406757u32, 2151317542u32, 2151317543u32, 2151317544u32,
+                    2151317545u32, 2151317546u32, 2151317547u32, 5472293u32,
+                    2147516416u32, 2150694916u32, 2153119789u32,
                 ];
                 static SHIFT_TERM_OFFSETS: &[u32] = &[
                     0u32, 2u32, 3u32, 3u32, 4u32, 13u32, 14u32, 23u32, 23u32, 23u32,
@@ -7037,19 +6882,19 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     170u32, 170u32, 176u32, 185u32, 185u32, 186u32, 189u32, 193u32,
                     193u32, 193u32, 193u32, 193u32, 193u32, 195u32, 195u32, 195u32,
                     195u32, 195u32, 196u32, 196u32, 197u32, 197u32, 197u32, 197u32,
-                    197u32, 213u32, 217u32, 218u32, 218u32, 218u32, 222u32, 222u32,
-                    222u32, 226u32, 227u32, 227u32, 231u32, 231u32, 233u32, 278u32,
-                    278u32, 278u32, 323u32, 323u32, 323u32, 324u32, 324u32, 326u32,
-                    327u32, 327u32, 328u32, 328u32, 373u32, 373u32, 418u32, 418u32,
-                    463u32, 463u32, 508u32, 508u32, 553u32, 553u32, 598u32, 598u32,
-                    643u32, 643u32, 688u32, 688u32, 690u32, 690u32, 691u32, 691u32,
-                    693u32, 693u32, 694u32, 694u32, 698u32, 699u32, 699u32, 703u32,
-                    703u32, 705u32, 705u32, 706u32, 706u32, 708u32, 708u32, 709u32,
-                    709u32, 754u32, 754u32, 799u32, 799u32, 844u32, 844u32, 889u32,
-                    889u32, 890u32, 890u32, 890u32, 892u32, 892u32, 893u32, 893u32,
+                    197u32, 212u32, 216u32, 217u32, 217u32, 217u32, 221u32, 221u32,
+                    221u32, 225u32, 226u32, 226u32, 230u32, 230u32, 232u32, 276u32,
+                    276u32, 276u32, 320u32, 320u32, 320u32, 321u32, 321u32, 323u32,
+                    324u32, 324u32, 325u32, 325u32, 369u32, 369u32, 413u32, 413u32,
+                    457u32, 457u32, 501u32, 501u32, 545u32, 545u32, 589u32, 589u32,
+                    633u32, 633u32, 677u32, 677u32, 679u32, 679u32, 680u32, 680u32,
+                    682u32, 682u32, 683u32, 683u32, 687u32, 688u32, 688u32, 692u32,
+                    692u32, 694u32, 694u32, 695u32, 695u32, 697u32, 697u32, 698u32,
+                    698u32, 742u32, 742u32, 786u32, 786u32, 787u32, 787u32, 787u32,
+                    789u32, 789u32, 790u32, 790u32,
                 ];
                 static SHIFT_NONTERM_DATA: &[u32] = &[
-                    2153119744u32, 5668875u32, 2153152524u32, 2153218061u32, 5734428u32,
+                    2152988672u32, 5537803u32, 2153021452u32, 2153086989u32, 5603356u32,
                     2147581953u32, 2149810178u32, 2150662147u32, 2149908485u32,
                     2148696071u32, 2149941256u32, 2149974030u32, 2150039567u32,
                     2148696071u32, 2149777416u32, 2148696071u32, 2148728840u32,
@@ -7069,8 +6914,8 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     2151317529u32, 2151219225u32, 2151907354u32, 2151317529u32,
                     2151219225u32, 2152038426u32, 2151317529u32, 2150825994u32,
                     2152464411u32, 2150924298u32, 2151219225u32, 2152857626u32,
-                    2151317529u32, 2151219225u32, 2152988698u32, 2151317529u32,
-                    2153119744u32, 5668875u32, 2153152524u32, 2153185308u32,
+                    2151317529u32, 2152988672u32, 5537803u32, 2153021452u32,
+                    2153054236u32,
                 ];
                 static SHIFT_NONTERM_OFFSETS: &[u32] = &[
                     0u32, 5u32, 6u32, 6u32, 6u32, 13u32, 13u32, 15u32, 15u32, 15u32,
@@ -7089,60 +6934,60 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     69u32, 69u32, 70u32, 70u32, 72u32, 72u32, 73u32, 73u32, 75u32, 75u32,
                     76u32, 76u32, 76u32, 76u32, 76u32, 76u32, 76u32, 76u32, 76u32, 76u32,
                     78u32, 78u32, 78u32, 79u32, 79u32, 79u32, 79u32, 79u32, 79u32, 79u32,
-                    79u32, 79u32, 79u32, 81u32, 81u32, 82u32, 82u32, 84u32, 84u32, 85u32,
-                    85u32, 85u32, 85u32, 85u32, 89u32, 89u32, 89u32, 89u32,
+                    79u32, 79u32, 79u32, 81u32, 81u32, 82u32, 82u32, 82u32, 82u32, 82u32,
+                    86u32, 86u32, 86u32, 86u32,
                 ];
                 static REDUCE_DATA: &[u32] = &[
-                    2u32, 1u32, 2u32, 2u32, 1u32, 1u32, 3u32, 1u32, 86u32, 4u32, 1u32,
-                    86u32, 16u32, 1u32, 86u32, 38u32, 1u32, 86u32, 0u32, 1u32, 24u32,
+                    2u32, 1u32, 2u32, 2u32, 1u32, 1u32, 3u32, 1u32, 84u32, 4u32, 1u32,
+                    84u32, 16u32, 1u32, 84u32, 37u32, 1u32, 84u32, 0u32, 1u32, 24u32,
                     3u32, 1u32, 24u32, 4u32, 1u32, 24u32, 7u32, 1u32, 24u32, 8u32, 1u32,
                     24u32, 11u32, 1u32, 24u32, 12u32, 1u32, 24u32, 13u32, 1u32, 24u32,
                     14u32, 1u32, 24u32, 16u32, 1u32, 24u32, 17u32, 1u32, 24u32, 19u32,
-                    1u32, 24u32, 38u32, 1u32, 24u32, 39u32, 1u32, 24u32, 40u32, 1u32,
-                    24u32, 41u32, 1u32, 24u32, 42u32, 1u32, 24u32, 43u32, 1u32, 24u32,
-                    44u32, 1u32, 24u32, 0u32, 1u32, 24u32, 3u32, 1u32, 24u32, 4u32, 1u32,
+                    1u32, 24u32, 37u32, 1u32, 24u32, 38u32, 1u32, 24u32, 39u32, 1u32,
+                    24u32, 40u32, 1u32, 24u32, 41u32, 1u32, 24u32, 42u32, 1u32, 24u32,
+                    43u32, 1u32, 24u32, 0u32, 1u32, 24u32, 3u32, 1u32, 24u32, 4u32, 1u32,
                     24u32, 7u32, 1u32, 24u32, 8u32, 1u32, 24u32, 9u32, 1u32, 24u32,
                     11u32, 1u32, 24u32, 12u32, 1u32, 24u32, 13u32, 1u32, 24u32, 14u32,
                     1u32, 24u32, 16u32, 1u32, 24u32, 17u32, 1u32, 24u32, 18u32, 1u32,
-                    24u32, 19u32, 1u32, 24u32, 38u32, 1u32, 24u32, 39u32, 1u32, 24u32,
-                    40u32, 1u32, 24u32, 41u32, 1u32, 24u32, 42u32, 1u32, 24u32, 43u32,
-                    1u32, 24u32, 44u32, 1u32, 24u32, 45u32, 1u32, 24u32, 0u32, 1u32,
+                    24u32, 19u32, 1u32, 24u32, 37u32, 1u32, 24u32, 38u32, 1u32, 24u32,
+                    39u32, 1u32, 24u32, 40u32, 1u32, 24u32, 41u32, 1u32, 24u32, 42u32,
+                    1u32, 24u32, 43u32, 1u32, 24u32, 44u32, 1u32, 24u32, 0u32, 1u32,
                     23u32, 3u32, 1u32, 23u32, 4u32, 1u32, 23u32, 7u32, 1u32, 23u32, 8u32,
                     1u32, 23u32, 9u32, 1u32, 23u32, 11u32, 1u32, 23u32, 12u32, 1u32,
                     23u32, 13u32, 1u32, 23u32, 14u32, 1u32, 23u32, 16u32, 1u32, 23u32,
-                    17u32, 1u32, 23u32, 18u32, 1u32, 23u32, 19u32, 1u32, 23u32, 38u32,
-                    1u32, 23u32, 39u32, 1u32, 23u32, 40u32, 1u32, 23u32, 41u32, 1u32,
-                    23u32, 42u32, 1u32, 23u32, 43u32, 1u32, 23u32, 44u32, 1u32, 23u32,
-                    45u32, 1u32, 23u32, 0u32, 1u32, 33u32, 3u32, 1u32, 33u32, 4u32, 1u32,
+                    17u32, 1u32, 23u32, 18u32, 1u32, 23u32, 19u32, 1u32, 23u32, 37u32,
+                    1u32, 23u32, 38u32, 1u32, 23u32, 39u32, 1u32, 23u32, 40u32, 1u32,
+                    23u32, 41u32, 1u32, 23u32, 42u32, 1u32, 23u32, 43u32, 1u32, 23u32,
+                    44u32, 1u32, 23u32, 0u32, 1u32, 33u32, 3u32, 1u32, 33u32, 4u32, 1u32,
                     33u32, 7u32, 1u32, 33u32, 8u32, 1u32, 33u32, 9u32, 1u32, 33u32,
                     11u32, 1u32, 33u32, 12u32, 1u32, 33u32, 13u32, 1u32, 33u32, 14u32,
                     1u32, 33u32, 16u32, 1u32, 33u32, 17u32, 1u32, 33u32, 18u32, 1u32,
-                    33u32, 19u32, 1u32, 33u32, 38u32, 1u32, 33u32, 39u32, 1u32, 33u32,
-                    40u32, 1u32, 33u32, 41u32, 1u32, 33u32, 42u32, 1u32, 33u32, 43u32,
-                    1u32, 33u32, 44u32, 1u32, 33u32, 45u32, 1u32, 33u32, 0u32, 1u32,
+                    33u32, 19u32, 1u32, 33u32, 37u32, 1u32, 33u32, 38u32, 1u32, 33u32,
+                    39u32, 1u32, 33u32, 40u32, 1u32, 33u32, 41u32, 1u32, 33u32, 42u32,
+                    1u32, 33u32, 43u32, 1u32, 33u32, 44u32, 1u32, 33u32, 0u32, 1u32,
                     34u32, 3u32, 1u32, 34u32, 4u32, 1u32, 34u32, 7u32, 1u32, 34u32, 8u32,
                     1u32, 34u32, 9u32, 1u32, 34u32, 11u32, 1u32, 34u32, 12u32, 1u32,
                     34u32, 13u32, 1u32, 34u32, 14u32, 1u32, 34u32, 16u32, 1u32, 34u32,
-                    17u32, 1u32, 34u32, 18u32, 1u32, 34u32, 19u32, 1u32, 34u32, 38u32,
-                    1u32, 34u32, 39u32, 1u32, 34u32, 40u32, 1u32, 34u32, 41u32, 1u32,
-                    34u32, 42u32, 1u32, 34u32, 43u32, 1u32, 34u32, 44u32, 1u32, 34u32,
-                    45u32, 1u32, 34u32, 0u32, 1u32, 35u32, 3u32, 1u32, 35u32, 4u32, 1u32,
+                    17u32, 1u32, 34u32, 18u32, 1u32, 34u32, 19u32, 1u32, 34u32, 37u32,
+                    1u32, 34u32, 38u32, 1u32, 34u32, 39u32, 1u32, 34u32, 40u32, 1u32,
+                    34u32, 41u32, 1u32, 34u32, 42u32, 1u32, 34u32, 43u32, 1u32, 34u32,
+                    44u32, 1u32, 34u32, 0u32, 1u32, 35u32, 3u32, 1u32, 35u32, 4u32, 1u32,
                     35u32, 7u32, 1u32, 35u32, 8u32, 1u32, 35u32, 9u32, 1u32, 35u32,
                     11u32, 1u32, 35u32, 12u32, 1u32, 35u32, 13u32, 1u32, 35u32, 14u32,
                     1u32, 35u32, 16u32, 1u32, 35u32, 17u32, 1u32, 35u32, 18u32, 1u32,
-                    35u32, 19u32, 1u32, 35u32, 38u32, 1u32, 35u32, 39u32, 1u32, 35u32,
-                    40u32, 1u32, 35u32, 41u32, 1u32, 35u32, 42u32, 1u32, 35u32, 43u32,
-                    1u32, 35u32, 44u32, 1u32, 35u32, 45u32, 1u32, 35u32, 0u32, 1u32,
+                    35u32, 19u32, 1u32, 35u32, 37u32, 1u32, 35u32, 38u32, 1u32, 35u32,
+                    39u32, 1u32, 35u32, 40u32, 1u32, 35u32, 41u32, 1u32, 35u32, 42u32,
+                    1u32, 35u32, 43u32, 1u32, 35u32, 44u32, 1u32, 35u32, 0u32, 1u32,
                     36u32, 3u32, 1u32, 36u32, 4u32, 1u32, 36u32, 7u32, 1u32, 36u32, 8u32,
                     1u32, 36u32, 9u32, 1u32, 36u32, 11u32, 1u32, 36u32, 12u32, 1u32,
                     36u32, 13u32, 1u32, 36u32, 14u32, 1u32, 36u32, 16u32, 1u32, 36u32,
-                    17u32, 1u32, 36u32, 18u32, 1u32, 36u32, 19u32, 1u32, 36u32, 38u32,
-                    1u32, 36u32, 39u32, 1u32, 36u32, 40u32, 1u32, 36u32, 41u32, 1u32,
-                    36u32, 42u32, 1u32, 36u32, 43u32, 1u32, 36u32, 44u32, 1u32, 36u32,
-                    45u32, 1u32, 36u32, 3u32, 1u32, 100u32, 18u32, 1u32, 100u32, 0u32,
-                    1u32, 92u32, 11u32, 1u32, 92u32, 13u32, 1u32, 92u32, 20u32, 1u32,
-                    92u32, 0u32, 1u32, 91u32, 11u32, 1u32, 91u32, 13u32, 1u32, 91u32,
-                    20u32, 1u32, 91u32, 20u32, 1u32, 96u32, 0u32, 1u32, 13u32, 11u32,
+                    17u32, 1u32, 36u32, 18u32, 1u32, 36u32, 19u32, 1u32, 36u32, 37u32,
+                    1u32, 36u32, 38u32, 1u32, 36u32, 39u32, 1u32, 36u32, 40u32, 1u32,
+                    36u32, 41u32, 1u32, 36u32, 42u32, 1u32, 36u32, 43u32, 1u32, 36u32,
+                    44u32, 1u32, 36u32, 3u32, 1u32, 98u32, 18u32, 1u32, 98u32, 0u32,
+                    1u32, 90u32, 11u32, 1u32, 90u32, 13u32, 1u32, 90u32, 20u32, 1u32,
+                    90u32, 0u32, 1u32, 89u32, 11u32, 1u32, 89u32, 13u32, 1u32, 89u32,
+                    20u32, 1u32, 89u32, 20u32, 1u32, 94u32, 0u32, 1u32, 13u32, 11u32,
                     1u32, 13u32, 13u32, 1u32, 13u32, 20u32, 1u32, 13u32, 0u32, 1u32,
                     14u32, 11u32, 1u32, 14u32, 13u32, 1u32, 14u32, 20u32, 1u32, 14u32,
                     0u32, 1u32, 15u32, 11u32, 1u32, 15u32, 13u32, 1u32, 15u32, 20u32,
@@ -7153,212 +6998,210 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     16u32, 11u32, 1u32, 16u32, 13u32, 1u32, 16u32, 20u32, 1u32, 16u32,
                     0u32, 1u32, 17u32, 11u32, 1u32, 17u32, 13u32, 1u32, 17u32, 20u32,
                     1u32, 17u32, 0u32, 1u32, 18u32, 11u32, 1u32, 18u32, 13u32, 1u32,
-                    18u32, 20u32, 1u32, 18u32, 0u32, 1u32, 93u32, 11u32, 1u32, 93u32,
-                    13u32, 1u32, 93u32, 20u32, 1u32, 93u32, 20u32, 1u32, 95u32, 0u32,
-                    1u32, 94u32, 11u32, 1u32, 94u32, 13u32, 1u32, 94u32, 20u32, 1u32,
-                    94u32, 0u32, 1u32, 22u32, 3u32, 1u32, 22u32, 4u32, 1u32, 22u32, 7u32,
+                    18u32, 20u32, 1u32, 18u32, 0u32, 1u32, 91u32, 11u32, 1u32, 91u32,
+                    13u32, 1u32, 91u32, 20u32, 1u32, 91u32, 20u32, 1u32, 93u32, 0u32,
+                    1u32, 92u32, 11u32, 1u32, 92u32, 13u32, 1u32, 92u32, 20u32, 1u32,
+                    92u32, 0u32, 1u32, 22u32, 3u32, 1u32, 22u32, 4u32, 1u32, 22u32, 7u32,
                     1u32, 22u32, 8u32, 1u32, 22u32, 9u32, 1u32, 22u32, 11u32, 1u32,
                     22u32, 12u32, 1u32, 22u32, 13u32, 1u32, 22u32, 14u32, 1u32, 22u32,
                     16u32, 1u32, 22u32, 17u32, 1u32, 22u32, 18u32, 1u32, 22u32, 19u32,
-                    1u32, 22u32, 38u32, 1u32, 22u32, 39u32, 1u32, 22u32, 40u32, 1u32,
-                    22u32, 41u32, 1u32, 22u32, 42u32, 1u32, 22u32, 43u32, 1u32, 22u32,
-                    44u32, 1u32, 22u32, 45u32, 1u32, 22u32, 0u32, 1u32, 29u32, 3u32,
+                    1u32, 22u32, 37u32, 1u32, 22u32, 38u32, 1u32, 22u32, 39u32, 1u32,
+                    22u32, 40u32, 1u32, 22u32, 41u32, 1u32, 22u32, 42u32, 1u32, 22u32,
+                    43u32, 1u32, 22u32, 44u32, 1u32, 22u32, 0u32, 1u32, 29u32, 3u32,
                     1u32, 29u32, 4u32, 1u32, 29u32, 7u32, 1u32, 29u32, 8u32, 1u32, 29u32,
                     9u32, 1u32, 29u32, 11u32, 1u32, 29u32, 12u32, 1u32, 29u32, 13u32,
                     1u32, 29u32, 14u32, 1u32, 29u32, 16u32, 1u32, 29u32, 17u32, 1u32,
-                    29u32, 18u32, 1u32, 29u32, 19u32, 1u32, 29u32, 38u32, 1u32, 29u32,
-                    39u32, 1u32, 29u32, 40u32, 1u32, 29u32, 41u32, 1u32, 29u32, 42u32,
-                    1u32, 29u32, 43u32, 1u32, 29u32, 44u32, 1u32, 29u32, 45u32, 1u32,
+                    29u32, 18u32, 1u32, 29u32, 19u32, 1u32, 29u32, 37u32, 1u32, 29u32,
+                    38u32, 1u32, 29u32, 39u32, 1u32, 29u32, 40u32, 1u32, 29u32, 41u32,
+                    1u32, 29u32, 42u32, 1u32, 29u32, 43u32, 1u32, 29u32, 44u32, 1u32,
                     29u32, 0u32, 1u32, 32u32, 3u32, 1u32, 32u32, 4u32, 1u32, 32u32, 7u32,
                     1u32, 32u32, 8u32, 1u32, 32u32, 9u32, 1u32, 32u32, 11u32, 1u32,
                     32u32, 12u32, 1u32, 32u32, 13u32, 1u32, 32u32, 14u32, 1u32, 32u32,
                     16u32, 1u32, 32u32, 17u32, 1u32, 32u32, 18u32, 1u32, 32u32, 19u32,
-                    1u32, 32u32, 38u32, 1u32, 32u32, 39u32, 1u32, 32u32, 40u32, 1u32,
-                    32u32, 41u32, 1u32, 32u32, 42u32, 1u32, 32u32, 43u32, 1u32, 32u32,
-                    44u32, 1u32, 32u32, 45u32, 1u32, 32u32, 0u32, 1u32, 97u32, 3u32,
-                    1u32, 97u32, 7u32, 1u32, 97u32, 8u32, 1u32, 97u32, 11u32, 1u32,
-                    97u32, 12u32, 1u32, 97u32, 13u32, 1u32, 97u32, 14u32, 1u32, 97u32,
-                    17u32, 1u32, 97u32, 18u32, 1u32, 97u32, 19u32, 1u32, 97u32, 0u32,
+                    1u32, 32u32, 37u32, 1u32, 32u32, 38u32, 1u32, 32u32, 39u32, 1u32,
+                    32u32, 40u32, 1u32, 32u32, 41u32, 1u32, 32u32, 42u32, 1u32, 32u32,
+                    43u32, 1u32, 32u32, 44u32, 1u32, 32u32, 0u32, 1u32, 95u32, 3u32,
+                    1u32, 95u32, 7u32, 1u32, 95u32, 8u32, 1u32, 95u32, 11u32, 1u32,
+                    95u32, 12u32, 1u32, 95u32, 13u32, 1u32, 95u32, 14u32, 1u32, 95u32,
+                    17u32, 1u32, 95u32, 18u32, 1u32, 95u32, 19u32, 1u32, 95u32, 0u32,
                     1u32, 25u32, 3u32, 1u32, 25u32, 4u32, 1u32, 25u32, 7u32, 1u32, 25u32,
                     8u32, 1u32, 25u32, 9u32, 1u32, 25u32, 11u32, 1u32, 25u32, 12u32,
                     1u32, 25u32, 13u32, 1u32, 25u32, 14u32, 1u32, 25u32, 16u32, 1u32,
                     25u32, 17u32, 1u32, 25u32, 18u32, 1u32, 25u32, 19u32, 1u32, 25u32,
-                    38u32, 1u32, 25u32, 39u32, 1u32, 25u32, 40u32, 1u32, 25u32, 41u32,
-                    1u32, 25u32, 42u32, 1u32, 25u32, 43u32, 1u32, 25u32, 44u32, 1u32,
-                    25u32, 45u32, 1u32, 25u32, 0u32, 1u32, 26u32, 3u32, 1u32, 26u32,
+                    37u32, 1u32, 25u32, 38u32, 1u32, 25u32, 39u32, 1u32, 25u32, 40u32,
+                    1u32, 25u32, 41u32, 1u32, 25u32, 42u32, 1u32, 25u32, 43u32, 1u32,
+                    25u32, 44u32, 1u32, 25u32, 0u32, 1u32, 26u32, 3u32, 1u32, 26u32,
                     4u32, 1u32, 26u32, 7u32, 1u32, 26u32, 8u32, 1u32, 26u32, 9u32, 1u32,
                     26u32, 11u32, 1u32, 26u32, 12u32, 1u32, 26u32, 13u32, 1u32, 26u32,
                     14u32, 1u32, 26u32, 16u32, 1u32, 26u32, 17u32, 1u32, 26u32, 18u32,
-                    1u32, 26u32, 19u32, 1u32, 26u32, 38u32, 1u32, 26u32, 39u32, 1u32,
-                    26u32, 40u32, 1u32, 26u32, 41u32, 1u32, 26u32, 42u32, 1u32, 26u32,
-                    43u32, 1u32, 26u32, 44u32, 1u32, 26u32, 45u32, 1u32, 26u32, 0u32,
+                    1u32, 26u32, 19u32, 1u32, 26u32, 37u32, 1u32, 26u32, 38u32, 1u32,
+                    26u32, 39u32, 1u32, 26u32, 40u32, 1u32, 26u32, 41u32, 1u32, 26u32,
+                    42u32, 1u32, 26u32, 43u32, 1u32, 26u32, 44u32, 1u32, 26u32, 0u32,
                     1u32, 27u32, 3u32, 1u32, 27u32, 4u32, 1u32, 27u32, 7u32, 1u32, 27u32,
                     8u32, 1u32, 27u32, 9u32, 1u32, 27u32, 11u32, 1u32, 27u32, 12u32,
                     1u32, 27u32, 13u32, 1u32, 27u32, 14u32, 1u32, 27u32, 16u32, 1u32,
                     27u32, 17u32, 1u32, 27u32, 18u32, 1u32, 27u32, 19u32, 1u32, 27u32,
-                    38u32, 1u32, 27u32, 39u32, 1u32, 27u32, 40u32, 1u32, 27u32, 41u32,
-                    1u32, 27u32, 42u32, 1u32, 27u32, 43u32, 1u32, 27u32, 44u32, 1u32,
-                    27u32, 45u32, 1u32, 27u32, 0u32, 1u32, 28u32, 3u32, 1u32, 28u32,
+                    37u32, 1u32, 27u32, 38u32, 1u32, 27u32, 39u32, 1u32, 27u32, 40u32,
+                    1u32, 27u32, 41u32, 1u32, 27u32, 42u32, 1u32, 27u32, 43u32, 1u32,
+                    27u32, 44u32, 1u32, 27u32, 0u32, 1u32, 28u32, 3u32, 1u32, 28u32,
                     4u32, 1u32, 28u32, 7u32, 1u32, 28u32, 8u32, 1u32, 28u32, 9u32, 1u32,
                     28u32, 11u32, 1u32, 28u32, 12u32, 1u32, 28u32, 13u32, 1u32, 28u32,
                     14u32, 1u32, 28u32, 16u32, 1u32, 28u32, 17u32, 1u32, 28u32, 18u32,
-                    1u32, 28u32, 19u32, 1u32, 28u32, 38u32, 1u32, 28u32, 39u32, 1u32,
-                    28u32, 40u32, 1u32, 28u32, 41u32, 1u32, 28u32, 42u32, 1u32, 28u32,
-                    43u32, 1u32, 28u32, 44u32, 1u32, 28u32, 45u32, 1u32, 28u32, 0u32,
+                    1u32, 28u32, 19u32, 1u32, 28u32, 37u32, 1u32, 28u32, 38u32, 1u32,
+                    28u32, 39u32, 1u32, 28u32, 40u32, 1u32, 28u32, 41u32, 1u32, 28u32,
+                    42u32, 1u32, 28u32, 43u32, 1u32, 28u32, 44u32, 1u32, 28u32, 0u32,
                     1u32, 37u32, 3u32, 1u32, 37u32, 4u32, 1u32, 37u32, 7u32, 1u32, 37u32,
                     8u32, 1u32, 37u32, 9u32, 1u32, 37u32, 11u32, 1u32, 37u32, 12u32,
                     1u32, 37u32, 13u32, 1u32, 37u32, 14u32, 1u32, 37u32, 16u32, 1u32,
                     37u32, 17u32, 1u32, 37u32, 18u32, 1u32, 37u32, 19u32, 1u32, 37u32,
-                    38u32, 1u32, 37u32, 43u32, 1u32, 37u32, 45u32, 1u32, 37u32, 0u32,
+                    37u32, 1u32, 37u32, 42u32, 1u32, 37u32, 44u32, 1u32, 37u32, 0u32,
                     1u32, 30u32, 3u32, 1u32, 30u32, 4u32, 1u32, 30u32, 7u32, 1u32, 30u32,
                     8u32, 1u32, 30u32, 9u32, 1u32, 30u32, 11u32, 1u32, 30u32, 12u32,
                     1u32, 30u32, 13u32, 1u32, 30u32, 14u32, 1u32, 30u32, 16u32, 1u32,
                     30u32, 17u32, 1u32, 30u32, 18u32, 1u32, 30u32, 19u32, 1u32, 30u32,
-                    38u32, 1u32, 30u32, 43u32, 1u32, 30u32, 44u32, 1u32, 30u32, 45u32,
-                    1u32, 30u32, 3u32, 1u32, 99u32, 18u32, 1u32, 99u32, 0u32, 1u32,
-                    98u32, 3u32, 1u32, 98u32, 7u32, 1u32, 98u32, 8u32, 1u32, 98u32,
-                    11u32, 1u32, 98u32, 12u32, 1u32, 98u32, 13u32, 1u32, 98u32, 14u32,
-                    1u32, 98u32, 17u32, 1u32, 98u32, 18u32, 1u32, 98u32, 19u32, 1u32,
-                    98u32, 3u32, 1u32, 101u32, 18u32, 1u32, 101u32, 3u32, 1u32, 100u32,
-                    18u32, 1u32, 100u32, 3u32, 1u32, 102u32, 18u32, 1u32, 102u32, 0u32,
+                    37u32, 1u32, 30u32, 42u32, 1u32, 30u32, 43u32, 1u32, 30u32, 44u32,
+                    1u32, 30u32, 3u32, 1u32, 97u32, 18u32, 1u32, 97u32, 0u32, 1u32,
+                    96u32, 3u32, 1u32, 96u32, 7u32, 1u32, 96u32, 8u32, 1u32, 96u32,
+                    11u32, 1u32, 96u32, 12u32, 1u32, 96u32, 13u32, 1u32, 96u32, 14u32,
+                    1u32, 96u32, 17u32, 1u32, 96u32, 18u32, 1u32, 96u32, 19u32, 1u32,
+                    96u32, 3u32, 1u32, 99u32, 18u32, 1u32, 99u32, 3u32, 1u32, 98u32,
+                    18u32, 1u32, 98u32, 3u32, 1u32, 100u32, 18u32, 1u32, 100u32, 0u32,
                     1u32, 31u32, 3u32, 1u32, 31u32, 4u32, 1u32, 31u32, 7u32, 1u32, 31u32,
                     8u32, 1u32, 31u32, 9u32, 1u32, 31u32, 11u32, 1u32, 31u32, 12u32,
                     1u32, 31u32, 13u32, 1u32, 31u32, 14u32, 1u32, 31u32, 16u32, 1u32,
                     31u32, 17u32, 1u32, 31u32, 18u32, 1u32, 31u32, 19u32, 1u32, 31u32,
-                    38u32, 1u32, 31u32, 39u32, 1u32, 31u32, 40u32, 1u32, 31u32, 41u32,
-                    1u32, 31u32, 42u32, 1u32, 31u32, 43u32, 1u32, 31u32, 44u32, 1u32,
-                    31u32, 45u32, 1u32, 31u32, 18u32, 1u32, 104u32, 18u32, 1u32, 103u32,
+                    37u32, 1u32, 31u32, 38u32, 1u32, 31u32, 39u32, 1u32, 31u32, 40u32,
+                    1u32, 31u32, 41u32, 1u32, 31u32, 42u32, 1u32, 31u32, 43u32, 1u32,
+                    31u32, 44u32, 1u32, 31u32, 18u32, 1u32, 102u32, 18u32, 1u32, 101u32,
                     0u32, 1u32, 39u32, 3u32, 1u32, 39u32, 4u32, 1u32, 39u32, 7u32, 1u32,
                     39u32, 8u32, 1u32, 39u32, 9u32, 1u32, 39u32, 11u32, 1u32, 39u32,
                     12u32, 1u32, 39u32, 13u32, 1u32, 39u32, 14u32, 1u32, 39u32, 16u32,
                     1u32, 39u32, 17u32, 1u32, 39u32, 18u32, 1u32, 39u32, 19u32, 1u32,
-                    39u32, 38u32, 1u32, 39u32, 39u32, 1u32, 39u32, 40u32, 1u32, 39u32,
-                    41u32, 1u32, 39u32, 42u32, 1u32, 39u32, 43u32, 1u32, 39u32, 44u32,
-                    1u32, 39u32, 45u32, 1u32, 39u32, 0u32, 1u32, 40u32, 3u32, 1u32,
+                    39u32, 37u32, 1u32, 39u32, 38u32, 1u32, 39u32, 39u32, 1u32, 39u32,
+                    40u32, 1u32, 39u32, 41u32, 1u32, 39u32, 42u32, 1u32, 39u32, 43u32,
+                    1u32, 39u32, 44u32, 1u32, 39u32, 0u32, 1u32, 40u32, 3u32, 1u32,
                     40u32, 4u32, 1u32, 40u32, 7u32, 1u32, 40u32, 8u32, 1u32, 40u32, 9u32,
                     1u32, 40u32, 11u32, 1u32, 40u32, 12u32, 1u32, 40u32, 13u32, 1u32,
                     40u32, 14u32, 1u32, 40u32, 16u32, 1u32, 40u32, 17u32, 1u32, 40u32,
-                    18u32, 1u32, 40u32, 19u32, 1u32, 40u32, 38u32, 1u32, 40u32, 39u32,
-                    1u32, 40u32, 40u32, 1u32, 40u32, 41u32, 1u32, 40u32, 42u32, 1u32,
-                    40u32, 43u32, 1u32, 40u32, 44u32, 1u32, 40u32, 45u32, 1u32, 40u32,
+                    18u32, 1u32, 40u32, 19u32, 1u32, 40u32, 37u32, 1u32, 40u32, 38u32,
+                    1u32, 40u32, 39u32, 1u32, 40u32, 40u32, 1u32, 40u32, 41u32, 1u32,
+                    40u32, 42u32, 1u32, 40u32, 43u32, 1u32, 40u32, 44u32, 1u32, 40u32,
                     0u32, 1u32, 42u32, 3u32, 1u32, 42u32, 4u32, 1u32, 42u32, 7u32, 1u32,
                     42u32, 8u32, 1u32, 42u32, 9u32, 1u32, 42u32, 11u32, 1u32, 42u32,
                     12u32, 1u32, 42u32, 13u32, 1u32, 42u32, 14u32, 1u32, 42u32, 16u32,
                     1u32, 42u32, 17u32, 1u32, 42u32, 18u32, 1u32, 42u32, 19u32, 1u32,
-                    42u32, 38u32, 1u32, 42u32, 39u32, 1u32, 42u32, 40u32, 1u32, 42u32,
-                    41u32, 1u32, 42u32, 42u32, 1u32, 42u32, 43u32, 1u32, 42u32, 44u32,
-                    1u32, 42u32, 45u32, 1u32, 42u32, 0u32, 1u32, 41u32, 3u32, 1u32,
+                    42u32, 37u32, 1u32, 42u32, 38u32, 1u32, 42u32, 39u32, 1u32, 42u32,
+                    40u32, 1u32, 42u32, 41u32, 1u32, 42u32, 42u32, 1u32, 42u32, 43u32,
+                    1u32, 42u32, 44u32, 1u32, 42u32, 0u32, 1u32, 41u32, 3u32, 1u32,
                     41u32, 4u32, 1u32, 41u32, 7u32, 1u32, 41u32, 8u32, 1u32, 41u32, 9u32,
                     1u32, 41u32, 11u32, 1u32, 41u32, 12u32, 1u32, 41u32, 13u32, 1u32,
                     41u32, 14u32, 1u32, 41u32, 16u32, 1u32, 41u32, 17u32, 1u32, 41u32,
-                    18u32, 1u32, 41u32, 19u32, 1u32, 41u32, 38u32, 1u32, 41u32, 39u32,
-                    1u32, 41u32, 40u32, 1u32, 41u32, 41u32, 1u32, 41u32, 42u32, 1u32,
-                    41u32, 43u32, 1u32, 41u32, 44u32, 1u32, 41u32, 45u32, 1u32, 41u32,
+                    18u32, 1u32, 41u32, 19u32, 1u32, 41u32, 37u32, 1u32, 41u32, 38u32,
+                    1u32, 41u32, 39u32, 1u32, 41u32, 40u32, 1u32, 41u32, 41u32, 1u32,
+                    41u32, 42u32, 1u32, 41u32, 43u32, 1u32, 41u32, 44u32, 1u32, 41u32,
                     0u32, 1u32, 38u32, 3u32, 1u32, 38u32, 4u32, 1u32, 38u32, 7u32, 1u32,
                     38u32, 8u32, 1u32, 38u32, 9u32, 1u32, 38u32, 11u32, 1u32, 38u32,
                     12u32, 1u32, 38u32, 13u32, 1u32, 38u32, 14u32, 1u32, 38u32, 16u32,
                     1u32, 38u32, 17u32, 1u32, 38u32, 18u32, 1u32, 38u32, 19u32, 1u32,
-                    38u32, 38u32, 1u32, 38u32, 39u32, 1u32, 38u32, 40u32, 1u32, 38u32,
-                    41u32, 1u32, 38u32, 42u32, 1u32, 38u32, 43u32, 1u32, 38u32, 44u32,
-                    1u32, 38u32, 45u32, 1u32, 38u32, 0u32, 1u32, 12u32, 3u32, 1u32,
+                    38u32, 37u32, 1u32, 38u32, 38u32, 1u32, 38u32, 39u32, 1u32, 38u32,
+                    40u32, 1u32, 38u32, 41u32, 1u32, 38u32, 42u32, 1u32, 38u32, 43u32,
+                    1u32, 38u32, 44u32, 1u32, 38u32, 0u32, 1u32, 12u32, 3u32, 1u32,
                     12u32, 4u32, 1u32, 12u32, 7u32, 1u32, 12u32, 8u32, 1u32, 12u32,
                     11u32, 1u32, 12u32, 12u32, 1u32, 12u32, 13u32, 1u32, 12u32, 14u32,
                     1u32, 12u32, 16u32, 1u32, 12u32, 17u32, 1u32, 12u32, 19u32, 1u32,
-                    12u32, 38u32, 1u32, 12u32, 3u32, 1u32, 86u32, 4u32, 1u32, 86u32,
-                    16u32, 1u32, 86u32, 38u32, 1u32, 86u32, 3u32, 1u32, 3u32, 38u32,
-                    1u32, 3u32, 0u32, 1u32, 83u32, 3u32, 1u32, 83u32, 4u32, 1u32, 83u32,
-                    7u32, 1u32, 83u32, 8u32, 1u32, 83u32, 11u32, 1u32, 83u32, 12u32,
-                    1u32, 83u32, 13u32, 1u32, 83u32, 14u32, 1u32, 83u32, 16u32, 1u32,
-                    83u32, 17u32, 1u32, 83u32, 19u32, 1u32, 83u32, 38u32, 1u32, 83u32,
+                    12u32, 37u32, 1u32, 12u32, 3u32, 1u32, 84u32, 4u32, 1u32, 84u32,
+                    16u32, 1u32, 84u32, 37u32, 1u32, 84u32, 3u32, 1u32, 3u32, 37u32,
+                    1u32, 3u32, 0u32, 1u32, 81u32, 3u32, 1u32, 81u32, 4u32, 1u32, 81u32,
+                    7u32, 1u32, 81u32, 8u32, 1u32, 81u32, 11u32, 1u32, 81u32, 12u32,
+                    1u32, 81u32, 13u32, 1u32, 81u32, 14u32, 1u32, 81u32, 16u32, 1u32,
+                    81u32, 17u32, 1u32, 81u32, 19u32, 1u32, 81u32, 37u32, 1u32, 81u32,
                     0u32, 1u32, 11u32, 3u32, 1u32, 11u32, 4u32, 1u32, 11u32, 7u32, 1u32,
                     11u32, 8u32, 1u32, 11u32, 11u32, 1u32, 11u32, 12u32, 1u32, 11u32,
                     13u32, 1u32, 11u32, 14u32, 1u32, 11u32, 16u32, 1u32, 11u32, 17u32,
-                    1u32, 11u32, 19u32, 1u32, 11u32, 38u32, 1u32, 11u32, 3u32, 1u32,
-                    85u32, 4u32, 1u32, 85u32, 16u32, 1u32, 85u32, 38u32, 1u32, 85u32,
-                    0u32, 1u32, 84u32, 3u32, 1u32, 84u32, 4u32, 1u32, 84u32, 7u32, 1u32,
-                    84u32, 8u32, 1u32, 84u32, 11u32, 1u32, 84u32, 12u32, 1u32, 84u32,
-                    13u32, 1u32, 84u32, 14u32, 1u32, 84u32, 16u32, 1u32, 84u32, 17u32,
-                    1u32, 84u32, 19u32, 1u32, 84u32, 38u32, 1u32, 84u32, 3u32, 1u32,
-                    90u32, 16u32, 1u32, 90u32, 38u32, 1u32, 90u32, 0u32, 1u32, 45u32,
+                    1u32, 11u32, 19u32, 1u32, 11u32, 37u32, 1u32, 11u32, 3u32, 1u32,
+                    83u32, 4u32, 1u32, 83u32, 16u32, 1u32, 83u32, 37u32, 1u32, 83u32,
+                    0u32, 1u32, 82u32, 3u32, 1u32, 82u32, 4u32, 1u32, 82u32, 7u32, 1u32,
+                    82u32, 8u32, 1u32, 82u32, 11u32, 1u32, 82u32, 12u32, 1u32, 82u32,
+                    13u32, 1u32, 82u32, 14u32, 1u32, 82u32, 16u32, 1u32, 82u32, 17u32,
+                    1u32, 82u32, 19u32, 1u32, 82u32, 37u32, 1u32, 82u32, 3u32, 1u32,
+                    88u32, 16u32, 1u32, 88u32, 37u32, 1u32, 88u32, 0u32, 1u32, 45u32,
                     3u32, 1u32, 45u32, 4u32, 1u32, 45u32, 11u32, 1u32, 45u32, 13u32,
-                    1u32, 45u32, 16u32, 1u32, 45u32, 38u32, 1u32, 45u32, 0u32, 1u32,
+                    1u32, 45u32, 16u32, 1u32, 45u32, 37u32, 1u32, 45u32, 0u32, 1u32,
                     46u32, 3u32, 1u32, 46u32, 4u32, 1u32, 46u32, 11u32, 1u32, 46u32,
-                    13u32, 1u32, 46u32, 16u32, 1u32, 46u32, 38u32, 1u32, 46u32, 0u32,
+                    13u32, 1u32, 46u32, 16u32, 1u32, 46u32, 37u32, 1u32, 46u32, 0u32,
                     1u32, 47u32, 3u32, 1u32, 47u32, 4u32, 1u32, 47u32, 11u32, 1u32,
-                    47u32, 13u32, 1u32, 47u32, 16u32, 1u32, 47u32, 38u32, 1u32, 47u32,
-                    3u32, 1u32, 7u32, 4u32, 1u32, 7u32, 16u32, 1u32, 7u32, 38u32, 1u32,
-                    7u32, 3u32, 1u32, 6u32, 4u32, 1u32, 6u32, 16u32, 1u32, 6u32, 38u32,
+                    47u32, 13u32, 1u32, 47u32, 16u32, 1u32, 47u32, 37u32, 1u32, 47u32,
+                    3u32, 1u32, 7u32, 4u32, 1u32, 7u32, 16u32, 1u32, 7u32, 37u32, 1u32,
+                    7u32, 3u32, 1u32, 6u32, 4u32, 1u32, 6u32, 16u32, 1u32, 6u32, 37u32,
                     1u32, 6u32, 3u32, 1u32, 8u32, 4u32, 1u32, 8u32, 16u32, 1u32, 8u32,
-                    38u32, 1u32, 8u32, 3u32, 1u32, 9u32, 4u32, 1u32, 9u32, 16u32, 1u32,
-                    9u32, 38u32, 1u32, 9u32, 3u32, 1u32, 10u32, 4u32, 1u32, 10u32, 16u32,
-                    1u32, 10u32, 38u32, 1u32, 10u32, 3u32, 1u32, 87u32, 4u32, 1u32,
-                    87u32, 16u32, 1u32, 87u32, 38u32, 1u32, 87u32, 3u32, 1u32, 89u32,
-                    16u32, 1u32, 89u32, 38u32, 1u32, 89u32, 3u32, 1u32, 88u32, 4u32,
-                    1u32, 88u32, 16u32, 1u32, 88u32, 38u32, 1u32, 88u32, 3u32, 1u32,
-                    44u32, 38u32, 1u32, 44u32, 3u32, 1u32, 43u32, 38u32, 1u32, 43u32,
-                    3u32, 1u32, 5u32, 38u32, 1u32, 5u32, 0u32, 1u32, 0u32, 4u32, 1u32,
-                    0u32, 46u32, 1u32, 0u32, 3u32, 1u32, 4u32, 38u32, 1u32, 4u32, 0u32,
-                    1u32, 58u32, 4u32, 1u32, 58u32, 46u32, 1u32, 58u32, 0u32, 1u32,
-                    151u32, 11u32, 1u32, 151u32, 13u32, 1u32, 151u32, 38u32, 1u32,
-                    151u32, 0u32, 1u32, 57u32, 4u32, 1u32, 57u32, 46u32, 1u32, 57u32,
-                    0u32, 1u32, 152u32, 11u32, 1u32, 152u32, 13u32, 1u32, 152u32, 38u32,
-                    1u32, 152u32, 0u32, 1u32, 60u32, 4u32, 1u32, 60u32, 46u32, 1u32,
-                    60u32, 0u32, 1u32, 59u32, 4u32, 1u32, 59u32, 46u32, 1u32, 59u32,
-                    0u32, 1u32, 49u32, 4u32, 1u32, 49u32, 46u32, 1u32, 49u32, 0u32, 1u32,
-                    149u32, 1u32, 1u32, 149u32, 2u32, 1u32, 149u32, 3u32, 1u32, 149u32,
-                    4u32, 1u32, 149u32, 5u32, 1u32, 149u32, 6u32, 1u32, 149u32, 7u32,
-                    1u32, 149u32, 8u32, 1u32, 149u32, 9u32, 1u32, 149u32, 10u32, 1u32,
-                    149u32, 11u32, 1u32, 149u32, 12u32, 1u32, 149u32, 13u32, 1u32,
-                    149u32, 14u32, 1u32, 149u32, 15u32, 1u32, 149u32, 16u32, 1u32,
-                    149u32, 17u32, 1u32, 149u32, 18u32, 1u32, 149u32, 19u32, 1u32,
-                    149u32, 20u32, 1u32, 149u32, 21u32, 1u32, 149u32, 22u32, 1u32,
-                    149u32, 23u32, 1u32, 149u32, 24u32, 1u32, 149u32, 25u32, 1u32,
-                    149u32, 26u32, 1u32, 149u32, 27u32, 1u32, 149u32, 28u32, 1u32,
-                    149u32, 29u32, 1u32, 149u32, 30u32, 1u32, 149u32, 31u32, 1u32,
-                    149u32, 32u32, 1u32, 149u32, 33u32, 1u32, 149u32, 34u32, 1u32,
-                    149u32, 35u32, 1u32, 149u32, 36u32, 1u32, 149u32, 37u32, 1u32,
-                    149u32, 38u32, 1u32, 149u32, 39u32, 1u32, 149u32, 40u32, 1u32,
-                    149u32, 41u32, 1u32, 149u32, 42u32, 1u32, 149u32, 43u32, 1u32,
-                    149u32, 44u32, 1u32, 149u32, 0u32, 1u32, 48u32, 4u32, 1u32, 48u32,
-                    46u32, 1u32, 48u32, 0u32, 1u32, 150u32, 1u32, 1u32, 150u32, 2u32,
-                    1u32, 150u32, 3u32, 1u32, 150u32, 4u32, 1u32, 150u32, 5u32, 1u32,
-                    150u32, 6u32, 1u32, 150u32, 7u32, 1u32, 150u32, 8u32, 1u32, 150u32,
-                    9u32, 1u32, 150u32, 10u32, 1u32, 150u32, 11u32, 1u32, 150u32, 12u32,
-                    1u32, 150u32, 13u32, 1u32, 150u32, 14u32, 1u32, 150u32, 15u32, 1u32,
-                    150u32, 16u32, 1u32, 150u32, 17u32, 1u32, 150u32, 18u32, 1u32,
-                    150u32, 19u32, 1u32, 150u32, 20u32, 1u32, 150u32, 21u32, 1u32,
-                    150u32, 22u32, 1u32, 150u32, 23u32, 1u32, 150u32, 24u32, 1u32,
-                    150u32, 25u32, 1u32, 150u32, 26u32, 1u32, 150u32, 27u32, 1u32,
-                    150u32, 28u32, 1u32, 150u32, 29u32, 1u32, 150u32, 30u32, 1u32,
-                    150u32, 31u32, 1u32, 150u32, 32u32, 1u32, 150u32, 33u32, 1u32,
-                    150u32, 34u32, 1u32, 150u32, 35u32, 1u32, 150u32, 36u32, 1u32,
-                    150u32, 37u32, 1u32, 150u32, 38u32, 1u32, 150u32, 39u32, 1u32,
-                    150u32, 40u32, 1u32, 150u32, 41u32, 1u32, 150u32, 42u32, 1u32,
-                    150u32, 43u32, 1u32, 150u32, 44u32, 1u32, 150u32, 0u32, 1u32, 50u32,
-                    4u32, 1u32, 50u32, 46u32, 1u32, 50u32, 0u32, 1u32, 51u32, 4u32, 1u32,
-                    51u32, 46u32, 1u32, 51u32, 0u32, 1u32, 52u32, 4u32, 1u32, 52u32,
-                    46u32, 1u32, 52u32, 0u32, 1u32, 54u32, 4u32, 1u32, 54u32, 46u32,
-                    1u32, 54u32, 0u32, 1u32, 53u32, 4u32, 1u32, 53u32, 46u32, 1u32,
-                    53u32, 0u32, 1u32, 56u32, 4u32, 1u32, 56u32, 46u32, 1u32, 56u32,
-                    0u32, 1u32, 55u32, 4u32, 1u32, 55u32, 46u32, 1u32, 55u32, 0u32, 1u32,
-                    64u32, 4u32, 1u32, 64u32, 46u32, 1u32, 64u32, 0u32, 1u32, 63u32,
-                    4u32, 1u32, 63u32, 46u32, 1u32, 63u32, 0u32, 1u32, 66u32, 4u32, 1u32,
-                    66u32, 46u32, 1u32, 66u32, 0u32, 1u32, 65u32, 4u32, 1u32, 65u32,
-                    46u32, 1u32, 65u32, 0u32, 1u32, 69u32, 4u32, 1u32, 69u32, 46u32,
-                    1u32, 69u32, 0u32, 1u32, 70u32, 4u32, 1u32, 70u32, 46u32, 1u32,
-                    70u32, 0u32, 1u32, 67u32, 4u32, 1u32, 67u32, 46u32, 1u32, 67u32,
-                    0u32, 1u32, 68u32, 4u32, 1u32, 68u32, 46u32, 1u32, 68u32, 0u32, 1u32,
-                    62u32, 4u32, 1u32, 62u32, 46u32, 1u32, 62u32, 0u32, 1u32, 61u32,
-                    4u32, 1u32, 61u32, 46u32, 1u32, 61u32, 0u32, 1u32, 71u32, 4u32, 1u32,
-                    71u32, 46u32, 1u32, 71u32, 0u32, 1u32, 72u32, 4u32, 1u32, 72u32,
-                    46u32, 1u32, 72u32, 0u32, 1u32, 73u32, 4u32, 1u32, 73u32, 46u32,
-                    1u32, 73u32, 0u32, 1u32, 74u32, 4u32, 1u32, 74u32, 46u32, 1u32,
-                    74u32, 0u32, 1u32, 76u32, 4u32, 1u32, 76u32, 46u32, 1u32, 76u32,
-                    0u32, 1u32, 75u32, 4u32, 1u32, 75u32, 46u32, 1u32, 75u32, 0u32, 1u32,
-                    78u32, 4u32, 1u32, 78u32, 46u32, 1u32, 78u32, 0u32, 1u32, 77u32,
-                    4u32, 1u32, 77u32, 46u32, 1u32, 77u32, 0u32, 1u32, 79u32, 4u32, 1u32,
-                    79u32, 46u32, 1u32, 79u32, 0u32, 1u32, 80u32, 4u32, 1u32, 80u32,
-                    46u32, 1u32, 80u32, 46u32, 1u32, 153u32, 46u32, 1u32, 154u32,
+                    37u32, 1u32, 8u32, 3u32, 1u32, 9u32, 4u32, 1u32, 9u32, 16u32, 1u32,
+                    9u32, 37u32, 1u32, 9u32, 3u32, 1u32, 10u32, 4u32, 1u32, 10u32, 16u32,
+                    1u32, 10u32, 37u32, 1u32, 10u32, 3u32, 1u32, 85u32, 4u32, 1u32,
+                    85u32, 16u32, 1u32, 85u32, 37u32, 1u32, 85u32, 3u32, 1u32, 87u32,
+                    16u32, 1u32, 87u32, 37u32, 1u32, 87u32, 3u32, 1u32, 86u32, 4u32,
+                    1u32, 86u32, 16u32, 1u32, 86u32, 37u32, 1u32, 86u32, 3u32, 1u32,
+                    44u32, 37u32, 1u32, 44u32, 3u32, 1u32, 43u32, 37u32, 1u32, 43u32,
+                    3u32, 1u32, 5u32, 37u32, 1u32, 5u32, 0u32, 1u32, 0u32, 4u32, 1u32,
+                    0u32, 45u32, 1u32, 0u32, 3u32, 1u32, 4u32, 37u32, 1u32, 4u32, 0u32,
+                    1u32, 58u32, 4u32, 1u32, 58u32, 45u32, 1u32, 58u32, 0u32, 1u32,
+                    148u32, 11u32, 1u32, 148u32, 13u32, 1u32, 148u32, 37u32, 1u32,
+                    148u32, 0u32, 1u32, 57u32, 4u32, 1u32, 57u32, 45u32, 1u32, 57u32,
+                    0u32, 1u32, 149u32, 11u32, 1u32, 149u32, 13u32, 1u32, 149u32, 37u32,
+                    1u32, 149u32, 0u32, 1u32, 60u32, 4u32, 1u32, 60u32, 45u32, 1u32,
+                    60u32, 0u32, 1u32, 59u32, 4u32, 1u32, 59u32, 45u32, 1u32, 59u32,
+                    0u32, 1u32, 49u32, 4u32, 1u32, 49u32, 45u32, 1u32, 49u32, 0u32, 1u32,
+                    146u32, 1u32, 1u32, 146u32, 2u32, 1u32, 146u32, 3u32, 1u32, 146u32,
+                    4u32, 1u32, 146u32, 5u32, 1u32, 146u32, 6u32, 1u32, 146u32, 7u32,
+                    1u32, 146u32, 8u32, 1u32, 146u32, 9u32, 1u32, 146u32, 10u32, 1u32,
+                    146u32, 11u32, 1u32, 146u32, 12u32, 1u32, 146u32, 13u32, 1u32,
+                    146u32, 14u32, 1u32, 146u32, 15u32, 1u32, 146u32, 16u32, 1u32,
+                    146u32, 17u32, 1u32, 146u32, 18u32, 1u32, 146u32, 19u32, 1u32,
+                    146u32, 20u32, 1u32, 146u32, 21u32, 1u32, 146u32, 22u32, 1u32,
+                    146u32, 23u32, 1u32, 146u32, 24u32, 1u32, 146u32, 25u32, 1u32,
+                    146u32, 26u32, 1u32, 146u32, 27u32, 1u32, 146u32, 28u32, 1u32,
+                    146u32, 29u32, 1u32, 146u32, 30u32, 1u32, 146u32, 31u32, 1u32,
+                    146u32, 32u32, 1u32, 146u32, 33u32, 1u32, 146u32, 34u32, 1u32,
+                    146u32, 35u32, 1u32, 146u32, 36u32, 1u32, 146u32, 37u32, 1u32,
+                    146u32, 38u32, 1u32, 146u32, 39u32, 1u32, 146u32, 40u32, 1u32,
+                    146u32, 41u32, 1u32, 146u32, 42u32, 1u32, 146u32, 43u32, 1u32,
+                    146u32, 0u32, 1u32, 48u32, 4u32, 1u32, 48u32, 45u32, 1u32, 48u32,
+                    0u32, 1u32, 147u32, 1u32, 1u32, 147u32, 2u32, 1u32, 147u32, 3u32,
+                    1u32, 147u32, 4u32, 1u32, 147u32, 5u32, 1u32, 147u32, 6u32, 1u32,
+                    147u32, 7u32, 1u32, 147u32, 8u32, 1u32, 147u32, 9u32, 1u32, 147u32,
+                    10u32, 1u32, 147u32, 11u32, 1u32, 147u32, 12u32, 1u32, 147u32, 13u32,
+                    1u32, 147u32, 14u32, 1u32, 147u32, 15u32, 1u32, 147u32, 16u32, 1u32,
+                    147u32, 17u32, 1u32, 147u32, 18u32, 1u32, 147u32, 19u32, 1u32,
+                    147u32, 20u32, 1u32, 147u32, 21u32, 1u32, 147u32, 22u32, 1u32,
+                    147u32, 23u32, 1u32, 147u32, 24u32, 1u32, 147u32, 25u32, 1u32,
+                    147u32, 26u32, 1u32, 147u32, 27u32, 1u32, 147u32, 28u32, 1u32,
+                    147u32, 29u32, 1u32, 147u32, 30u32, 1u32, 147u32, 31u32, 1u32,
+                    147u32, 32u32, 1u32, 147u32, 33u32, 1u32, 147u32, 34u32, 1u32,
+                    147u32, 35u32, 1u32, 147u32, 36u32, 1u32, 147u32, 37u32, 1u32,
+                    147u32, 38u32, 1u32, 147u32, 39u32, 1u32, 147u32, 40u32, 1u32,
+                    147u32, 41u32, 1u32, 147u32, 42u32, 1u32, 147u32, 43u32, 1u32,
+                    147u32, 0u32, 1u32, 50u32, 4u32, 1u32, 50u32, 45u32, 1u32, 50u32,
+                    0u32, 1u32, 51u32, 4u32, 1u32, 51u32, 45u32, 1u32, 51u32, 0u32, 1u32,
+                    52u32, 4u32, 1u32, 52u32, 45u32, 1u32, 52u32, 0u32, 1u32, 54u32,
+                    4u32, 1u32, 54u32, 45u32, 1u32, 54u32, 0u32, 1u32, 53u32, 4u32, 1u32,
+                    53u32, 45u32, 1u32, 53u32, 0u32, 1u32, 56u32, 4u32, 1u32, 56u32,
+                    45u32, 1u32, 56u32, 0u32, 1u32, 55u32, 4u32, 1u32, 55u32, 45u32,
+                    1u32, 55u32, 0u32, 1u32, 64u32, 4u32, 1u32, 64u32, 45u32, 1u32,
+                    64u32, 0u32, 1u32, 63u32, 4u32, 1u32, 63u32, 45u32, 1u32, 63u32,
+                    0u32, 1u32, 66u32, 4u32, 1u32, 66u32, 45u32, 1u32, 66u32, 0u32, 1u32,
+                    65u32, 4u32, 1u32, 65u32, 45u32, 1u32, 65u32, 0u32, 1u32, 69u32,
+                    4u32, 1u32, 69u32, 45u32, 1u32, 69u32, 0u32, 1u32, 70u32, 4u32, 1u32,
+                    70u32, 45u32, 1u32, 70u32, 0u32, 1u32, 67u32, 4u32, 1u32, 67u32,
+                    45u32, 1u32, 67u32, 0u32, 1u32, 68u32, 4u32, 1u32, 68u32, 45u32,
+                    1u32, 68u32, 0u32, 1u32, 62u32, 4u32, 1u32, 62u32, 45u32, 1u32,
+                    62u32, 0u32, 1u32, 61u32, 4u32, 1u32, 61u32, 45u32, 1u32, 61u32,
+                    0u32, 1u32, 71u32, 4u32, 1u32, 71u32, 45u32, 1u32, 71u32, 0u32, 1u32,
+                    72u32, 4u32, 1u32, 72u32, 45u32, 1u32, 72u32, 0u32, 1u32, 73u32,
+                    4u32, 1u32, 73u32, 45u32, 1u32, 73u32, 0u32, 1u32, 74u32, 4u32, 1u32,
+                    74u32, 45u32, 1u32, 74u32, 0u32, 1u32, 76u32, 4u32, 1u32, 76u32,
+                    45u32, 1u32, 76u32, 0u32, 1u32, 75u32, 4u32, 1u32, 75u32, 45u32,
+                    1u32, 75u32, 0u32, 1u32, 77u32, 4u32, 1u32, 77u32, 45u32, 1u32,
+                    77u32, 0u32, 1u32, 78u32, 4u32, 1u32, 78u32, 45u32, 1u32, 78u32,
+                    45u32, 1u32, 150u32, 45u32, 1u32, 151u32,
                 ];
                 static REDUCE_OFFSETS: &[u32] = &[
                     0u32, 0u32, 3u32, 6u32, 6u32, 18u32, 75u32, 75u32, 141u32, 207u32,
@@ -7376,216 +7219,200 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     2037u32, 2049u32, 2055u32, 2061u32, 2067u32, 2076u32, 2082u32,
                     2082u32, 2082u32, 2082u32, 2091u32, 2103u32, 2103u32, 2112u32,
                     2124u32, 2124u32, 2124u32, 2133u32, 2133u32, 2142u32, 2142u32,
-                    2142u32, 2151u32, 2286u32, 2286u32, 2295u32, 2430u32, 2430u32,
-                    2439u32, 2439u32, 2439u32, 2448u32, 2448u32, 2457u32, 2457u32,
-                    2466u32, 2466u32, 2475u32, 2475u32, 2484u32, 2484u32, 2493u32,
-                    2493u32, 2502u32, 2502u32, 2511u32, 2511u32, 2520u32, 2520u32,
-                    2529u32, 2529u32, 2538u32, 2538u32, 2547u32, 2547u32, 2556u32,
-                    2556u32, 2565u32, 2565u32, 2565u32, 2574u32, 2574u32, 2583u32,
-                    2583u32, 2592u32, 2592u32, 2601u32, 2601u32, 2610u32, 2610u32,
-                    2619u32, 2619u32, 2628u32, 2628u32, 2637u32, 2637u32, 2646u32,
-                    2646u32, 2655u32, 2655u32, 2664u32, 2673u32, 2676u32, 2679u32,
-                    2679u32, 2679u32,
+                    2142u32, 2151u32, 2283u32, 2283u32, 2292u32, 2424u32, 2424u32,
+                    2433u32, 2433u32, 2433u32, 2442u32, 2442u32, 2451u32, 2451u32,
+                    2460u32, 2460u32, 2469u32, 2469u32, 2478u32, 2478u32, 2487u32,
+                    2487u32, 2496u32, 2496u32, 2505u32, 2505u32, 2514u32, 2514u32,
+                    2523u32, 2523u32, 2532u32, 2532u32, 2541u32, 2541u32, 2550u32,
+                    2550u32, 2559u32, 2559u32, 2559u32, 2568u32, 2568u32, 2577u32,
+                    2577u32, 2586u32, 2586u32, 2595u32, 2595u32, 2604u32, 2604u32,
+                    2613u32, 2613u32, 2622u32, 2622u32, 2631u32, 2631u32, 2640u32,
+                    2649u32, 2652u32, 2655u32, 2655u32, 2655u32,
                 ];
                 static RULESET_DATA: &[u32] = &[
                     0u32, 48u32, 49u32, 50u32, 51u32, 52u32, 53u32, 54u32, 55u32, 56u32,
                     57u32, 58u32, 59u32, 60u32, 61u32, 62u32, 63u32, 64u32, 65u32, 66u32,
                     67u32, 68u32, 69u32, 70u32, 71u32, 72u32, 73u32, 74u32, 75u32, 76u32,
-                    77u32, 78u32, 79u32, 80u32, 81u32, 82u32, 153u32, 154u32, 155u32,
-                    65536u32, 1u32, 2u32, 65537u32, 131072u32, 196608u32, 3u32, 4u32,
-                    5u32, 11u32, 12u32, 22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32,
-                    29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32,
-                    39u32, 40u32, 41u32, 42u32, 83u32, 84u32, 85u32, 86u32, 65548u32,
-                    65560u32, 131084u32, 22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32,
-                    29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32,
-                    39u32, 40u32, 41u32, 42u32, 65560u32, 65559u32, 65574u32, 65575u32,
-                    65576u32, 65577u32, 65578u32, 131110u32, 131111u32, 131112u32,
-                    131113u32, 131114u32, 22u32, 23u32, 24u32, 25u32, 26u32, 27u32,
-                    28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32, 37u32,
-                    38u32, 196646u32, 39u32, 196647u32, 40u32, 196648u32, 41u32,
-                    196649u32, 42u32, 196650u32, 65569u32, 65570u32, 65571u32, 65572u32,
-                    22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32,
-                    65567u32, 32u32, 65568u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32,
-                    39u32, 40u32, 41u32, 42u32, 97u32, 98u32, 99u32, 100u32, 101u32,
-                    102u32, 65558u32, 91u32, 92u32, 65627u32, 13u32, 14u32, 15u32, 16u32,
-                    17u32, 18u32, 19u32, 20u32, 21u32, 131094u32, 93u32, 94u32, 95u32,
-                    96u32, 65549u32, 65550u32, 65551u32, 131086u32, 131087u32, 196622u32,
-                    196623u32, 65555u32, 65556u32, 65557u32, 131092u32, 131093u32,
-                    196628u32, 196629u32, 65552u32, 65553u32, 65554u32, 131089u32,
-                    131090u32, 196625u32, 196626u32, 65629u32, 13u32, 14u32, 15u32,
-                    16u32, 17u32, 18u32, 19u32, 20u32, 21u32, 65630u32, 65631u32,
-                    131166u32, 196630u32, 262166u32, 65565u32, 65561u32, 65562u32,
-                    65563u32, 65564u32, 65566u32, 65573u32, 262182u32, 262183u32,
-                    262184u32, 262185u32, 262186u32, 22u32, 23u32, 24u32, 25u32, 26u32,
-                    27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32,
-                    37u32, 38u32, 327718u32, 39u32, 327719u32, 40u32, 327720u32, 41u32,
-                    327721u32, 42u32, 327722u32, 131104u32, 196640u32, 65561u32,
-                    65562u32, 65563u32, 65564u32, 65566u32, 65573u32, 65633u32,
-                    131097u32, 131098u32, 131099u32, 131100u32, 22u32, 23u32, 24u32,
-                    25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32,
-                    35u32, 36u32, 37u32, 131109u32, 38u32, 39u32, 40u32, 41u32, 42u32,
-                    65561u32, 65562u32, 65563u32, 65564u32, 65566u32, 196645u32, 22u32,
-                    23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 131102u32,
-                    31u32, 32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 39u32, 40u32,
-                    41u32, 42u32, 65561u32, 65562u32, 65563u32, 65564u32, 196638u32,
+                    77u32, 78u32, 79u32, 80u32, 150u32, 151u32, 152u32, 65536u32, 1u32,
+                    2u32, 65537u32, 131072u32, 196608u32, 3u32, 4u32, 5u32, 11u32, 12u32,
                     22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32,
                     32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 39u32, 40u32, 41u32,
-                    42u32, 65634u32, 65635u32, 65561u32, 65562u32, 65563u32, 65564u32,
-                    65566u32, 65573u32, 131170u32, 65637u32, 131103u32, 65638u32, 22u32,
+                    42u32, 81u32, 82u32, 83u32, 84u32, 65548u32, 65560u32, 131084u32,
+                    22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32,
+                    32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 39u32, 40u32, 41u32,
+                    42u32, 65560u32, 65559u32, 65574u32, 65575u32, 65576u32, 65577u32,
+                    65578u32, 131110u32, 131111u32, 131112u32, 131113u32, 131114u32,
+                    22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32,
+                    32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 196646u32, 39u32,
+                    196647u32, 40u32, 196648u32, 41u32, 196649u32, 42u32, 196650u32,
+                    65569u32, 65570u32, 65571u32, 65572u32, 22u32, 23u32, 24u32, 25u32,
+                    26u32, 27u32, 28u32, 29u32, 30u32, 31u32, 65567u32, 32u32, 65568u32,
+                    33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 39u32, 40u32, 41u32, 42u32,
+                    95u32, 96u32, 97u32, 98u32, 99u32, 100u32, 65558u32, 89u32, 90u32,
+                    65625u32, 13u32, 14u32, 15u32, 16u32, 17u32, 18u32, 19u32, 20u32,
+                    21u32, 131094u32, 91u32, 92u32, 93u32, 94u32, 65549u32, 65550u32,
+                    65551u32, 131086u32, 131087u32, 196622u32, 196623u32, 65555u32,
+                    65556u32, 65557u32, 131092u32, 131093u32, 196628u32, 196629u32,
+                    65552u32, 65553u32, 65554u32, 131089u32, 131090u32, 196625u32,
+                    196626u32, 65627u32, 13u32, 14u32, 15u32, 16u32, 17u32, 18u32, 19u32,
+                    20u32, 21u32, 65628u32, 65629u32, 131164u32, 196630u32, 262166u32,
+                    65565u32, 65561u32, 65562u32, 65563u32, 65564u32, 65566u32, 65573u32,
+                    262182u32, 262183u32, 262184u32, 262185u32, 262186u32, 22u32, 23u32,
+                    24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32,
+                    34u32, 35u32, 36u32, 37u32, 38u32, 327718u32, 39u32, 327719u32,
+                    40u32, 327720u32, 41u32, 327721u32, 42u32, 327722u32, 131104u32,
+                    196640u32, 65561u32, 65562u32, 65563u32, 65564u32, 65566u32,
+                    65573u32, 65631u32, 131097u32, 131098u32, 131099u32, 131100u32,
+                    22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32,
+                    32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 131109u32, 38u32, 39u32,
+                    40u32, 41u32, 42u32, 65561u32, 65562u32, 65563u32, 65564u32,
+                    65566u32, 196645u32, 22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32,
+                    29u32, 30u32, 131102u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32,
+                    37u32, 38u32, 39u32, 40u32, 41u32, 42u32, 65561u32, 65562u32,
+                    65563u32, 65564u32, 196638u32, 22u32, 23u32, 24u32, 25u32, 26u32,
+                    27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32,
+                    37u32, 38u32, 39u32, 40u32, 41u32, 42u32, 65632u32, 65633u32,
+                    65561u32, 65562u32, 65563u32, 65564u32, 65566u32, 65573u32,
+                    131168u32, 65635u32, 131103u32, 65636u32, 22u32, 23u32, 24u32, 25u32,
+                    26u32, 27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32,
+                    36u32, 37u32, 38u32, 39u32, 40u32, 41u32, 42u32, 95u32, 96u32, 97u32,
+                    98u32, 131172u32, 196708u32, 196639u32, 65561u32, 65562u32, 65563u32,
+                    65564u32, 65566u32, 65573u32, 393254u32, 393255u32, 393256u32,
+                    393257u32, 393258u32, 101u32, 102u32, 458791u32, 458792u32,
+                    458794u32, 65637u32, 524327u32, 589863u32, 524328u32, 589864u32,
+                    524330u32, 589866u32, 458793u32, 524329u32, 458790u32, 524326u32,
+                    196620u32, 65561u32, 65562u32, 65563u32, 65564u32, 65566u32,
+                    65573u32, 262144u32, 65539u32, 131075u32, 5u32, 11u32, 12u32, 22u32,
                     23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32, 32u32,
                     33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 39u32, 40u32, 41u32, 42u32,
-                    97u32, 98u32, 99u32, 100u32, 131174u32, 196710u32, 196639u32,
-                    65561u32, 65562u32, 65563u32, 65564u32, 65566u32, 65573u32,
-                    393254u32, 393255u32, 393256u32, 393257u32, 393258u32, 103u32,
-                    104u32, 458791u32, 458792u32, 458794u32, 65639u32, 524327u32,
-                    589863u32, 524328u32, 589864u32, 524330u32, 589866u32, 458793u32,
-                    524329u32, 458790u32, 524326u32, 196620u32, 65561u32, 65562u32,
-                    65563u32, 65564u32, 65566u32, 65573u32, 262144u32, 65539u32,
-                    131075u32, 5u32, 11u32, 12u32, 22u32, 23u32, 24u32, 25u32, 26u32,
-                    27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32, 35u32, 36u32,
-                    37u32, 38u32, 39u32, 40u32, 41u32, 42u32, 83u32, 84u32, 85u32, 86u32,
-                    196611u32, 65619u32, 65547u32, 65561u32, 65562u32, 65563u32,
-                    65564u32, 65566u32, 65573u32, 11u32, 12u32, 22u32, 23u32, 24u32,
-                    25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32, 32u32, 33u32, 34u32,
-                    35u32, 36u32, 37u32, 38u32, 39u32, 40u32, 41u32, 42u32, 65620u32,
-                    65621u32, 131156u32, 65541u32, 6u32, 7u32, 8u32, 9u32, 10u32, 87u32,
-                    88u32, 89u32, 90u32, 65542u32, 65543u32, 65544u32, 65545u32,
-                    65546u32, 131078u32, 131079u32, 45u32, 46u32, 47u32, 65581u32,
-                    65582u32, 65583u32, 196615u32, 196614u32, 131080u32, 131081u32,
-                    196616u32, 196617u32, 131082u32, 65623u32, 6u32, 7u32, 8u32, 9u32,
-                    10u32, 65624u32, 65625u32, 131160u32, 131077u32, 43u32, 44u32,
-                    65579u32, 196613u32, 327680u32, 65540u32, 65584u32, 65585u32,
+                    81u32, 82u32, 83u32, 84u32, 196611u32, 65617u32, 65547u32, 65561u32,
+                    65562u32, 65563u32, 65564u32, 65566u32, 65573u32, 11u32, 12u32,
+                    22u32, 23u32, 24u32, 25u32, 26u32, 27u32, 28u32, 29u32, 30u32, 31u32,
+                    32u32, 33u32, 34u32, 35u32, 36u32, 37u32, 38u32, 39u32, 40u32, 41u32,
+                    42u32, 65618u32, 65619u32, 131154u32, 65541u32, 6u32, 7u32, 8u32,
+                    9u32, 10u32, 85u32, 86u32, 87u32, 88u32, 65542u32, 65543u32,
+                    65544u32, 65545u32, 65546u32, 131078u32, 131079u32, 45u32, 46u32,
+                    47u32, 65581u32, 65582u32, 65583u32, 196615u32, 196614u32, 131080u32,
+                    131081u32, 196616u32, 196617u32, 131082u32, 65621u32, 6u32, 7u32,
+                    8u32, 9u32, 10u32, 65622u32, 65623u32, 131158u32, 131077u32, 43u32,
+                    44u32, 65579u32, 196613u32, 327680u32, 65540u32, 65584u32, 65585u32,
                     65586u32, 65587u32, 65588u32, 65589u32, 65590u32, 65591u32, 65592u32,
                     65593u32, 65594u32, 65595u32, 65596u32, 65597u32, 65598u32, 65599u32,
                     65600u32, 65601u32, 65602u32, 65603u32, 65604u32, 65605u32, 65606u32,
                     65607u32, 65608u32, 65609u32, 65610u32, 65611u32, 65612u32, 65613u32,
-                    65614u32, 65615u32, 45u32, 46u32, 47u32, 131129u32, 131130u32,
-                    151u32, 152u32, 196666u32, 262202u32, 65687u32, 45u32, 46u32, 47u32,
-                    196665u32, 65688u32, 262201u32, 131224u32, 45u32, 46u32, 47u32,
-                    131131u32, 131132u32, 151u32, 152u32, 196668u32, 262204u32, 45u32,
-                    46u32, 47u32, 196667u32, 65688u32, 262203u32, 131120u32, 131121u32,
-                    131122u32, 196656u32, 196657u32, 105u32, 106u32, 107u32, 108u32,
+                    45u32, 46u32, 47u32, 131129u32, 131130u32, 148u32, 149u32, 196666u32,
+                    262202u32, 65684u32, 45u32, 46u32, 47u32, 196665u32, 65685u32,
+                    262201u32, 131221u32, 45u32, 46u32, 47u32, 131131u32, 131132u32,
+                    148u32, 149u32, 196668u32, 262204u32, 45u32, 46u32, 47u32, 196667u32,
+                    65685u32, 262203u32, 131120u32, 131121u32, 131122u32, 196656u32,
+                    196657u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32, 109u32,
+                    110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32,
+                    118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32,
+                    126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32,
+                    134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32,
+                    142u32, 143u32, 144u32, 145u32, 146u32, 147u32, 262193u32, 65682u32,
+                    262192u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32, 109u32,
+                    110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32,
+                    118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32,
+                    126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32,
+                    134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32,
+                    142u32, 143u32, 144u32, 145u32, 65683u32, 327728u32, 131219u32,
+                    196658u32, 262194u32, 131123u32, 131124u32, 196659u32, 262195u32,
+                    196660u32, 262196u32, 131125u32, 131126u32, 103u32, 104u32, 105u32,
+                    106u32, 107u32, 108u32, 109u32, 110u32, 111u32, 112u32, 113u32,
+                    114u32, 115u32, 116u32, 117u32, 118u32, 119u32, 120u32, 121u32,
+                    122u32, 123u32, 124u32, 125u32, 126u32, 127u32, 128u32, 129u32,
+                    130u32, 131u32, 132u32, 133u32, 134u32, 135u32, 136u32, 137u32,
+                    138u32, 139u32, 140u32, 141u32, 142u32, 143u32, 144u32, 145u32,
+                    146u32, 147u32, 196662u32, 196661u32, 103u32, 104u32, 105u32, 106u32,
+                    107u32, 108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32,
+                    115u32, 116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32,
+                    123u32, 124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32,
+                    131u32, 132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32,
+                    139u32, 140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 65683u32,
+                    262197u32, 131127u32, 131128u32, 103u32, 104u32, 105u32, 106u32,
+                    107u32, 108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32,
+                    115u32, 116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32,
+                    123u32, 124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32,
+                    131u32, 132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32,
+                    139u32, 140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 146u32,
+                    147u32, 196664u32, 196663u32, 103u32, 104u32, 105u32, 106u32, 107u32,
+                    108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32, 115u32,
+                    116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32, 123u32,
+                    124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32, 131u32,
+                    132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32, 139u32,
+                    140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 65683u32, 262199u32,
+                    131135u32, 131136u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32,
                     109u32, 110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32,
                     117u32, 118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32,
                     125u32, 126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32,
                     133u32, 134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32,
-                    141u32, 142u32, 143u32, 144u32, 145u32, 146u32, 147u32, 148u32,
-                    149u32, 150u32, 262193u32, 65685u32, 262192u32, 105u32, 106u32,
-                    107u32, 108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32,
-                    115u32, 116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32,
-                    123u32, 124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32,
-                    131u32, 132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32,
-                    139u32, 140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 146u32,
-                    147u32, 148u32, 65686u32, 327728u32, 131222u32, 196658u32, 262194u32,
-                    131123u32, 131124u32, 196659u32, 262195u32, 196660u32, 262196u32,
-                    131125u32, 131126u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
+                    141u32, 142u32, 143u32, 144u32, 145u32, 146u32, 147u32, 196672u32,
+                    196671u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32, 109u32,
+                    110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32,
+                    118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32,
+                    126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32,
+                    134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32,
+                    142u32, 143u32, 144u32, 145u32, 65683u32, 262207u32, 131137u32,
+                    131138u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32, 109u32,
+                    110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32,
+                    118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32,
+                    126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32,
+                    134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32,
+                    142u32, 143u32, 144u32, 145u32, 146u32, 147u32, 196674u32, 196673u32,
+                    103u32, 104u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
                     111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
                     119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
                     127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
                     135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 149u32, 150u32,
-                    196662u32, 196661u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 65686u32, 262197u32,
-                    131127u32, 131128u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 149u32, 150u32,
-                    196664u32, 196663u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 65686u32, 262199u32,
-                    131135u32, 131136u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 149u32, 150u32,
-                    196672u32, 196671u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 65686u32, 262207u32,
-                    131137u32, 131138u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 149u32, 150u32,
-                    196674u32, 196673u32, 105u32, 106u32, 107u32, 108u32, 109u32, 110u32,
-                    111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32, 118u32,
-                    119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32, 126u32,
-                    127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32, 134u32,
-                    135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32, 142u32,
-                    143u32, 144u32, 145u32, 146u32, 147u32, 148u32, 65686u32, 262209u32,
-                    131141u32, 131142u32, 196677u32, 196678u32, 262214u32, 131139u32,
-                    131140u32, 196675u32, 196676u32, 262212u32, 45u32, 46u32, 47u32,
-                    131133u32, 131134u32, 151u32, 152u32, 196670u32, 262206u32, 45u32,
-                    46u32, 47u32, 196669u32, 65688u32, 262205u32, 131143u32, 131144u32,
-                    196679u32, 196680u32, 262216u32, 131145u32, 131146u32, 196681u32,
-                    196682u32, 262218u32, 131147u32, 131148u32, 105u32, 106u32, 107u32,
-                    108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32, 115u32,
-                    116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32, 123u32,
-                    124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32, 131u32,
-                    132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32, 139u32,
-                    140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 146u32, 147u32,
-                    148u32, 149u32, 150u32, 196684u32, 196683u32, 105u32, 106u32, 107u32,
-                    108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32, 115u32,
-                    116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32, 123u32,
-                    124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32, 131u32,
-                    132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32, 139u32,
-                    140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 146u32, 147u32,
-                    148u32, 65686u32, 262219u32, 131149u32, 131150u32, 105u32, 106u32,
-                    107u32, 108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32,
-                    115u32, 116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32,
-                    123u32, 124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32,
-                    131u32, 132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32,
-                    139u32, 140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 146u32,
-                    147u32, 148u32, 149u32, 150u32, 196686u32, 196685u32, 105u32, 106u32,
-                    107u32, 108u32, 109u32, 110u32, 111u32, 112u32, 113u32, 114u32,
-                    115u32, 116u32, 117u32, 118u32, 119u32, 120u32, 121u32, 122u32,
-                    123u32, 124u32, 125u32, 126u32, 127u32, 128u32, 129u32, 130u32,
-                    131u32, 132u32, 133u32, 134u32, 135u32, 136u32, 137u32, 138u32,
-                    139u32, 140u32, 141u32, 142u32, 143u32, 144u32, 145u32, 146u32,
-                    147u32, 148u32, 65686u32, 262221u32, 131151u32, 196687u32, 65616u32,
-                    0u32, 48u32, 49u32, 50u32, 51u32, 52u32, 53u32, 54u32, 55u32, 56u32,
-                    57u32, 58u32, 59u32, 60u32, 61u32, 62u32, 63u32, 64u32, 65u32, 66u32,
-                    67u32, 68u32, 69u32, 70u32, 71u32, 72u32, 73u32, 74u32, 75u32, 76u32,
-                    77u32, 78u32, 79u32, 80u32, 81u32, 153u32, 65689u32, 154u32,
-                    65690u32, 131226u32, 65691u32, 131227u32,
+                    143u32, 144u32, 145u32, 65683u32, 262209u32, 131141u32, 131142u32,
+                    196677u32, 196678u32, 262214u32, 131139u32, 131140u32, 196675u32,
+                    196676u32, 262212u32, 45u32, 46u32, 47u32, 131133u32, 131134u32,
+                    148u32, 149u32, 196670u32, 262206u32, 45u32, 46u32, 47u32, 196669u32,
+                    65685u32, 262205u32, 131143u32, 131144u32, 196679u32, 196680u32,
+                    262216u32, 131145u32, 131146u32, 196681u32, 196682u32, 262218u32,
+                    131147u32, 131148u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32,
+                    109u32, 110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32,
+                    117u32, 118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32,
+                    125u32, 126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32,
+                    133u32, 134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32,
+                    141u32, 142u32, 143u32, 144u32, 145u32, 146u32, 147u32, 196684u32,
+                    196683u32, 103u32, 104u32, 105u32, 106u32, 107u32, 108u32, 109u32,
+                    110u32, 111u32, 112u32, 113u32, 114u32, 115u32, 116u32, 117u32,
+                    118u32, 119u32, 120u32, 121u32, 122u32, 123u32, 124u32, 125u32,
+                    126u32, 127u32, 128u32, 129u32, 130u32, 131u32, 132u32, 133u32,
+                    134u32, 135u32, 136u32, 137u32, 138u32, 139u32, 140u32, 141u32,
+                    142u32, 143u32, 144u32, 145u32, 65683u32, 262219u32, 131149u32,
+                    196685u32, 65614u32, 0u32, 48u32, 49u32, 50u32, 51u32, 52u32, 53u32,
+                    54u32, 55u32, 56u32, 57u32, 58u32, 59u32, 60u32, 61u32, 62u32, 63u32,
+                    64u32, 65u32, 66u32, 67u32, 68u32, 69u32, 70u32, 71u32, 72u32, 73u32,
+                    74u32, 75u32, 76u32, 77u32, 78u32, 79u32, 150u32, 65686u32, 151u32,
+                    65687u32, 131223u32, 65688u32, 131224u32,
                 ];
                 static RULESET_OFFSETS: &[u32] = &[
-                    0u32, 39u32, 42u32, 43u32, 44u32, 75u32, 77u32, 99u32, 100u32,
-                    101u32, 106u32, 111u32, 137u32, 138u32, 139u32, 140u32, 141u32,
-                    170u32, 173u32, 174u32, 188u32, 191u32, 193u32, 194u32, 195u32,
-                    198u32, 200u32, 201u32, 202u32, 205u32, 207u32, 208u32, 209u32,
-                    210u32, 221u32, 222u32, 223u32, 224u32, 225u32, 236u32, 262u32,
-                    263u32, 264u32, 271u32, 272u32, 273u32, 274u32, 275u32, 297u32,
-                    303u32, 325u32, 330u32, 353u32, 360u32, 361u32, 363u32, 389u32,
-                    390u32, 391u32, 404u32, 408u32, 409u32, 410u32, 411u32, 412u32,
-                    413u32, 414u32, 415u32, 416u32, 417u32, 418u32, 425u32, 427u32,
-                    456u32, 457u32, 458u32, 465u32, 490u32, 491u32, 501u32, 506u32,
-                    511u32, 512u32, 513u32, 514u32, 515u32, 516u32, 518u32, 519u32,
-                    520u32, 521u32, 522u32, 529u32, 530u32, 533u32, 534u32, 535u32,
-                    536u32, 537u32, 569u32, 576u32, 577u32, 578u32, 579u32, 584u32,
-                    585u32, 586u32, 593u32, 594u32, 595u32, 600u32, 601u32, 604u32,
-                    652u32, 653u32, 654u32, 700u32, 701u32, 702u32, 703u32, 704u32,
-                    706u32, 707u32, 708u32, 709u32, 710u32, 758u32, 759u32, 805u32,
-                    806u32, 854u32, 855u32, 901u32, 902u32, 950u32, 951u32, 997u32,
-                    998u32, 1046u32, 1047u32, 1093u32, 1094u32, 1096u32, 1097u32,
-                    1098u32, 1099u32, 1101u32, 1102u32, 1103u32, 1104u32, 1111u32,
-                    1112u32, 1113u32, 1118u32, 1119u32, 1121u32, 1122u32, 1123u32,
-                    1124u32, 1126u32, 1127u32, 1128u32, 1129u32, 1177u32, 1178u32,
-                    1224u32, 1225u32, 1273u32, 1274u32, 1320u32, 1321u32, 1322u32,
-                    1323u32, 1324u32, 1363u32, 1364u32, 1365u32, 1366u32,
+                    0u32, 37u32, 40u32, 41u32, 42u32, 73u32, 75u32, 97u32, 98u32, 99u32,
+                    104u32, 109u32, 135u32, 136u32, 137u32, 138u32, 139u32, 168u32,
+                    171u32, 172u32, 186u32, 189u32, 191u32, 192u32, 193u32, 196u32,
+                    198u32, 199u32, 200u32, 203u32, 205u32, 206u32, 207u32, 208u32,
+                    219u32, 220u32, 221u32, 222u32, 223u32, 234u32, 260u32, 261u32,
+                    262u32, 269u32, 270u32, 271u32, 272u32, 273u32, 295u32, 301u32,
+                    323u32, 328u32, 351u32, 358u32, 359u32, 361u32, 387u32, 388u32,
+                    389u32, 402u32, 406u32, 407u32, 408u32, 409u32, 410u32, 411u32,
+                    412u32, 413u32, 414u32, 415u32, 416u32, 423u32, 425u32, 454u32,
+                    455u32, 456u32, 463u32, 488u32, 489u32, 499u32, 504u32, 509u32,
+                    510u32, 511u32, 512u32, 513u32, 514u32, 516u32, 517u32, 518u32,
+                    519u32, 520u32, 527u32, 528u32, 531u32, 532u32, 533u32, 534u32,
+                    535u32, 565u32, 572u32, 573u32, 574u32, 575u32, 580u32, 581u32,
+                    582u32, 589u32, 590u32, 591u32, 596u32, 597u32, 600u32, 647u32,
+                    648u32, 649u32, 694u32, 695u32, 696u32, 697u32, 698u32, 700u32,
+                    701u32, 702u32, 703u32, 704u32, 751u32, 752u32, 797u32, 798u32,
+                    845u32, 846u32, 891u32, 892u32, 939u32, 940u32, 985u32, 986u32,
+                    1033u32, 1034u32, 1079u32, 1080u32, 1082u32, 1083u32, 1084u32,
+                    1085u32, 1087u32, 1088u32, 1089u32, 1090u32, 1097u32, 1098u32,
+                    1099u32, 1104u32, 1105u32, 1107u32, 1108u32, 1109u32, 1110u32,
+                    1112u32, 1113u32, 1114u32, 1115u32, 1162u32, 1163u32, 1208u32,
+                    1209u32, 1210u32, 1211u32, 1212u32, 1249u32, 1250u32, 1251u32,
+                    1252u32,
                 ];
                 static CAN_ACCEPT_ERROR: &[u8] = &[
                     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8, 2u8, 0u8, 0u8, 0u8, 2u8, 2u8,
@@ -7600,9 +7427,9 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
                     0u8, 1u8, 0u8, 0u8, 0u8, 1u8, 0u8, 0u8, 0u8, 1u8, 0u8, 0u8, 0u8, 0u8,
                     1u8, 0u8, 0u8, 0u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
-                    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+                    0u8, 0u8, 0u8, 0u8, 0u8,
                 ];
-                let num_states = 177usize;
+                let num_states = 173usize;
                 let mut states = Vec::with_capacity(num_states);
                 for i in 0..num_states {
                     let term_start = SHIFT_TERM_OFFSETS[i] as usize;

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -12,9 +12,6 @@ pub enum Token {
     LParen,
     RParen,
 }
-fn filter(term: &Token) -> &Token {
-    term
-}
 
 // =================================User Codes End=================================
 /*
@@ -118,7 +115,7 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for ETerminalClasses {
     }
     fn from_term(terminal: &Self::Term) -> Self {
         #[allow(unreachable_patterns, unused_variables)]
-        match filter(terminal) {
+        match terminal {
             Token::Num(_) => ETerminalClasses::num,
             Token::Plus => ETerminalClasses::plus,
             Token::Star => ETerminalClasses::star,


### PR DESCRIPTION

# Description
This Pull Request simplifies the grammar specification and the code generator by completely removing two unused and legacy syntax directives: `%trace` and `%filter`.
### Key Changes
1. **Removed `%filter` Directive**:
   - Removed `%filter` parsing rules, arguments, macro substitution, and verification logic.
   - Deleted the unused diagnostic errors `MultipleFilterDefinition` and `FilterNotDefined` from `rusty_lr_parser` and `rusty_lr_buildscript`.
   - Removed the filter function implementation and directive from the calculator example (`example/calculator`).
2. **Documentation Updates (`SYNTAX.md`, `README.md`)**:
   - Removed all references to `%filter`, and `$filter`.
   - Enhanced the `%token` definition section in `SYNTAX.md` with detailed instructions and examples on using native Rust structural pattern matching (destructuring) for wrapped/struct tokens.
