### PR TITLE
Remove Option Wrapper from Rule Precedence

### DIFF
--- a/rusty_lr_core/src/builder/grammar.rs
+++ b/rusty_lr_core/src/builder/grammar.rs
@@ -70,7 +70,7 @@ impl<Term, NonTerm> Grammar<TerminalSymbol<Term>, NonTerm> {
         &mut self,
         name: NonTerm,
         rule: Vec<Token<TerminalSymbol<Term>, NonTerm>>,
-        precedence: Option<Precedence>,
+        precedence: Precedence,
         priority: usize,
     ) -> usize
     where
@@ -838,13 +838,9 @@ impl<Term, NonTerm> Grammar<TerminalSymbol<Term>, NonTerm> {
                 let mut remove_shift = true;
 
                 for &reduce_rule in reduce_rules.iter() {
-                    let Some(reduce_op) = self.rules[reduce_rule].rule.precedence else {
-                        // no operator for this reduce rule
-                        remove_shift = false;
-                        continue;
-                    };
+                    let reduce_op = self.rules[reduce_rule].rule.precedence;
                     let Precedence::Fixed(reduce_prec) = reduce_op else {
-                        // not fixed operator, so no precedence known at this time
+                        // no fixed operator precedence known at this time
                         remove_shift = false;
                         continue;
                     };
@@ -1038,13 +1034,9 @@ impl<Term, NonTerm> Grammar<TerminalSymbol<Term>, NonTerm> {
             let mut remove_shift = true;
 
             for &reduce_rule in reduce_rules.iter() {
-                let Some(reduce_op) = self.rules[reduce_rule].rule.precedence else {
-                    // no operator for this reduce rule
-                    remove_shift = false;
-                    continue;
-                };
+                let reduce_op = self.rules[reduce_rule].rule.precedence;
                 let Precedence::Fixed(reduce_prec) = reduce_op else {
-                    // not fixed operator, so no precedence known at this time
+                    // no fixed operator precedence known at this time
                     remove_shift = false;
                     continue;
                 };

--- a/rusty_lr_core/src/parser/deterministic/context.rs
+++ b/rusty_lr_core/src/parser/deterministic/context.rs
@@ -439,13 +439,13 @@ impl<
                 let tokens_len = rule.len;
 
                 let reduce_prec = match rule.precedence {
-                    Some(crate::rule::Precedence::Fixed(level)) => Precedence::new(level as u8),
-                    Some(crate::rule::Precedence::Dynamic(token_idx)) => {
+                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
+                    crate::rule::Precedence::Dynamic(token_idx) => {
                         // get token_idx'th precedence from back of precedence stack
                         let idx = self.precedence_stack.len() - tokens_len + token_idx;
                         self.precedence_stack[idx]
                     }
-                    None => Precedence::none(),
+                    crate::rule::Precedence::None => Precedence::none(),
                 };
 
                 // resolve shift/reduce conflict by precedence
@@ -677,8 +677,8 @@ impl<
                 let tokens_len = rule.len;
 
                 let reduce_prec = match rule.precedence {
-                    Some(crate::rule::Precedence::Fixed(level)) => Precedence::new(level as u8),
-                    Some(crate::rule::Precedence::Dynamic(token_idx)) => {
+                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
+                    crate::rule::Precedence::Dynamic(token_idx) => {
                         // get token_idx'th precedence from back of precedence stack
                         let idx = stack_len + extra_precedence_stack.len() - tokens_len + token_idx;
                         if idx < stack_len {
@@ -688,7 +688,7 @@ impl<
                             extra_precedence_stack[idx]
                         }
                     }
-                    None => Precedence::none(),
+                    crate::rule::Precedence::None => Precedence::none(),
                 };
 
                 // resolve shift/reduce conflict by precedence

--- a/rusty_lr_core/src/parser/nondeterministic/context.rs
+++ b/rusty_lr_core/src/parser/nondeterministic/context.rs
@@ -840,14 +840,14 @@ impl<
             for reduce_rule in reduce_rules.to_iter() {
                 let rule = *self.tables.rule(reduce_rule.into_usize());
                 let reduce_prec = match rule.precedence {
-                    Some(crate::rule::Precedence::Fixed(level)) => Precedence::new(level as u8),
-                    Some(crate::rule::Precedence::Dynamic(token_index)) => {
+                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
+                    crate::rule::Precedence::Dynamic(token_index) => {
                         // fix the value to the offset from current node
                         let ith = rule.len - token_index - 1;
                         let (node, ith) = self.skip_last_n(node, ith).unwrap();
                         self.node(node).precedence_stack[ith]
                     }
-                    None => Precedence::none(),
+                    crate::rule::Precedence::None => Precedence::none(),
                 };
 
                 // if there is shift/reduce conflict, check for reduce rule's precedence and shift terminal's precedence
@@ -1357,8 +1357,8 @@ impl<
             for reduce_rule in reduce_rules.to_iter() {
                 let rule = *self.tables.rule(reduce_rule.into_usize());
                 let reduce_prec = match rule.precedence {
-                    Some(crate::rule::Precedence::Fixed(level)) => Precedence::new(level as u8),
-                    Some(crate::rule::Precedence::Dynamic(token_index)) => {
+                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
+                    crate::rule::Precedence::Dynamic(token_index) => {
                         // fix the value to the offset from current node
                         let mut ith = rule.len - token_index - 1;
                         if ith < extra_precedence_stack.len() {
@@ -1377,7 +1377,7 @@ impl<
                             // safe unwrap since ith >= extra_precedence_stack.len()
                         }
                     }
-                    None => Precedence::none(),
+                    crate::rule::Precedence::None => Precedence::none(),
                 };
 
                 // if there is shift/reduce conflict, check for reduce rule's precedence and shift terminal's precedence

--- a/rusty_lr_core/src/parser/table.rs
+++ b/rusty_lr_core/src/parser/table.rs
@@ -18,7 +18,7 @@ use crate::TriState;
 pub struct RuleInfo<NonTerm> {
     pub name: NonTerm,
     pub len: usize,
-    pub precedence: Option<crate::rule::Precedence>,
+    pub precedence: crate::rule::Precedence,
 }
 
 /// Intermediate flat parser table data used by generated code before converting to a concrete

--- a/rusty_lr_core/src/rule.rs
+++ b/rusty_lr_core/src/rule.rs
@@ -24,13 +24,26 @@ impl std::fmt::Display for ReduceType {
 }
 
 /// Operator precedence for production rules
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Precedence {
+    /// no operator precedence
+    #[default]
+    None,
+
     /// fixed precedence level
     Fixed(usize), // precedence level
 
     /// get precedence from i'th child token; for runtime conflict resolution
     Dynamic(usize), // token index
+}
+impl Precedence {
+    pub fn is_some(self) -> bool {
+        !matches!(self, Precedence::None)
+    }
+
+    pub fn is_none(self) -> bool {
+        matches!(self, Precedence::None)
+    }
 }
 
 // Production rule.
@@ -40,7 +53,7 @@ pub enum Precedence {
 pub struct ProductionRule<Term, NonTerm> {
     pub name: NonTerm,
     pub rule: Vec<Token<Term, NonTerm>>,
-    pub precedence: Option<Precedence>,
+    pub precedence: Precedence,
 }
 impl<Term: Display, NonTerm: Display> Display for ProductionRule<Term, NonTerm> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -64,8 +77,8 @@ impl<Term: Debug, NonTerm: Debug> Debug for ProductionRule<Term, NonTerm> {
             }
         }
 
-        if let Some(prec) = self.precedence {
-            write!(f, " [prec: {:?}]", prec)?;
+        if self.precedence.is_some() {
+            write!(f, " [prec: {:?}]", self.precedence)?;
         }
         Ok(())
     }
@@ -141,8 +154,8 @@ impl<Term: Display, NonTerm: Display> Display for ShiftedRule<Term, NonTerm> {
             write!(f, " •")?;
         }
 
-        if let Some(prec) = self.rule.precedence {
-            write!(f, " [prec: {:?}]", prec)?;
+        if self.rule.precedence.is_some() {
+            write!(f, " [prec: {:?}]", self.rule.precedence)?;
         }
         Ok(())
     }

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -660,27 +660,24 @@ impl Grammar {
             );
             rule_names.push(rule.rule.name as u32);
 
-            let prec_val = if let Some(precedence) = rule.rule.precedence {
-                match precedence {
-                    rusty_lr_core::rule::Precedence::Fixed(level) => {
-                        assert!(
-                            level < (1 << 30),
-                            "Precedence level {} exceeds 30-bit limit",
-                            level
-                        );
-                        ((level as u32) << 2) | 1
-                    }
-                    rusty_lr_core::rule::Precedence::Dynamic(idx) => {
-                        assert!(
-                            idx < (1 << 30),
-                            "Precedence dynamic token index {} exceeds 30-bit limit",
-                            idx
-                        );
-                        ((idx as u32) << 2) | 2
-                    }
+            let prec_val = match rule.rule.precedence {
+                rusty_lr_core::rule::Precedence::None => 0,
+                rusty_lr_core::rule::Precedence::Fixed(level) => {
+                    assert!(
+                        level < (1 << 30),
+                        "Precedence level {} exceeds 30-bit limit",
+                        level
+                    );
+                    ((level as u32) << 2) | 1
                 }
-            } else {
-                0
+                rusty_lr_core::rule::Precedence::Dynamic(idx) => {
+                    assert!(
+                        idx < (1 << 30),
+                        "Precedence dynamic token index {} exceeds 30-bit limit",
+                        idx
+                    );
+                    ((idx as u32) << 2) | 2
+                }
             };
             rule_precedences.push(prec_val);
             rule_lengths.push(rule.rule.rule.len() as u32);
@@ -881,9 +878,9 @@ impl Grammar {
 
                             let prec_val = RULE_PRECEDENCES[i];
                             let precedence = match prec_val & 3 {
-                                0 => None,
-                                1 => Some(#module_prefix::rule::Precedence::Fixed((prec_val >> 2) as usize)),
-                                2 => Some(#module_prefix::rule::Precedence::Dynamic((prec_val >> 2) as usize)),
+                                0 => #module_prefix::rule::Precedence::None,
+                                1 => #module_prefix::rule::Precedence::Fixed((prec_val >> 2) as usize),
+                                2 => #module_prefix::rule::Precedence::Dynamic((prec_val >> 2) as usize),
                                 _ => unreachable!(),
                             };
 

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -1690,6 +1690,11 @@ impl Grammar {
                                     changed = true;
                                 }
                             }
+                            Precedence::None => {
+                                if nonterm_prec_candidates[nonterm_idx].insert(None) {
+                                    changed = true;
+                                }
+                            }
                         },
                         _ => {
                             if nonterm_prec_candidates[nonterm_idx].insert(None) {
@@ -2512,7 +2517,9 @@ impl Grammar {
                 grammar.add_rule(
                     nonterm_id,
                     tokens,
-                    rule.prec.map(Located::into_value),
+                    rule.prec
+                        .map(Located::into_value)
+                        .unwrap_or(Precedence::None),
                     rule.dprec.map_or(0, Located::into_value),
                 );
             }

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -6738,20 +6738,12 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     let name = GrammarNonTerminals::from_usize(RULE_NAMES[i] as usize);
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
-                        0 => None,
+                        0 => ::rusty_lr_core::rule::Precedence::None,
                         1 => {
-                            Some(
-                                ::rusty_lr_core::rule::Precedence::Fixed(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
+                            ::rusty_lr_core::rule::Precedence::Fixed((prec_val >> 2) as usize)
                         }
                         2 => {
-                            Some(
-                                ::rusty_lr_core::rule::Precedence::Dynamic(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
+                            ::rusty_lr_core::rule::Precedence::Dynamic((prec_val >> 2) as usize)
                         }
                         _ => unreachable!(),
                     };

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -6740,10 +6740,14 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     let precedence = match prec_val & 3 {
                         0 => ::rusty_lr_core::rule::Precedence::None,
                         1 => {
-                            ::rusty_lr_core::rule::Precedence::Fixed((prec_val >> 2) as usize)
+                            ::rusty_lr_core::rule::Precedence::Fixed(
+                                (prec_val >> 2) as usize,
+                            )
                         }
                         2 => {
-                            ::rusty_lr_core::rule::Precedence::Dynamic((prec_val >> 2) as usize)
+                            ::rusty_lr_core::rule::Precedence::Dynamic(
+                                (prec_val >> 2) as usize,
+                            )
                         }
                         _ => unreachable!(),
                     };

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -682,21 +682,9 @@ impl ::rusty_lr::parser::Parser for EParser {
                     let name = ENonTerminals::from_usize(RULE_NAMES[i] as usize);
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
-                        0 => None,
-                        1 => {
-                            Some(
-                                ::rusty_lr::rule::Precedence::Fixed(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
-                        }
-                        2 => {
-                            Some(
-                                ::rusty_lr::rule::Precedence::Dynamic(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
-                        }
+                        0 => ::rusty_lr::rule::Precedence::None,
+                        1 => ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize),
+                        2 => ::rusty_lr::rule::Precedence::Dynamic((prec_val >> 2) as usize),
                         _ => unreachable!(),
                     };
                     rules

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -683,8 +683,14 @@ impl ::rusty_lr::parser::Parser for EParser {
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
                         0 => ::rusty_lr::rule::Precedence::None,
-                        1 => ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize),
-                        2 => ::rusty_lr::rule::Precedence::Dynamic((prec_val >> 2) as usize),
+                        1 => {
+                            ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize)
+                        }
+                        2 => {
+                            ::rusty_lr::rule::Precedence::Dynamic(
+                                (prec_val >> 2) as usize,
+                            )
+                        }
                         _ => unreachable!(),
                     };
                     rules

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -925,21 +925,9 @@ impl ::rusty_lr::parser::Parser for EParser {
                     let name = ENonTerminals::from_usize(RULE_NAMES[i] as usize);
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
-                        0 => None,
-                        1 => {
-                            Some(
-                                ::rusty_lr::rule::Precedence::Fixed(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
-                        }
-                        2 => {
-                            Some(
-                                ::rusty_lr::rule::Precedence::Dynamic(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
-                        }
+                        0 => ::rusty_lr::rule::Precedence::None,
+                        1 => ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize),
+                        2 => ::rusty_lr::rule::Precedence::Dynamic((prec_val >> 2) as usize),
                         _ => unreachable!(),
                     };
                     rules

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -926,8 +926,14 @@ impl ::rusty_lr::parser::Parser for EParser {
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
                         0 => ::rusty_lr::rule::Precedence::None,
-                        1 => ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize),
-                        2 => ::rusty_lr::rule::Precedence::Dynamic((prec_val >> 2) as usize),
+                        1 => {
+                            ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize)
+                        }
+                        2 => {
+                            ::rusty_lr::rule::Precedence::Dynamic(
+                                (prec_val >> 2) as usize,
+                            )
+                        }
                         _ => unreachable!(),
                     };
                     rules

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -2148,8 +2148,14 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
                         0 => ::rusty_lr::rule::Precedence::None,
-                        1 => ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize),
-                        2 => ::rusty_lr::rule::Precedence::Dynamic((prec_val >> 2) as usize),
+                        1 => {
+                            ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize)
+                        }
+                        2 => {
+                            ::rusty_lr::rule::Precedence::Dynamic(
+                                (prec_val >> 2) as usize,
+                            )
+                        }
                         _ => unreachable!(),
                     };
                     rules

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -2147,21 +2147,9 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                     let name = JsonNonTerminals::from_usize(RULE_NAMES[i] as usize);
                     let prec_val = RULE_PRECEDENCES[i];
                     let precedence = match prec_val & 3 {
-                        0 => None,
-                        1 => {
-                            Some(
-                                ::rusty_lr::rule::Precedence::Fixed(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
-                        }
-                        2 => {
-                            Some(
-                                ::rusty_lr::rule::Precedence::Dynamic(
-                                    (prec_val >> 2) as usize,
-                                ),
-                            )
-                        }
+                        0 => ::rusty_lr::rule::Precedence::None,
+                        1 => ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize),
+                        2 => ::rusty_lr::rule::Precedence::Dynamic((prec_val >> 2) as usize),
                         _ => unreachable!(),
                     };
                     rules


### PR DESCRIPTION
## Description

This PR moves the “no precedence” state into `core::rule::Precedence` itself by adding `Precedence::None`, instead of representing rule precedence as `Option<Precedence>`.

## Changes

- Added `Precedence::None` and made it the default variant.
- Changed production rule and parser table precedence fields from `Option<Precedence>` to `Precedence`.
- Updated builder, deterministic parser, and nondeterministic parser logic to match on `Precedence::None`.
- Updated parser code generation to serialize and decode `Precedence::None`.
- Updated checked-in generated parser output and diff snapshots.