### PR TITLE
Remove Unused Parser State Types and Move Table Primitives

### DIFF
--- a/rusty_lr_core/src/builder/state.rs
+++ b/rusty_lr_core/src/builder/state.rs
@@ -43,7 +43,7 @@ impl<Term, NonTerm> Default for State<Term, NonTerm> {
 }
 
 impl<Term, NonTerm> From<State<Term, NonTerm>>
-    for crate::parser::state::IntermediateState<Term, NonTerm, usize, usize>
+    for crate::parser::state::IntermediateState<Term, NonTerm>
 where
     Term: Ord,
 {

--- a/rusty_lr_core/src/builder/state.rs
+++ b/rusty_lr_core/src/builder/state.rs
@@ -48,7 +48,7 @@ where
     Term: Ord,
 {
     fn from(state: crate::builder::State<Term, NonTerm>) -> Self {
-        use crate::parser::state::ShiftTarget;
+        use crate::parser::table::ShiftTarget;
 
         crate::parser::state::IntermediateState {
             shift_goto_map_term: state

--- a/rusty_lr_core/src/parser/deterministic/context.rs
+++ b/rusty_lr_core/src/parser/deterministic/context.rs
@@ -5,7 +5,7 @@ use crate::Location;
 
 use crate::parser::data_stack::DataStack;
 use crate::parser::nonterminal::NonTerminal;
-use crate::parser::state::Index;
+use crate::parser::table::Index;
 use crate::parser::table::ParserTables;
 use crate::parser::terminalclass::TerminalClass;
 use crate::parser::Parser;

--- a/rusty_lr_core/src/parser/mod.rs
+++ b/rusty_lr_core/src/parser/mod.rs
@@ -12,7 +12,6 @@ pub mod nonterminal;
 pub mod terminalclass;
 
 pub mod state;
-pub use state::State;
 pub mod table;
 
 #[derive(Clone, Copy)]

--- a/rusty_lr_core/src/parser/mod.rs
+++ b/rusty_lr_core/src/parser/mod.rs
@@ -51,7 +51,7 @@ pub trait Parser {
     /// The type of non-terminal symbols.
     type NonTerm: nonterminal::NonTerminal + 'static;
     /// The compact integer type used for state indices.
-    type StateIndex: state::Index + 'static;
+    type StateIndex: table::Index + 'static;
     /// The reduce-rule container for a terminal action.
     type ReduceRules: table::ReduceRules + 'static;
     /// The type of the parser table.

--- a/rusty_lr_core/src/parser/nondeterministic/context.rs
+++ b/rusty_lr_core/src/parser/nondeterministic/context.rs
@@ -5,7 +5,7 @@ use super::ParseError;
 
 use crate::parser::data_stack::DataStack;
 use crate::parser::nonterminal::NonTerminal;
-use crate::parser::state::Index;
+use crate::parser::table::Index;
 use crate::parser::table::ParserTables;
 use crate::parser::terminalclass::TerminalClass;
 use crate::parser::Parser;

--- a/rusty_lr_core/src/parser/state.rs
+++ b/rusty_lr_core/src/parser/state.rs
@@ -3,53 +3,10 @@ use crate::TriState;
 
 /// One decoded parser-table row used by generated code and the grammar builder before converting
 /// to a concrete runtime table layout.
-pub struct IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex> {
-    pub shift_goto_map_term: Vec<(TermClass, ShiftTarget<StateIndex>)>, // must be sorted
-    pub shift_goto_map_nonterm: Vec<(NonTerm, ShiftTarget<StateIndex>)>, // must be sorted
-    pub reduce_map: Vec<(TermClass, Vec<RuleIndex>)>,                   // must be sorted
+pub struct IntermediateState<TermClass, NonTerm> {
+    pub shift_goto_map_term: Vec<(TermClass, ShiftTarget<usize>)>, // must be sorted
+    pub shift_goto_map_nonterm: Vec<(NonTerm, ShiftTarget<usize>)>, // must be sorted
+    pub reduce_map: Vec<(TermClass, Vec<usize>)>,                  // must be sorted
     pub ruleset: Vec<crate::rule::ShiftedRuleRef>,
     pub can_accept_error: TriState,
-}
-
-/// For state, terminal and class indices, we use the most compact integer type that can hold the maximum value.
-/// This trait defines the conversion between {u8, u16, u32, usize} <-> usize.
-pub trait Index: Copy {
-    fn into_usize(self) -> usize;
-    fn from_usize_unchecked(value: usize) -> Self;
-}
-
-impl Index for usize {
-    fn into_usize(self) -> usize {
-        self
-    }
-    fn from_usize_unchecked(value: usize) -> Self {
-        value
-    }
-}
-
-impl Index for u8 {
-    fn into_usize(self) -> usize {
-        self as usize
-    }
-    fn from_usize_unchecked(value: usize) -> Self {
-        value as u8
-    }
-}
-
-impl Index for u16 {
-    fn into_usize(self) -> usize {
-        self as usize
-    }
-    fn from_usize_unchecked(value: usize) -> Self {
-        value as u16
-    }
-}
-
-impl Index for u32 {
-    fn into_usize(self) -> usize {
-        self as usize
-    }
-    fn from_usize_unchecked(value: usize) -> Self {
-        value as u32
-    }
 }

--- a/rusty_lr_core/src/parser/state.rs
+++ b/rusty_lr_core/src/parser/state.rs
@@ -1,26 +1,8 @@
-use std::hash::Hash;
-
-use crate::hash::HashMap;
-use crate::parser::nonterminal::NonTerminal;
-use crate::parser::table::ReduceRules;
-use crate::parser::terminalclass::TerminalClass;
+use crate::parser::table::ShiftTarget;
 use crate::TriState;
 
-#[derive(Debug, Clone, Copy)]
-pub struct ShiftTarget<StateIndex> {
-    pub state: StateIndex,
-    /// true if the data should be pushed, false if data should not be pushed (so `Empty` tag will be pushed)
-    pub push: bool,
-}
-impl<StateIndex> ShiftTarget<StateIndex> {
-    #[inline]
-    pub fn new(state: StateIndex, push: bool) -> Self {
-        ShiftTarget { state, push }
-    }
-}
-
-/// This intermediate state is a common structure to convert from generated code and grammar builder
-/// into various types of parser states (SparseState, DenseState, ...).
+/// One decoded parser-table row used by generated code and the grammar builder before converting
+/// to a concrete runtime table layout.
 pub struct IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex> {
     pub shift_goto_map_term: Vec<(TermClass, ShiftTarget<StateIndex>)>, // must be sorted
     pub shift_goto_map_nonterm: Vec<(NonTerm, ShiftTarget<StateIndex>)>, // must be sorted
@@ -35,6 +17,7 @@ pub trait Index: Copy {
     fn into_usize(self) -> usize;
     fn from_usize_unchecked(value: usize) -> Self;
 }
+
 impl Index for usize {
     fn into_usize(self) -> usize {
         self
@@ -43,6 +26,7 @@ impl Index for usize {
         value
     }
 }
+
 impl Index for u8 {
     fn into_usize(self) -> usize {
         self as usize
@@ -51,6 +35,7 @@ impl Index for u8 {
         value as u8
     }
 }
+
 impl Index for u16 {
     fn into_usize(self) -> usize {
         self as usize
@@ -59,327 +44,12 @@ impl Index for u16 {
         value as u16
     }
 }
+
 impl Index for u32 {
     fn into_usize(self) -> usize {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
         value as u32
-    }
-}
-
-/// A trait representing a parser state.
-pub trait State {
-    type TermClass: TerminalClass;
-    type NonTerm: NonTerminal;
-    type ReduceRules: ReduceRules;
-    type StateIndex: Index;
-
-    /// Get the next state for a given terminal symbol.
-    fn shift_goto_class(&self, class: Self::TermClass) -> Option<ShiftTarget<Self::StateIndex>>;
-
-    /// Get the next state for a given non-terminal symbol.
-    fn shift_goto_nonterm(&self, nonterm: Self::NonTerm) -> Option<ShiftTarget<Self::StateIndex>>;
-    /// Get the reduce rule index for a given terminal symbol.
-    fn reduce(&self, class: Self::TermClass) -> Option<&Self::ReduceRules>;
-
-    /// Check if this state is an accept state.
-    fn is_accept(&self) -> bool;
-
-    /// Get the set of expected terminal classes for shift in this state
-    fn expected_shift_term(&self) -> impl Iterator<Item = Self::TermClass> + '_;
-
-    /// Get the set of expected non-terminal symbols for shift in this state
-    fn expected_shift_nonterm(&self) -> impl Iterator<Item = Self::NonTerm> + '_;
-
-    /// Get the set of production rule for reduce in this state
-    fn expected_reduce_rule(&self) -> impl Iterator<Item = impl Index> + '_;
-
-    fn can_accept_error(&self) -> TriState;
-}
-
-/// `State` implementation for a sparse state representation using HashMap
-#[derive(Debug, Clone)]
-pub struct SparseState<TermClass, NonTerm, RuleContainer, StateIndex> {
-    /// terminal symbol -> next state
-    pub(crate) shift_goto_map_class: HashMap<TermClass, ShiftTarget<StateIndex>>,
-
-    /// non-terminal symbol -> next state
-    pub(crate) shift_goto_map_nonterm: HashMap<NonTerm, ShiftTarget<StateIndex>>,
-
-    /// terminal symbol -> reduce rule index
-    pub(crate) reduce_map: HashMap<TermClass, RuleContainer>,
-
-    pub(crate) can_accept_error: TriState,
-}
-
-impl<
-        TermClass: TerminalClass + Hash + Eq,
-        NonTerm: NonTerminal + Hash + Eq,
-        RuleContainer: ReduceRules,
-        StateIndex: Index,
-    > State for SparseState<TermClass, NonTerm, RuleContainer, StateIndex>
-{
-    type TermClass = TermClass;
-    type NonTerm = NonTerm;
-    type ReduceRules = RuleContainer;
-    type StateIndex = StateIndex;
-
-    fn shift_goto_class(&self, class: Self::TermClass) -> Option<ShiftTarget<Self::StateIndex>> {
-        self.shift_goto_map_class.get(&class).copied()
-    }
-    fn shift_goto_nonterm(&self, nonterm: Self::NonTerm) -> Option<ShiftTarget<Self::StateIndex>> {
-        self.shift_goto_map_nonterm.get(&nonterm).copied()
-    }
-    fn reduce(&self, class: Self::TermClass) -> Option<&Self::ReduceRules> {
-        self.reduce_map.get(&class)
-    }
-    fn is_accept(&self) -> bool {
-        self.reduce_map.is_empty()
-            && self.shift_goto_map_class.is_empty()
-            && self.shift_goto_map_nonterm.is_empty()
-    }
-    fn expected_shift_term(&self) -> impl Iterator<Item = Self::TermClass> + '_ {
-        self.shift_goto_map_class.keys().copied()
-    }
-    fn expected_shift_nonterm(&self) -> impl Iterator<Item = Self::NonTerm> + '_ {
-        self.shift_goto_map_nonterm.keys().copied()
-    }
-    fn expected_reduce_rule(&self) -> impl Iterator<Item = impl Index> + '_ {
-        self.reduce_map.values().flat_map(RuleContainer::to_iter)
-    }
-    fn can_accept_error(&self) -> TriState {
-        self.can_accept_error
-    }
-}
-
-/// `State` implementation for a dense state representation using Vec
-#[derive(Debug, Clone)]
-pub struct DenseState<TermClass, NonTerm, RuleContainer, StateIndex> {
-    /// terminal symbol -> next state
-    pub(crate) shift_goto_map_class: Vec<Option<ShiftTarget<StateIndex>>>,
-    /// shift_goto_map_class[i] will contain i+offset 'th class's next state.
-    pub(crate) shift_class_offset: usize,
-    /// set of terminal classes that is keys of `shift_goto_map_class`
-    pub(crate) shift_goto_map_class_keys: Vec<TermClass>,
-
-    /// non-terminal symbol -> next state
-    pub(crate) shift_goto_map_nonterm: Vec<Option<ShiftTarget<StateIndex>>>,
-    pub(crate) shift_nonterm_offset: usize,
-    /// set of non-terminal symbols that is keys of `shift_goto_map_nonterm`
-    pub(crate) shift_goto_map_nonterm_keys: Vec<NonTerm>,
-
-    /// terminal symbol -> reduce rule index
-    pub(crate) reduce_map: Vec<Option<RuleContainer>>,
-    /// reduce_map[i] will contain i+offset 'th class's reduce rule.
-    pub(crate) reduce_offset: usize,
-
-    pub(crate) can_accept_error: TriState,
-}
-impl<
-        TermClass: TerminalClass,
-        NonTerm: NonTerminal,
-        RuleContainer: ReduceRules,
-        StateIndex: Index,
-    > State for DenseState<TermClass, NonTerm, RuleContainer, StateIndex>
-{
-    type TermClass = TermClass;
-    type NonTerm = NonTerm;
-    type ReduceRules = RuleContainer;
-    type StateIndex = StateIndex;
-
-    fn shift_goto_class(&self, class: Self::TermClass) -> Option<ShiftTarget<Self::StateIndex>> {
-        self.shift_goto_map_class
-            .get(class.to_usize().wrapping_sub(self.shift_class_offset))
-            .copied()
-            .flatten()
-    }
-    fn shift_goto_nonterm(&self, nonterm: Self::NonTerm) -> Option<ShiftTarget<Self::StateIndex>> {
-        self.shift_goto_map_nonterm
-            .get(nonterm.to_usize().wrapping_sub(self.shift_nonterm_offset))
-            .copied()
-            .flatten()
-    }
-    fn reduce(&self, class: Self::TermClass) -> Option<&Self::ReduceRules> {
-        self.reduce_map
-            .get(class.to_usize().wrapping_sub(self.reduce_offset))
-            .and_then(|r| r.as_ref())
-    }
-    fn is_accept(&self) -> bool {
-        self.reduce_map.is_empty()
-            && self.shift_goto_map_class.is_empty()
-            && self.shift_goto_map_nonterm.is_empty()
-    }
-    fn expected_shift_term(&self) -> impl Iterator<Item = Self::TermClass> + '_ {
-        self.shift_goto_map_class_keys.iter().copied()
-    }
-    fn expected_shift_nonterm(&self) -> impl Iterator<Item = NonTerm> + '_ {
-        self.shift_goto_map_nonterm_keys.iter().copied()
-    }
-    fn expected_reduce_rule(&self) -> impl Iterator<Item = impl Index> + '_ {
-        self.reduce_map
-            .iter()
-            .filter_map(|r| r.as_ref())
-            .flat_map(RuleContainer::to_iter)
-    }
-
-    fn can_accept_error(&self) -> TriState {
-        self.can_accept_error
-    }
-}
-
-impl<TermClass: TerminalClass, NonTerm: NonTerminal, RuleContainer, StateIndex, RuleIndex>
-    From<IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex>>
-    for SparseState<TermClass, NonTerm, RuleContainer, StateIndex>
-where
-    TermClass: Ord + Hash,
-    NonTerm: Hash + Eq,
-    RuleContainer: ReduceRules,
-    RuleContainer::RuleIndex: TryFrom<RuleIndex>,
-{
-    fn from(builder_state: IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex>) -> Self {
-        // TerminalSymbol::Term(_) < TerminalSymbol::Error < TerminalSymbol::Eof
-        // since maps are sorted, eof and error should be at the end of the array
-
-        // make sure the order is preserved
-        #[cfg(debug_assertions)]
-        {
-            let keys = builder_state
-                .shift_goto_map_term
-                .iter()
-                .map(|(term, _)| term)
-                .collect::<Vec<_>>();
-            debug_assert!(keys.is_sorted());
-
-            let keys = builder_state
-                .reduce_map
-                .iter()
-                .map(|(term, _)| term)
-                .collect::<Vec<_>>();
-            debug_assert!(keys.is_sorted());
-        }
-        SparseState {
-            shift_goto_map_class: builder_state.shift_goto_map_term.into_iter().collect(),
-            shift_goto_map_nonterm: builder_state.shift_goto_map_nonterm.into_iter().collect(),
-            reduce_map: builder_state
-                .reduce_map
-                .into_iter()
-                .map(|(term, rule)| {
-                    (
-                        term.try_into().expect("term conversion failed"),
-                        RuleContainer::from_set(rule),
-                    )
-                })
-                .collect(),
-            can_accept_error: builder_state.can_accept_error,
-        }
-    }
-}
-impl<TermClass: TerminalClass, NonTerm: NonTerminal, RuleContainer, StateIndex, RuleIndex>
-    From<IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex>>
-    for DenseState<TermClass, NonTerm, RuleContainer, StateIndex>
-where
-    TermClass: Ord + Copy,
-    NonTerm: Hash + Eq + Copy + NonTerminal,
-    StateIndex: Copy,
-    RuleContainer: Clone + ReduceRules,
-    RuleContainer::RuleIndex: TryFrom<RuleIndex>,
-{
-    fn from(builder_state: IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex>) -> Self {
-        // TerminalSymbol::Term(_) < TerminalSymbol::Error < TerminalSymbol::Eof
-        // since maps are sorted, eof and error should be at the end of the array
-
-        // make sure the order is preserved
-        #[cfg(debug_assertions)]
-        {
-            let keys = builder_state
-                .shift_goto_map_term
-                .iter()
-                .map(|(term, _)| term)
-                .collect::<Vec<_>>();
-            debug_assert!(keys.is_sorted());
-
-            let keys = builder_state
-                .reduce_map
-                .iter()
-                .map(|(term, _)| term)
-                .collect::<Vec<_>>();
-            debug_assert!(keys.is_sorted());
-        }
-
-        let (shift_min, shift_len) = {
-            let mut iter = builder_state
-                .shift_goto_map_term
-                .iter()
-                .map(|(term, _)| term);
-            let min: Option<usize> = iter.next().map(|x| x.to_usize());
-            let max: Option<usize> = iter.next_back().map(|x| x.to_usize()).or(min);
-
-            if let (Some(min), Some(max)) = (min, max) {
-                (min, max - min + 1)
-            } else {
-                (0, 0)
-            }
-        };
-        let (reduce_min, reduce_len) = {
-            let mut iter = builder_state.reduce_map.iter().map(|(term, _)| term);
-            let min: Option<usize> = iter.next().map(|x| x.to_usize());
-            let max: Option<usize> = iter.next_back().map(|x| x.to_usize()).or(min);
-            if let (Some(min), Some(max)) = (min, max) {
-                (min, max - min + 1)
-            } else {
-                (0, 0)
-            }
-        };
-        let (nonterm_min, nonterm_len) = {
-            let mut iter = builder_state
-                .shift_goto_map_nonterm
-                .iter()
-                .map(|(nonterm, _)| nonterm);
-            let min = iter.next().map(|x| x.to_usize());
-            let max = iter.next_back().map(|x| x.to_usize()).or(min);
-            if let (Some(min), Some(max)) = (min, max) {
-                (min, max - min + 1)
-            } else {
-                (0, 0)
-            }
-        };
-
-        let shift_term_keys = builder_state
-            .shift_goto_map_term
-            .iter()
-            .map(|(term, _)| *term)
-            .collect();
-        let mut shift_goto_map_class = vec![None; shift_len];
-        for (term, state) in builder_state.shift_goto_map_term {
-            shift_goto_map_class[term.to_usize() - shift_min] = Some(state);
-        }
-
-        let mut reduce_map = vec![None; reduce_len];
-        for (term, rule) in builder_state.reduce_map {
-            reduce_map[term.to_usize() - reduce_min] = Some(RuleContainer::from_set(rule));
-        }
-
-        let nonterm_keys = builder_state
-            .shift_goto_map_nonterm
-            .iter()
-            .map(|(nonterm, _)| *nonterm)
-            .collect();
-        let mut shift_goto_map_nonterm = vec![None; nonterm_len];
-        for (nonterm, state) in builder_state.shift_goto_map_nonterm {
-            shift_goto_map_nonterm[nonterm.to_usize() - nonterm_min] = Some(state);
-        }
-
-        DenseState {
-            shift_goto_map_class,
-            shift_class_offset: shift_min,
-            shift_goto_map_class_keys: shift_term_keys,
-            shift_goto_map_nonterm,
-            shift_goto_map_nonterm_keys: nonterm_keys,
-            shift_nonterm_offset: nonterm_min,
-            reduce_map,
-            reduce_offset: reduce_min,
-            can_accept_error: builder_state.can_accept_error,
-        }
     }
 }

--- a/rusty_lr_core/src/parser/table.rs
+++ b/rusty_lr_core/src/parser/table.rs
@@ -3,10 +3,52 @@
 //! This module is the public home for parser table layouts used by generated parsers.
 
 use crate::parser::nonterminal::NonTerminal;
-use crate::parser::state::Index;
 use crate::parser::state::IntermediateState;
 use crate::parser::terminalclass::TerminalClass;
 use crate::TriState;
+
+/// For state, terminal and class indices, we use the most compact integer type that can hold the maximum value.
+/// This trait defines the conversion between {u8, u16, u32, usize} <-> usize.
+pub trait Index: Copy {
+    fn into_usize(self) -> usize;
+    fn from_usize_unchecked(value: usize) -> Self;
+}
+
+impl Index for usize {
+    fn into_usize(self) -> usize {
+        self
+    }
+    fn from_usize_unchecked(value: usize) -> Self {
+        value
+    }
+}
+
+impl Index for u8 {
+    fn into_usize(self) -> usize {
+        self as usize
+    }
+    fn from_usize_unchecked(value: usize) -> Self {
+        value as u8
+    }
+}
+
+impl Index for u16 {
+    fn into_usize(self) -> usize {
+        self as usize
+    }
+    fn from_usize_unchecked(value: usize) -> Self {
+        value as u16
+    }
+}
+
+impl Index for u32 {
+    fn into_usize(self) -> usize {
+        self as usize
+    }
+    fn from_usize_unchecked(value: usize) -> Self {
+        value as u32
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct ShiftTarget<StateIndex> {
@@ -19,6 +61,16 @@ impl<StateIndex> ShiftTarget<StateIndex> {
     #[inline]
     pub fn new(state: StateIndex, push: bool) -> Self {
         ShiftTarget { state, push }
+    }
+}
+
+impl ShiftTarget<usize> {
+    #[inline]
+    fn compact<StateIndex: Index>(self) -> ShiftTarget<StateIndex> {
+        ShiftTarget {
+            state: StateIndex::from_usize_unchecked(self.state),
+            push: self.push,
+        }
     }
 }
 
@@ -35,9 +87,9 @@ pub struct RuleInfo<NonTerm> {
 
 /// Intermediate flat parser table data used by generated code before converting to a concrete
 /// dense or sparse runtime layout.
-pub struct IntermediateTables<TermClass, NonTerm, StateIndex, RuleIndex> {
+pub struct IntermediateTables<TermClass, NonTerm> {
     /// One decoded transition/action row per LR state.
-    pub state_rows: Vec<IntermediateState<TermClass, NonTerm, StateIndex, RuleIndex>>,
+    pub state_rows: Vec<IntermediateState<TermClass, NonTerm>>,
     pub rules: Vec<RuleInfo<NonTerm>>,
 }
 
@@ -225,16 +277,16 @@ pub struct SparseFlatTables<TermClass, NonTerm, RuleContainer, StateIndex> {
     rules: Vec<RuleInfo<NonTerm>>,
 }
 
-impl<TermClass, NonTerm, RuleContainer, StateIndex, RuleIndex>
-    From<IntermediateTables<TermClass, NonTerm, StateIndex, RuleIndex>>
+impl<TermClass, NonTerm, RuleContainer, StateIndex> From<IntermediateTables<TermClass, NonTerm>>
     for SparseFlatTables<TermClass, NonTerm, RuleContainer, StateIndex>
 where
     TermClass: TerminalClass + Ord,
     NonTerm: NonTerminal + Ord,
+    StateIndex: Index,
     RuleContainer: ReduceRules,
-    RuleContainer::RuleIndex: TryFrom<RuleIndex>,
+    RuleContainer::RuleIndex: TryFrom<usize>,
 {
-    fn from(intermediate: IntermediateTables<TermClass, NonTerm, StateIndex, RuleIndex>) -> Self {
+    fn from(intermediate: IntermediateTables<TermClass, NonTerm>) -> Self {
         let mut term_offsets = Vec::with_capacity(intermediate.state_rows.len() + 1);
         let mut term_actions = Vec::new();
         let mut nonterm_offsets = Vec::with_capacity(intermediate.state_rows.len() + 1);
@@ -258,14 +310,17 @@ where
                         match shift_term.cmp(reduce_term) {
                             Ordering::Less => {
                                 let (term, shift) = shifts.next().unwrap();
-                                term_actions.push((term, TermAction::Shift(shift)));
+                                term_actions.push((term, TermAction::Shift(shift.compact())));
                             }
                             Ordering::Equal => {
                                 let (term, shift) = shifts.next().unwrap();
                                 let (_, rules) = reduces.next().unwrap();
                                 term_actions.push((
                                     term,
-                                    TermAction::ShiftReduce(shift, RuleContainer::from_set(rules)),
+                                    TermAction::ShiftReduce(
+                                        shift.compact(),
+                                        RuleContainer::from_set(rules),
+                                    ),
                                 ));
                             }
                             Ordering::Greater => {
@@ -279,7 +334,7 @@ where
                     }
                     (Some(_), None) => {
                         let (term, shift) = shifts.next().unwrap();
-                        term_actions.push((term, TermAction::Shift(shift)));
+                        term_actions.push((term, TermAction::Shift(shift.compact())));
                     }
                     (None, Some(_)) => {
                         let (term, rules) = reduces.next().unwrap();
@@ -291,7 +346,12 @@ where
             }
             term_offsets.push(term_actions.len());
 
-            nonterm_goto.extend(state.shift_goto_map_nonterm);
+            nonterm_goto.extend(
+                state
+                    .shift_goto_map_nonterm
+                    .into_iter()
+                    .map(|(nonterm, target)| (nonterm, target.compact())),
+            );
             nonterm_offsets.push(nonterm_goto.len());
             can_accept_error.push(state.can_accept_error);
         }
@@ -432,17 +492,16 @@ pub struct DenseFlatTables<TermClass, NonTerm, RuleContainer, StateIndex> {
     rules: Vec<RuleInfo<NonTerm>>,
 }
 
-impl<TermClass, NonTerm, RuleContainer, StateIndex, RuleIndex>
-    From<IntermediateTables<TermClass, NonTerm, StateIndex, RuleIndex>>
+impl<TermClass, NonTerm, RuleContainer, StateIndex> From<IntermediateTables<TermClass, NonTerm>>
     for DenseFlatTables<TermClass, NonTerm, RuleContainer, StateIndex>
 where
     TermClass: TerminalClass + Ord,
     NonTerm: NonTerminal + Ord,
-    StateIndex: Copy,
+    StateIndex: Index,
     RuleContainer: Clone + ReduceRules,
-    RuleContainer::RuleIndex: TryFrom<RuleIndex>,
+    RuleContainer::RuleIndex: TryFrom<usize>,
 {
-    fn from(intermediate: IntermediateTables<TermClass, NonTerm, StateIndex, RuleIndex>) -> Self {
+    fn from(intermediate: IntermediateTables<TermClass, NonTerm>) -> Self {
         let mut term_offsets = Vec::with_capacity(intermediate.state_rows.len() + 1);
         let mut term_mins = Vec::with_capacity(intermediate.state_rows.len());
         let mut term_actions = Vec::new();
@@ -495,7 +554,7 @@ where
                             Ordering::Less => {
                                 let (term, shift) = shifts.next().unwrap();
                                 let idx = term_base + term.to_usize() - term_min;
-                                term_actions[idx] = Some(TermAction::Shift(shift));
+                                term_actions[idx] = Some(TermAction::Shift(shift.compact()));
                                 term_keys.push(term);
                             }
                             Ordering::Equal => {
@@ -503,7 +562,7 @@ where
                                 let (_, rules) = reduces.next().unwrap();
                                 let idx = term_base + term.to_usize() - term_min;
                                 term_actions[idx] = Some(TermAction::ShiftReduce(
-                                    shift,
+                                    shift.compact(),
                                     RuleContainer::from_set(rules),
                                 ));
                                 term_keys.push(term);
@@ -519,7 +578,7 @@ where
                     (Some(_), None) => {
                         let (term, shift) = shifts.next().unwrap();
                         let idx = term_base + term.to_usize() - term_min;
-                        term_actions[idx] = Some(TermAction::Shift(shift));
+                        term_actions[idx] = Some(TermAction::Shift(shift.compact()));
                         term_keys.push(term);
                     }
                     (None, Some(_)) => {
@@ -549,7 +608,7 @@ where
             nonterm_goto.resize_with(nonterm_base + nonterm_len, || None);
             for (nonterm, target) in state.shift_goto_map_nonterm {
                 let idx = nonterm_base + nonterm.to_usize() - nonterm_min;
-                nonterm_goto[idx] = Some(target);
+                nonterm_goto[idx] = Some(target.compact());
                 nonterm_keys.push(nonterm);
             }
             nonterm_offsets.push(nonterm_goto.len());

--- a/rusty_lr_core/src/parser/table.rs
+++ b/rusty_lr_core/src/parser/table.rs
@@ -1,14 +1,26 @@
 //! Runtime parser table layouts and access traits.
 //!
-//! The `state` module keeps state-level primitives and the older per-state representations.
-//! This module is the public home for whole-table layouts used by generated parsers.
+//! This module is the public home for parser table layouts used by generated parsers.
 
 use crate::parser::nonterminal::NonTerminal;
 use crate::parser::state::Index;
 use crate::parser::state::IntermediateState;
-use crate::parser::state::ShiftTarget;
 use crate::parser::terminalclass::TerminalClass;
 use crate::TriState;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ShiftTarget<StateIndex> {
+    pub state: StateIndex,
+    /// true if the data should be pushed, false if data should not be pushed (so `Empty` tag will be pushed)
+    pub push: bool,
+}
+
+impl<StateIndex> ShiftTarget<StateIndex> {
+    #[inline]
+    pub fn new(state: StateIndex, push: bool) -> Self {
+        ShiftTarget { state, push }
+    }
+}
 
 /// Hot-path information for a production rule.
 ///

--- a/rusty_lr_core/src/parser/table.rs
+++ b/rusty_lr_core/src/parser/table.rs
@@ -28,6 +28,7 @@ impl Index for u8 {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
+        debug_assert!(value <= u8::MAX as usize, "value {} out of bounds for u8", value);
         value as u8
     }
 }
@@ -37,6 +38,7 @@ impl Index for u16 {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
+        debug_assert!(value <= u16::MAX as usize, "value {} out of bounds for u16", value);
         value as u16
     }
 }
@@ -46,6 +48,7 @@ impl Index for u32 {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
+        debug_assert!(value <= u32::MAX as usize, "value {} out of bounds for u32", value);
         value as u32
     }
 }

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -903,7 +903,7 @@ impl Grammar {
                                 let term_class = #termclass_typename::from_usize((val & 0x7fff) as usize);
                                 let state = ((val >> 15) & 0xffff) as #state_index_typename;
                                 let push = (val >> 31) != 0;
-                                shift_goto_map_term.push((term_class, #module_prefix::parser::state::ShiftTarget::new(state, push)));
+                                shift_goto_map_term.push((term_class, #module_prefix::parser::table::ShiftTarget::new(state, push)));
                             }
 
                             // Decode shift transitions for non-terminals (non-terminal index, next state index, push flag)
@@ -915,7 +915,7 @@ impl Grammar {
                                 let nonterm = #nonterminals_enum_name::from_usize((val & 0x7fff) as usize);
                                 let state = ((val >> 15) & 0xffff) as #state_index_typename;
                                 let push = (val >> 31) != 0;
-                                shift_goto_map_nonterm.push((nonterm, #module_prefix::parser::state::ShiftTarget::new(state, push)));
+                                shift_goto_map_nonterm.push((nonterm, #module_prefix::parser::table::ShiftTarget::new(state, push)));
                             }
 
                             // Decode the reduce action map (variable-length encoding)

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -743,7 +743,7 @@ impl Grammar {
             }
             shift_nonterm_offsets.push(shift_nonterm_data.len() as u32);
 
-            // 3. reduce_map: Vec<(TermClass, Vec<RuleIndex>)>
+            // 3. reduce_map: Vec<(TermClass, Vec<usize>)>
             for (term, rules) in &state.reduce_map {
                 let term_idx = match term {
                     TerminalSymbol::Term(t) => *t,
@@ -901,7 +901,7 @@ impl Grammar {
                             for idx in term_start..term_end {
                                 let val = SHIFT_TERM_DATA[idx];
                                 let term_class = #termclass_typename::from_usize((val & 0x7fff) as usize);
-                                let state = ((val >> 15) & 0xffff) as #state_index_typename;
+                                let state = ((val >> 15) & 0xffff) as usize;
                                 let push = (val >> 31) != 0;
                                 shift_goto_map_term.push((term_class, #module_prefix::parser::table::ShiftTarget::new(state, push)));
                             }
@@ -913,7 +913,7 @@ impl Grammar {
                             for idx in nonterm_start..nonterm_end {
                                 let val = SHIFT_NONTERM_DATA[idx];
                                 let nonterm = #nonterminals_enum_name::from_usize((val & 0x7fff) as usize);
-                                let state = ((val >> 15) & 0xffff) as #state_index_typename;
+                                let state = ((val >> 15) & 0xffff) as usize;
                                 let push = (val >> 31) != 0;
                                 shift_goto_map_nonterm.push((nonterm, #module_prefix::parser::table::ShiftTarget::new(state, push)));
                             }
@@ -929,7 +929,7 @@ impl Grammar {
                                 let len = REDUCE_DATA[idx + 1] as usize;
                                 let mut rules = Vec::with_capacity(len);
                                 for r_idx in 0..len {
-                                    rules.push(REDUCE_DATA[idx + 2 + r_idx] as #rule_index_typename);
+                                    rules.push(REDUCE_DATA[idx + 2 + r_idx] as usize);
                                 }
                                 reduce_map.push((term_class, rules));
                                 idx += 2 + len;

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -113,9 +113,7 @@ pub struct Grammar {
     /// do terminal classificate optimization
     pub optimize: bool,
     pub builder: rusty_lr_core::builder::Grammar<TerminalSymbol<usize>, usize>,
-    pub states: Vec<
-        rusty_lr_core::parser::state::IntermediateState<TerminalSymbol<usize>, usize, usize, usize>,
-    >,
+    pub states: Vec<rusty_lr_core::parser::state::IntermediateState<TerminalSymbol<usize>, usize>>,
 
     /// set of terminals for each terminal class
     pub terminal_classes: Vec<TerminalClassDefinition>,
@@ -2545,12 +2543,7 @@ impl Grammar {
             }
         };
         let mut states: Vec<
-            rusty_lr_core::parser::state::IntermediateState<
-                TerminalSymbol<usize>,
-                usize,
-                usize,
-                usize,
-            >,
+            rusty_lr_core::parser::state::IntermediateState<TerminalSymbol<usize>, usize>,
         > = states.into_iter().map(Into::into).collect();
 
         // Identify states that only perform a single reduction of a single-token rule.

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -6771,7 +6771,7 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                         let term_class = GrammarTerminalClasses::from_usize(
                             (val & 0x7fff) as usize,
                         );
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_term
                             .push((
@@ -6792,7 +6792,7 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                         let nonterm = GrammarNonTerminals::from_usize(
                             (val & 0x7fff) as usize,
                         );
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_nonterm
                             .push((
@@ -6815,7 +6815,7 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                         let len = REDUCE_DATA[idx + 1] as usize;
                         let mut rules = Vec::with_capacity(len);
                         for r_idx in 0..len {
-                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as u8);
+                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as usize);
                         }
                         reduce_map.push((term_class, rules));
                         idx += 2 + len;

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -6776,7 +6776,7 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                         shift_goto_map_term
                             .push((
                                 term_class,
-                                ::rusty_lr_core::parser::state::ShiftTarget::new(
+                                ::rusty_lr_core::parser::table::ShiftTarget::new(
                                     state,
                                     push,
                                 ),
@@ -6797,7 +6797,7 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                         shift_goto_map_nonterm
                             .push((
                                 nonterm,
-                                ::rusty_lr_core::parser::state::ShiftTarget::new(
+                                ::rusty_lr_core::parser::table::ShiftTarget::new(
                                     state,
                                     push,
                                 ),

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -713,7 +713,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         let term_class = ETerminalClasses::from_usize(
                             (val & 0x7fff) as usize,
                         );
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_term
                             .push((
@@ -729,7 +729,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                     for idx in nonterm_start..nonterm_end {
                         let val = SHIFT_NONTERM_DATA[idx];
                         let nonterm = ENonTerminals::from_usize((val & 0x7fff) as usize);
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_nonterm
                             .push((
@@ -747,7 +747,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         let len = REDUCE_DATA[idx + 1] as usize;
                         let mut rules = Vec::with_capacity(len);
                         for r_idx in 0..len {
-                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as u8);
+                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as usize);
                         }
                         reduce_map.push((term_class, rules));
                         idx += 2 + len;

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -718,7 +718,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         shift_goto_map_term
                             .push((
                                 term_class,
-                                ::rusty_lr::parser::state::ShiftTarget::new(state, push),
+                                ::rusty_lr::parser::table::ShiftTarget::new(state, push),
                             ));
                     }
                     let nonterm_start = SHIFT_NONTERM_OFFSETS[i] as usize;
@@ -734,7 +734,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         shift_goto_map_nonterm
                             .push((
                                 nonterm,
-                                ::rusty_lr::parser::state::ShiftTarget::new(state, push),
+                                ::rusty_lr::parser::table::ShiftTarget::new(state, push),
                             ));
                     }
                     let reduce_start = REDUCE_OFFSETS[i] as usize;

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -961,7 +961,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         shift_goto_map_term
                             .push((
                                 term_class,
-                                ::rusty_lr::parser::state::ShiftTarget::new(state, push),
+                                ::rusty_lr::parser::table::ShiftTarget::new(state, push),
                             ));
                     }
                     let nonterm_start = SHIFT_NONTERM_OFFSETS[i] as usize;
@@ -977,7 +977,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         shift_goto_map_nonterm
                             .push((
                                 nonterm,
-                                ::rusty_lr::parser::state::ShiftTarget::new(state, push),
+                                ::rusty_lr::parser::table::ShiftTarget::new(state, push),
                             ));
                     }
                     let reduce_start = REDUCE_OFFSETS[i] as usize;

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -956,7 +956,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         let term_class = ETerminalClasses::from_usize(
                             (val & 0x7fff) as usize,
                         );
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_term
                             .push((
@@ -972,7 +972,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                     for idx in nonterm_start..nonterm_end {
                         let val = SHIFT_NONTERM_DATA[idx];
                         let nonterm = ENonTerminals::from_usize((val & 0x7fff) as usize);
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_nonterm
                             .push((
@@ -990,7 +990,7 @@ impl ::rusty_lr::parser::Parser for EParser {
                         let len = REDUCE_DATA[idx + 1] as usize;
                         let mut rules = Vec::with_capacity(len);
                         for r_idx in 0..len {
-                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as u8);
+                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as usize);
                         }
                         reduce_map.push((term_class, rules));
                         idx += 2 + len;

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -2178,7 +2178,7 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                         let term_class = JsonTerminalClasses::from_usize(
                             (val & 0x7fff) as usize,
                         );
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_term
                             .push((
@@ -2196,7 +2196,7 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                         let nonterm = JsonNonTerminals::from_usize(
                             (val & 0x7fff) as usize,
                         );
-                        let state = ((val >> 15) & 0xffff) as u8;
+                        let state = ((val >> 15) & 0xffff) as usize;
                         let push = (val >> 31) != 0;
                         shift_goto_map_nonterm
                             .push((
@@ -2216,7 +2216,7 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                         let len = REDUCE_DATA[idx + 1] as usize;
                         let mut rules = Vec::with_capacity(len);
                         for r_idx in 0..len {
-                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as u8);
+                            rules.push(REDUCE_DATA[idx + 2 + r_idx] as usize);
                         }
                         reduce_map.push((term_class, rules));
                         idx += 2 + len;

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -2183,7 +2183,7 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                         shift_goto_map_term
                             .push((
                                 term_class,
-                                ::rusty_lr::parser::state::ShiftTarget::new(state, push),
+                                ::rusty_lr::parser::table::ShiftTarget::new(state, push),
                             ));
                     }
                     let nonterm_start = SHIFT_NONTERM_OFFSETS[i] as usize;
@@ -2201,7 +2201,7 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                         shift_goto_map_nonterm
                             .push((
                                 nonterm,
-                                ::rusty_lr::parser::state::ShiftTarget::new(state, push),
+                                ::rusty_lr::parser::table::ShiftTarget::new(state, push),
                             ));
                     }
                     let reduce_start = REDUCE_OFFSETS[i] as usize;


### PR DESCRIPTION
## Summary

- Removed unused per-state runtime types from `parser::state`
- Moved `ShiftTarget` and `Index` into `parser::table`
- Simplified `IntermediateState` to use only `TermClass` and `NonTerm` generics
- Kept intermediate state/rule indices as `usize`, converting to compact runtime indices during table construction
- Updated generated parser code and fixtures to use the new table-side paths
