### PR TITLE
Generalize Diagnostics and Enable Source-Spanned Compile Warnings in Parser

### DIFF
--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -1379,7 +1379,8 @@ impl Builder {
             infos.push(diag);
         }
 
-        // print resolved conflict notes and unresolved GLR conflict help notes
+        // Print resolved conflict notes and unresolved GLR conflict help notes based on user flags.
+        // We match on the new generalized `Info` enum variants to decide whether to print them.
         if self.note_conflicts_resolving || self.note_conflicts {
             for (diag, info_variant) in infos.iter().zip(&grammar.infos) {
                 let should_print = match info_variant {
@@ -1394,7 +1395,7 @@ impl Builder {
                         self.note_conflicts_resolving
                     }
 
-                    _ => true, // optimization notes are printed unconditionally
+                    _ => true, // Optimization notes are printed unconditionally
                 };
                 if should_print {
                     let writer = self.stream();
@@ -1404,7 +1405,7 @@ impl Builder {
                 }
             }
         } else {
-            // print only optimization notes
+            // Print only optimization notes unconditionally if conflict flags are disabled.
             for (diag, info_variant) in infos.iter().zip(&grammar.infos) {
                 let should_print = match info_variant {
                     rusty_lr_parser::error::Info::TerminalsMerged { .. }

--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -1014,8 +1014,10 @@ impl Builder {
         let mut warnings = Vec::new();
         for warning in &grammar.warnings {
             let diag = match warning {
-                rusty_lr_parser::error::Warning::NonTermNotUsed { nonterm_location } => {
-                    let range = span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                rusty_lr_parser::error::Warning::NonTermNotUsed { nonterm_idx } => {
+                    let range = span_manager
+                        .get_byterange(&nonterm_idx.location())
+                        .unwrap_or(0..0);
                     Diagnostic::warning()
                         .with_message("NonTerminal deleted")
                         .with_labels(vec![Label::primary(file_id, range)
@@ -1024,8 +1026,10 @@ impl Builder {
                             "This non-terminal cannot be reached from initial state".to_string(),
                         ])
                 }
-                rusty_lr_parser::error::Warning::Cycle { nonterm_location } => {
-                    let range = span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                rusty_lr_parser::error::Warning::Cycle { nonterm_idx } => {
+                    let range = span_manager
+                        .get_byterange(&nonterm_idx.location())
+                        .unwrap_or(0..0);
                     Diagnostic::warning()
                         .with_message("Cycle detected")
                         .with_labels(vec![Label::primary(file_id, range)
@@ -1034,8 +1038,10 @@ impl Builder {
                             "This non-terminal is involved in bad cycle".to_string()
                         ])
                 }
-                rusty_lr_parser::error::Warning::NonTermDataNotUsed { nonterm_location } => {
-                    let range = span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                rusty_lr_parser::error::Warning::NonTermDataNotUsed { nonterm_idx } => {
+                    let range = span_manager
+                        .get_byterange(&nonterm_idx.location())
+                        .unwrap_or(0..0);
                     Diagnostic::warning()
                         .with_message("NonTerminal data type not used")
                         .with_labels(vec![Label::primary(file_id, range)
@@ -1046,10 +1052,13 @@ impl Builder {
                             "Consider removing data type to optimize memory usage".to_string(),
                         ])
                 }
-                rusty_lr_parser::error::Warning::UnusedTerminals {
-                    class_name,
-                    terminals,
-                } => {
+                rusty_lr_parser::error::Warning::UnusedTerminals { class_idx } => {
+                    let class_name = grammar.class_pretty_name_abbr(*class_idx);
+                    let terminals = grammar.terminal_classes[*class_idx]
+                        .terminals
+                        .iter()
+                        .map(|&term| grammar.term_pretty_name(term))
+                        .collect::<Vec<_>>();
                     let notes = vec![format!("{}: {}", class_name, terminals.join(", "))];
                     Diagnostic::warning()
                         .with_message("These terminals are not used in the grammar")
@@ -1062,10 +1071,16 @@ impl Builder {
         let mut infos = Vec::new();
         for info in &grammar.infos {
             let diag = match info {
-                rusty_lr_parser::error::Info::TerminalsMerged {
-                    class_name,
-                    terminals,
-                } => {
+                rusty_lr_parser::error::Info::TerminalsMerged { class_idx } => {
+                    let class_name = format!(
+                        "TerminalClass{}",
+                        grammar.terminal_classes[*class_idx].multiterm_counter
+                    );
+                    let terminals = grammar.terminal_classes[*class_idx]
+                        .terminals
+                        .iter()
+                        .map(|&term| grammar.term_pretty_name(term))
+                        .collect::<Vec<_>>();
                     let notes = vec![format!("{}: {}", class_name, terminals.join(", "))];
                     Diagnostic::note()
                         .with_message("These terminals are merged into terminal class")
@@ -1083,11 +1098,12 @@ impl Builder {
                         ])
                 }
                 rusty_lr_parser::error::Info::SingleNonTerminalRule {
-                    nonterm_location,
+                    nonterm_idx,
                     rule_location,
                 } => {
-                    let nonterm_range =
-                        span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                    let nonterm_range = span_manager
+                        .get_byterange(&nonterm_idx.location())
+                        .unwrap_or(0..0);
                     let rule_range = span_manager.get_byterange(rule_location).unwrap_or(0..0);
                     Diagnostic::note()
                         .with_message("NonTerminal deleted")
@@ -1145,6 +1161,7 @@ impl Builder {
                     shift_rules,
                     reduce_rules,
                 } => {
+                    let term_str = grammar.class_pretty_name_list(*term, 5);
                     let mut labels = Vec::new();
                     for &reduce_rule_pair in reduce_rules {
                         let (reduce_rule, reduce_prec) = reduce_rule_pair;
@@ -1195,7 +1212,7 @@ impl Builder {
                         );
                     }
                     Diagnostic::note()
-                        .with_message(format!("Shift/Reduce conflict resolved with terminal(class): {term}"))
+                        .with_message(format!("Shift/Reduce conflict resolved with terminal(class): {term_str}"))
                         .with_labels(labels)
                         .with_notes(vec![
                             "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
@@ -1209,6 +1226,7 @@ impl Builder {
                     shift_rules,
                     reduce_rules,
                 } => {
+                    let term_str = grammar.class_pretty_name_list(*term, 5);
                     let mut labels = Vec::new();
                     for &reduce_rule_pair in reduce_rules {
                         let (reduce_rule, reduce_prec) = reduce_rule_pair;
@@ -1257,7 +1275,7 @@ impl Builder {
                         );
                     }
                     Diagnostic::note()
-                        .with_message(format!("Shift/Reduce conflict resolved with terminal(class): {term}"))
+                        .with_message(format!("Shift/Reduce conflict resolved with terminal(class): {term_str}"))
                         .with_labels(labels)
                         .with_notes(vec![
                             "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
@@ -1271,6 +1289,7 @@ impl Builder {
                     shift_rules_backtrace,
                     reduce_rules,
                 } => {
+                    let term_str = grammar.class_pretty_name_list(*term, 5);
                     let mut labels = Vec::new();
                     let mut notes = vec![
                         "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
@@ -1314,7 +1333,7 @@ impl Builder {
                     }
                     Diagnostic::help()
                         .with_message(format!(
-                            "Shift/Reduce conflict detected with terminal(class): {term}"
+                            "Shift/Reduce conflict detected with terminal(class): {term_str}"
                         ))
                         .with_labels(labels)
                         .with_notes(notes)
@@ -1344,10 +1363,14 @@ impl Builder {
                             }
                         }
                     }
+                    let term_strings = terms
+                        .iter()
+                        .map(|&t| grammar.class_pretty_name_list(t, 5))
+                        .collect::<Vec<_>>();
                     Diagnostic::help()
                         .with_message(format!(
                             "Reduce/Reduce conflict detected with terminals: {}",
-                            terms.join(", ")
+                            term_strings.join(", ")
                         ))
                         .with_labels(labels)
                         .with_notes(notes)

--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -30,7 +30,6 @@ use codespan_reporting::term::termcolor::StandardStream;
 use proc_macro2::TokenStream;
 
 use quote::quote;
-use rusty_lr_core::TerminalSymbol;
 use rusty_lr_parser::error::ArgError;
 use rusty_lr_parser::error::ParseArgError;
 use rusty_lr_parser::error::ParseError;
@@ -873,538 +872,552 @@ impl Builder {
             }
         };
 
-        let mut optimize_diags = Vec::new();
-
         // diagnostics for optimization
         if grammar.optimize {
-            use rusty_lr_parser::grammar::OptimizeRemove;
-            let mut optimized = grammar.optimize(25);
-
-            optimized.removed.sort_by_key(|a| match a {
-                OptimizeRemove::TerminalClassRuleMerge(_) => 0,
-                OptimizeRemove::SingleNonTerminalRule(_, _) => 1,
-                OptimizeRemove::NonTermNotUsed(_) => 2,
-                OptimizeRemove::Cycle(_) => 3,
-                OptimizeRemove::NonTermDataNotUsed(_) => 4,
-            });
-
-            if self.note_optimization {
-                // terminals merged into terminal class
-                let mut class_message = Vec::new();
-                for (class_idx, class_def) in grammar.terminal_classes.iter().enumerate() {
-                    let len: usize = class_def
-                        .terminals
-                        .iter()
-                        .map(|term| grammar.terminals[*term].name.count())
-                        .sum();
-                    if len == 1 {
-                        continue;
-                    }
-                    let msg = format!(
-                        "TerminalClass{}: {}",
-                        class_def.multiterm_counter,
-                        grammar.class_pretty_name_list(TerminalSymbol::Term(class_idx), 10)
-                    );
-                    class_message.push(msg);
-                }
-                if !class_message.is_empty() {
-                    let diag = Diagnostic::note()
-                        .with_message("These terminals are merged into terminal class".to_string())
-                        .with_notes(class_message);
-
-                    optimize_diags.push(diag);
-                }
-
-                for o in optimized.removed {
-                    match o {
-                        OptimizeRemove::TerminalClassRuleMerge(rule) => {
-                            let message = "Production Rule deleted";
-                            let rule_location = rule.location();
-                            let range = span_manager.get_byterange(&rule_location).unwrap_or(0..0);
-                            let labels =
-                                vec![Label::primary(file_id, range).with_message("defined here")];
-                            let notes =
-                                vec!["Will be merged into rule using terminal class".to_string()];
-                            let diag = Diagnostic::note()
-                                .with_message(message)
-                                .with_labels(labels)
-                                .with_notes(notes);
-
-                            optimize_diags.push(diag);
-                        }
-                        OptimizeRemove::SingleNonTerminalRule(rule, nonterm_span) => {
-                            let message = "NonTerminal deleted";
-                            let mut labels = Vec::new();
-                            let notes = vec![
-                                "This non-terminal will be replaced by it's unique child rule"
-                                    .to_string(),
-                            ];
-
-                            labels.push(
-                                Label::primary(
-                                    file_id,
-                                    span_manager.get_byterange(&nonterm_span).unwrap_or(0..0),
-                                )
-                                .with_message("non-terminal defined here"),
-                            );
-
-                            let rule_location = rule.location();
-                            let rule_range =
-                                span_manager.get_byterange(&rule_location).unwrap_or(0..0);
-                            labels.push(
-                                Label::secondary(file_id, rule_range)
-                                    .with_message("this rule has only one child rule"),
-                            );
-                            let diag = Diagnostic::note()
-                                .with_message(message)
-                                .with_labels(labels)
-                                .with_notes(notes);
-
-                            optimize_diags.push(diag);
-                        }
-                        OptimizeRemove::NonTermNotUsed(span) => {
-                            let message = "NonTerminal deleted";
-                            let mut labels = Vec::new();
-                            let notes =
-                                vec!["This non-terminal cannot be reached from initial state"
-                                    .to_string()];
-
-                            labels.push(
-                                Label::primary(
-                                    file_id,
-                                    span_manager.get_byterange(&span).unwrap_or(0..0),
-                                )
-                                .with_message("non-terminal defined here"),
-                            );
-
-                            let diag = Diagnostic::warning()
-                                .with_message(message)
-                                .with_labels(labels)
-                                .with_notes(notes);
-
-                            optimize_diags.push(diag);
-                        }
-                        OptimizeRemove::Cycle(span) => {
-                            let message = "Cycle detected";
-                            let mut labels = Vec::new();
-                            let notes =
-                                vec!["This non-terminal is involved in bad cycle".to_string()];
-
-                            labels.push(
-                                Label::primary(
-                                    file_id,
-                                    span_manager.get_byterange(&span).unwrap_or(0..0),
-                                )
-                                .with_message("non-terminal defined here"),
-                            );
-
-                            let diag = Diagnostic::warning()
-                                .with_message(message)
-                                .with_labels(labels)
-                                .with_notes(notes);
-
-                            optimize_diags.push(diag);
-                        }
-                        OptimizeRemove::NonTermDataNotUsed(nonterm_idx) => {
-                            let nonterm = &grammar.nonterminals[nonterm_idx];
-                            let message = "NonTerminal data type not used";
-                            let mut labels = Vec::new();
-                            let notes = vec![
-                                "This non-terminal's data type is not used in any reduce action"
-                                    .to_string(),
-                                "Consider removing data type to optimize memory usage".to_string(),
-                            ];
-
-                            labels.push(
-                                Label::primary(
-                                    file_id,
-                                    span_manager
-                                        .get_byterange(&nonterm.name.location())
-                                        .unwrap_or(0..0),
-                                )
-                                .with_message("non-terminal defined here"),
-                            );
-
-                            let diag = Diagnostic::warning()
-                                .with_message(message)
-                                .with_labels(labels)
-                                .with_notes(notes);
-
-                            optimize_diags.push(diag);
-                        }
-                    }
-                }
-
-                // if other terminals were not used, print warning about removing them
-                let other_terminal_class =
-                    &grammar.terminal_classes[grammar.other_terminal_class_id];
-                if !grammar.other_used && other_terminal_class.terminals.len() > 1 {
-                    let class_name =
-                        grammar.class_pretty_name_abbr(grammar.other_terminal_class_id);
-                    let terms = grammar.class_pretty_name_list(
-                        TerminalSymbol::Term(grammar.other_terminal_class_id),
-                        10,
-                    );
-                    let mut notes = Vec::new();
-                    notes.push(format!("{class_name}: {terms}"));
-
-                    let diag = Diagnostic::warning()
-                        .with_message("These terminals are not used in the grammar")
-                        .with_notes(notes);
-
-                    optimize_diags.push(diag);
-                }
-            }
+            grammar.optimize(25);
         }
 
         grammar.builder = grammar.create_builder();
         let diags_collector = grammar.build_grammar();
 
-        let mut conflict_diags = Vec::new();
-        let mut conflict_diags_resolved = Vec::new();
+        let mut conflict_errors = Vec::new();
         let nonterm_mapper = |nonterm| grammar.nonterm_pretty_name(nonterm);
         let class_mapper = |class| grammar.class_pretty_name_list(class, 5);
 
-        // calculate conflicts
-        for (max_priority, reduce_rules, deleted_rules) in diags_collector.reduce_reduce_resolved {
-            let mut labels = Vec::new();
-            for rule in reduce_rules {
-                let priority = grammar.builder.rules[rule].priority;
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    rule,
-                    &grammar,
-                    "(Reduce) ",
-                    format!("(Reduce) rule with the highest priority: {priority}").as_str(),
-                );
-            }
-            for del in deleted_rules {
-                let priority = grammar.builder.rules[del].priority;
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    del,
-                    &grammar,
-                    "[Removed] (Reduce) ",
-                    format!("[Removed] (Reduce) rule with lower priority: {priority}").as_str(),
-                );
-            }
-
-            let message = "Reduce/Reduce conflict resolved";
-            let notes = vec![
-                format!("Max priority: {max_priority}"),
-                "Set priority for the rule with %dprec".to_string(),
-            ];
-            conflict_diags_resolved.push(
-                Diagnostic::note()
-                    .with_message(message)
-                    .with_labels(labels)
-                    .with_notes(notes),
-            );
-        }
-        for ((term, shift_rules), (shift_prec, reduce_rules)) in
-            diags_collector.shift_reduce_resolved_shift
-        {
-            let mut labels = Vec::new();
-            // shift_prec >= reduce_prec
-
-            for (reduce_rule, reduce_prec) in reduce_rules {
-                let (nonterm_info, local_id) = grammar.get_rule_by_id(reduce_rule).unwrap();
-                let rule_info = &nonterm_info.rules[local_id];
-                if shift_prec > reduce_prec {
-                    Self::extend_rule_source_label(
-                        &mut labels,
-                        file_id,
-                        reduce_rule,
-                        &grammar,
-                        "[Removed] (Reduce) ",
-                        format!("[Removed] (Reduce) lower precedence than shift: {reduce_prec}")
-                            .as_str(),
-                    );
-                } else {
-                    let reduce_type = "%right";
-                    Self::extend_rule_source_label(
-                        &mut labels,
-                        file_id,
-                        reduce_rule,
-                        &grammar,
-                        "[Removed] (Reduce) ",
-                        format!("[Removed] (Reduce) has {reduce_type} associativity").as_str(),
-                    );
-                }
-                if !nonterm_info.is_auto_generated() {
-                    let op_range = span_manager
-                        .get_byterange(&rule_info.prec.unwrap().location())
-                        .unwrap_or(0..0);
-                    labels.push(
-                        Label::secondary(file_id, op_range)
-                            .with_message("[Removed] (Reduce) operator for reduce rule"),
-                    );
-                }
-            }
-            for shift_rule in shift_rules {
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    shift_rule.rule,
-                    &grammar,
-                    "(Shift) ",
-                    format!("(Shift) precedence: {shift_prec}").as_str(),
-                );
-            }
-
-            let message = format!(
-                "Shift/Reduce conflict resolved with terminal(class): {}",
-                grammar.class_pretty_name_list(term, 5)
-            );
-            let notes = vec![
-                        "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
-                        "Set operator for rule explicitly with %prec".to_string(),
-                        "Set precedence for operator with %left, %right, or %precedence"
-                            .to_string(),
-                    ];
-            conflict_diags_resolved.push(
-                Diagnostic::note()
-                    .with_message(message)
-                    .with_labels(labels)
-                    .with_notes(notes),
-            );
-        }
-        for ((term, shift_rules), (shift_prec, reduce_rules)) in
-            diags_collector.shift_reduce_resolved_reduce
-        {
-            let mut labels = Vec::new();
-
-            for (reduce_rule, reduce_prec) in reduce_rules {
-                let (nonterm_info, local_id) = grammar.get_rule_by_id(reduce_rule).unwrap();
-                let rule_info = &nonterm_info.rules[local_id];
-                if reduce_prec > shift_prec {
-                    Self::extend_rule_source_label(
-                        &mut labels,
-                        file_id,
-                        reduce_rule,
-                        &grammar,
-                        "(Reduce) ",
-                        format!("(Reduce) higher precedence than shift: {reduce_prec}").as_str(),
-                    );
-                } else {
-                    let reduce_type = "%left";
-                    Self::extend_rule_source_label(
-                        &mut labels,
-                        file_id,
-                        reduce_rule,
-                        &grammar,
-                        "(Reduce) ",
-                        format!("(Reduce) has {reduce_type} associativity").as_str(),
-                    );
-                }
-
-                if !nonterm_info.is_auto_generated() {
-                    let op_range = span_manager
-                        .get_byterange(&rule_info.prec.unwrap().location())
-                        .unwrap_or(0..0);
-                    labels.push(
-                        Label::secondary(file_id, op_range)
-                            .with_message("(Reduce) operator for reduce rule"),
-                    );
-                }
-            }
-
-            for shift_rule in shift_rules {
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    shift_rule.rule,
-                    &grammar,
-                    "[Removed] (Shift) ",
-                    format!("[Removed] (Shift) lower precedence than reduce: {shift_prec}")
-                        .as_str(),
-                );
-            }
-
-            let message = format!(
-                "Shift/Reduce conflict resolved with terminal(class): {}",
-                grammar.class_pretty_name_list(term, 5)
-            );
-            let notes = vec![
-                        "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
-                        "Set operator for rule explicitly with %prec".to_string(),
-                        "Set precedence for operator with %left, %right, or %precedence"
-                            .to_string(),
-                    ];
-            conflict_diags_resolved.push(
-                Diagnostic::note()
-                    .with_message(message)
-                    .with_labels(labels)
-                    .with_notes(notes),
-            );
-        }
-
-        for ((term, shift_rules, shift_rules_backtrace), reduce_rules) in
-            diags_collector.shift_reduce_conflicts
-        {
-            let mut labels = Vec::new();
-            let mut notes = vec![
-                        "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
-                        "Set operator for rule explicitly with %prec".to_string(),
-                        "Set precedence for operator with %left, %right, or %precedence"
-                            .to_string(),
-                    ];
-
-            if self.note_backtrace {
-                if self.is_executable {
-                    notes.push("--no-backtrace to disable backtracing".to_string());
-                }
-                notes.push("Backtrace for the shift rule:".to_string());
-                for shift_rule in shift_rules_backtrace {
-                    let rule_str = grammar.builder.rules[shift_rule.rule]
-                        .rule
-                        .clone()
-                        .map(class_mapper, nonterm_mapper)
-                        .into_shifted(shift_rule.shifted);
-                    notes.push(format!("\t>>> {rule_str}"));
-                }
-            }
-            for shift_rule in shift_rules {
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    shift_rule.rule,
-                    &grammar,
-                    "(Shift) ",
-                    "(Shift) ",
-                );
-            }
-            for (reduce_rule, reduce_rule_backtrace) in reduce_rules {
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    reduce_rule,
-                    &grammar,
-                    "(Reduce) ",
-                    "(Reduce) ",
-                );
-
-                if self.note_backtrace {
-                    let name = nonterm_mapper(grammar.builder.rules[reduce_rule].rule.name);
-
-                    notes.push(format!("Backtrace for the reduce rule ({name}):"));
-                    notes.extend(reduce_rule_backtrace.into_iter().map(|shifted_rule| {
-                        let rule_str = grammar.builder.rules[shifted_rule.rule]
-                            .rule
-                            .clone()
-                            .map(class_mapper, nonterm_mapper)
-                            .into_shifted(shifted_rule.shifted);
-
-                        format!("\t>>> {rule_str}")
-                    }));
-                }
-            }
-
-            let message = format!(
-                "Shift/Reduce conflict detected with terminal(class): {}",
-                grammar.class_pretty_name_list(term, 5)
-            );
-
-            conflict_diags.push(
-                Diagnostic::error()
-                    .with_message(message)
-                    .with_labels(labels)
-                    .with_notes(notes),
-            );
-        }
-        for (reduce_rules, reduce_terms) in diags_collector.reduce_reduce_conflicts {
-            let mut labels = Vec::new();
-
-            let mut notes = vec!["Set priority for the rule with %dprec".to_string()];
-            for (reduce_rule, reduce_rule_from) in reduce_rules {
-                Self::extend_rule_source_label(
-                    &mut labels,
-                    file_id,
-                    reduce_rule,
-                    &grammar,
-                    "(Reduce) ",
-                    "(Reduce) ",
-                );
+        // construct conflict errors for non-GLR mode
+        if !grammar.glr {
+            for ((term, shift_rules, shift_rules_backtrace), reduce_rules) in
+                diags_collector.shift_reduce_conflicts
+            {
+                let mut labels = Vec::new();
+                let mut notes = vec![
+                    "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
+                    "Set operator for rule explicitly with %prec".to_string(),
+                    "Set precedence for operator with %left, %right, or %precedence"
+                        .to_string(),
+                ];
 
                 if self.note_backtrace {
                     if self.is_executable {
                         notes.push("--no-backtrace to disable backtracing".to_string());
                     }
-                    let name = nonterm_mapper(grammar.builder.rules[reduce_rule].rule.name);
-
-                    notes.push(format!("Backtrace for the reduce rule ({name}):"));
-                    notes.extend(reduce_rule_from.into_iter().map(|shifted_rule| {
-                        let rule_str = grammar.builder.rules[shifted_rule.rule]
+                    notes.push("Backtrace for the shift rule:".to_string());
+                    for shift_rule in shift_rules_backtrace {
+                        let rule_str = grammar.builder.rules[shift_rule.rule]
                             .rule
                             .clone()
                             .map(class_mapper, nonterm_mapper)
-                            .into_shifted(shifted_rule.shifted);
+                            .into_shifted(shift_rule.shifted);
+                        notes.push(format!("\t>>> {rule_str}"));
+                    }
+                }
+                for shift_rule in shift_rules {
+                    Self::extend_rule_source_label(
+                        &mut labels,
+                        file_id,
+                        shift_rule.rule,
+                        &grammar,
+                        "(Shift) ",
+                        "(Shift) ",
+                    );
+                }
+                for (reduce_rule, reduce_rule_backtrace) in reduce_rules {
+                    Self::extend_rule_source_label(
+                        &mut labels,
+                        file_id,
+                        reduce_rule,
+                        &grammar,
+                        "(Reduce) ",
+                        "(Reduce) ",
+                    );
 
-                        format!("\t>>> {rule_str}")
-                    }));
+                    if self.note_backtrace {
+                        let name = nonterm_mapper(grammar.builder.rules[reduce_rule].rule.name);
+
+                        notes.push(format!("Backtrace for the reduce rule ({name}):"));
+                        notes.extend(reduce_rule_backtrace.into_iter().map(|shifted_rule| {
+                            let rule_str = grammar.builder.rules[shifted_rule.rule]
+                                .rule
+                                .clone()
+                                .map(class_mapper, nonterm_mapper)
+                                .into_shifted(shifted_rule.shifted);
+
+                            format!("\t>>> {rule_str}")
+                        }));
+                    }
+                }
+
+                let message = format!(
+                    "Shift/Reduce conflict detected with terminal(class): {}",
+                    grammar.class_pretty_name_list(term, 5)
+                );
+
+                conflict_errors.push(
+                    Diagnostic::error()
+                        .with_message(message)
+                        .with_labels(labels)
+                        .with_notes(notes),
+                );
+            }
+            for (reduce_rules, reduce_terms) in diags_collector.reduce_reduce_conflicts {
+                let mut labels = Vec::new();
+
+                let mut notes = vec!["Set priority for the rule with %dprec".to_string()];
+                for (reduce_rule, reduce_rule_from) in reduce_rules {
+                    Self::extend_rule_source_label(
+                        &mut labels,
+                        file_id,
+                        reduce_rule,
+                        &grammar,
+                        "(Reduce) ",
+                        "(Reduce) ",
+                    );
+
+                    if self.note_backtrace {
+                        if self.is_executable {
+                            notes.push("--no-backtrace to disable backtracing".to_string());
+                        }
+                        let name = nonterm_mapper(grammar.builder.rules[reduce_rule].rule.name);
+
+                        notes.push(format!("Backtrace for the reduce rule ({name}):"));
+                        notes.extend(reduce_rule_from.into_iter().map(|shifted_rule| {
+                            let rule_str = grammar.builder.rules[shifted_rule.rule]
+                                .rule
+                                .clone()
+                                .map(class_mapper, nonterm_mapper)
+                                .into_shifted(shifted_rule.shifted);
+
+                            format!("\t>>> {rule_str}")
+                        }));
+                    }
+                }
+
+                let message = format!(
+                    "Reduce/Reduce conflict detected with terminals: {}",
+                    reduce_terms
+                        .into_iter()
+                        .map(class_mapper)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+
+                conflict_errors.push(
+                    Diagnostic::error()
+                        .with_message(message)
+                        .with_labels(labels)
+                        .with_notes(notes),
+                );
+            }
+        }
+
+        // Convert warning and info diagnostics from the grammar level
+        let mut warnings = Vec::new();
+        for warning in &grammar.warnings {
+            let diag = match warning {
+                rusty_lr_parser::error::Warning::NonTermNotUsed { nonterm_location } => {
+                    let range = span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                    Diagnostic::warning()
+                        .with_message("NonTerminal deleted")
+                        .with_labels(vec![Label::primary(file_id, range)
+                            .with_message("non-terminal defined here")])
+                        .with_notes(vec![
+                            "This non-terminal cannot be reached from initial state".to_string(),
+                        ])
+                }
+                rusty_lr_parser::error::Warning::Cycle { nonterm_location } => {
+                    let range = span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                    Diagnostic::warning()
+                        .with_message("Cycle detected")
+                        .with_labels(vec![Label::primary(file_id, range)
+                            .with_message("non-terminal defined here")])
+                        .with_notes(vec![
+                            "This non-terminal is involved in bad cycle".to_string()
+                        ])
+                }
+                rusty_lr_parser::error::Warning::NonTermDataNotUsed { nonterm_location } => {
+                    let range = span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                    Diagnostic::warning()
+                        .with_message("NonTerminal data type not used")
+                        .with_labels(vec![Label::primary(file_id, range)
+                            .with_message("non-terminal defined here")])
+                        .with_notes(vec![
+                            "This non-terminal's data type is not used in any reduce action"
+                                .to_string(),
+                            "Consider removing data type to optimize memory usage".to_string(),
+                        ])
+                }
+                rusty_lr_parser::error::Warning::UnusedTerminals {
+                    class_name,
+                    terminals,
+                } => {
+                    let notes = vec![format!("{}: {}", class_name, terminals.join(", "))];
+                    Diagnostic::warning()
+                        .with_message("These terminals are not used in the grammar")
+                        .with_notes(notes)
+                }
+            };
+            warnings.push(diag);
+        }
+
+        let mut infos = Vec::new();
+        for info in &grammar.infos {
+            let diag = match info {
+                rusty_lr_parser::error::Info::TerminalsMerged {
+                    class_name,
+                    terminals,
+                } => {
+                    let notes = vec![format!("{}: {}", class_name, terminals.join(", "))];
+                    Diagnostic::note()
+                        .with_message("These terminals are merged into terminal class")
+                        .with_notes(notes)
+                }
+                rusty_lr_parser::error::Info::TerminalClassRuleMerge { rule_location } => {
+                    let range = span_manager.get_byterange(rule_location).unwrap_or(0..0);
+                    Diagnostic::note()
+                        .with_message("Production Rule deleted")
+                        .with_labels(vec![
+                            Label::primary(file_id, range).with_message("defined here")
+                        ])
+                        .with_notes(vec![
+                            "Will be merged into rule using terminal class".to_string()
+                        ])
+                }
+                rusty_lr_parser::error::Info::SingleNonTerminalRule {
+                    nonterm_location,
+                    rule_location,
+                } => {
+                    let nonterm_range =
+                        span_manager.get_byterange(nonterm_location).unwrap_or(0..0);
+                    let rule_range = span_manager.get_byterange(rule_location).unwrap_or(0..0);
+                    Diagnostic::note()
+                        .with_message("NonTerminal deleted")
+                        .with_labels(vec![
+                            Label::primary(file_id, nonterm_range)
+                                .with_message("non-terminal defined here"),
+                            Label::secondary(file_id, rule_range)
+                                .with_message("this rule has only one child rule"),
+                        ])
+                        .with_notes(vec![
+                            "This non-terminal will be replaced by it's unique child rule"
+                                .to_string(),
+                        ])
+                }
+                rusty_lr_parser::error::Info::ReduceReduceConflictResolved {
+                    max_priority,
+                    reduce_rules,
+                    deleted_rules,
+                } => {
+                    let mut labels = Vec::new();
+                    for &rule in reduce_rules {
+                        let priority = grammar.builder.rules[rule].priority;
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            rule,
+                            &grammar,
+                            "(Reduce) ",
+                            format!("(Reduce) rule with the highest priority: {priority}").as_str(),
+                        );
+                    }
+                    for &del in deleted_rules {
+                        let priority = grammar.builder.rules[del].priority;
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            del,
+                            &grammar,
+                            "[Removed] (Reduce) ",
+                            format!("[Removed] (Reduce) rule with lower priority: {priority}")
+                                .as_str(),
+                        );
+                    }
+                    Diagnostic::note()
+                        .with_message("Reduce/Reduce conflict resolved")
+                        .with_labels(labels)
+                        .with_notes(vec![
+                            format!("Max priority: {max_priority}"),
+                            "Set priority for the rule with %dprec".to_string(),
+                        ])
+                }
+                rusty_lr_parser::error::Info::ShiftReduceConflictResolvedShift {
+                    term,
+                    shift_prec,
+                    shift_rules,
+                    reduce_rules,
+                } => {
+                    let mut labels = Vec::new();
+                    for &reduce_rule_pair in reduce_rules {
+                        let (reduce_rule, reduce_prec) = reduce_rule_pair;
+                        let (nonterm_info, local_id) = grammar.get_rule_by_id(reduce_rule).unwrap();
+                        let rule_info = &nonterm_info.rules[local_id];
+                        if shift_prec > &reduce_prec {
+                            Self::extend_rule_source_label(
+                                &mut labels,
+                                file_id,
+                                reduce_rule,
+                                &grammar,
+                                "[Removed] (Reduce) ",
+                                format!(
+                                    "[Removed] (Reduce) lower precedence than shift: {reduce_prec}"
+                                )
+                                .as_str(),
+                            );
+                        } else {
+                            let reduce_type = "%right";
+                            Self::extend_rule_source_label(
+                                &mut labels,
+                                file_id,
+                                reduce_rule,
+                                &grammar,
+                                "[Removed] (Reduce) ",
+                                format!("[Removed] (Reduce) has {reduce_type} associativity")
+                                    .as_str(),
+                            );
+                        }
+                        if !nonterm_info.is_auto_generated() {
+                            let op_range = span_manager
+                                .get_byterange(&rule_info.prec.unwrap().location())
+                                .unwrap_or(0..0);
+                            labels.push(
+                                Label::secondary(file_id, op_range)
+                                    .with_message("[Removed] (Reduce) operator for reduce rule"),
+                            );
+                        }
+                    }
+                    for &shift_rule in shift_rules {
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            shift_rule,
+                            &grammar,
+                            "(Shift) ",
+                            format!("(Shift) precedence: {shift_prec}").as_str(),
+                        );
+                    }
+                    Diagnostic::note()
+                        .with_message(format!("Shift/Reduce conflict resolved with terminal(class): {term}"))
+                        .with_labels(labels)
+                        .with_notes(vec![
+                            "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
+                            "Set operator for rule explicitly with %prec".to_string(),
+                            "Set precedence for operator with %left, %right, or %precedence".to_string(),
+                        ])
+                }
+                rusty_lr_parser::error::Info::ShiftReduceConflictResolvedReduce {
+                    term,
+                    shift_prec,
+                    shift_rules,
+                    reduce_rules,
+                } => {
+                    let mut labels = Vec::new();
+                    for &reduce_rule_pair in reduce_rules {
+                        let (reduce_rule, reduce_prec) = reduce_rule_pair;
+                        let (nonterm_info, local_id) = grammar.get_rule_by_id(reduce_rule).unwrap();
+                        let rule_info = &nonterm_info.rules[local_id];
+                        if &reduce_prec > shift_prec {
+                            Self::extend_rule_source_label(
+                                &mut labels,
+                                file_id,
+                                reduce_rule,
+                                &grammar,
+                                "(Reduce) ",
+                                format!("(Reduce) higher precedence than shift: {reduce_prec}")
+                                    .as_str(),
+                            );
+                        } else {
+                            let reduce_type = "%left";
+                            Self::extend_rule_source_label(
+                                &mut labels,
+                                file_id,
+                                reduce_rule,
+                                &grammar,
+                                "(Reduce) ",
+                                format!("(Reduce) has {reduce_type} associativity").as_str(),
+                            );
+                        }
+                        if !nonterm_info.is_auto_generated() {
+                            let op_range = span_manager
+                                .get_byterange(&rule_info.prec.unwrap().location())
+                                .unwrap_or(0..0);
+                            labels.push(
+                                Label::secondary(file_id, op_range)
+                                    .with_message("(Reduce) operator for reduce rule"),
+                            );
+                        }
+                    }
+                    for &shift_rule in shift_rules {
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            shift_rule,
+                            &grammar,
+                            "[Removed] (Shift) ",
+                            format!("[Removed] (Shift) lower precedence than reduce: {shift_prec}")
+                                .as_str(),
+                        );
+                    }
+                    Diagnostic::note()
+                        .with_message(format!("Shift/Reduce conflict resolved with terminal(class): {term}"))
+                        .with_labels(labels)
+                        .with_notes(vec![
+                            "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
+                            "Set operator for rule explicitly with %prec".to_string(),
+                            "Set precedence for operator with %left, %right, or %precedence".to_string(),
+                        ])
+                }
+                rusty_lr_parser::error::Info::ShiftReduceConflictGLR {
+                    term,
+                    shift_rules,
+                    shift_rules_backtrace,
+                    reduce_rules,
+                } => {
+                    let mut labels = Vec::new();
+                    let mut notes = vec![
+                        "Operator of production rule is the rightmost terminal symbol with precedence defined".to_string(),
+                        "Set operator for rule explicitly with %prec".to_string(),
+                        "Set precedence for operator with %left, %right, or %precedence".to_string(),
+                    ];
+
+                    if self.note_backtrace {
+                        if self.is_executable {
+                            notes.push("--no-backtrace to disable backtracing".to_string());
+                        }
+                        notes.push("Backtrace for the shift rule:".to_string());
+                        for s_bt in shift_rules_backtrace {
+                            notes.push(s_bt.clone());
+                        }
+                    }
+                    for &shift_rule in shift_rules {
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            shift_rule,
+                            &grammar,
+                            "(Shift) ",
+                            "(Shift) ",
+                        );
+                    }
+                    for &(reduce_rule, ref r_bt) in reduce_rules {
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            reduce_rule,
+                            &grammar,
+                            "(Reduce) ",
+                            "(Reduce) ",
+                        );
+                        if self.note_backtrace {
+                            for line in r_bt {
+                                notes.push(line.clone());
+                            }
+                        }
+                    }
+                    Diagnostic::help()
+                        .with_message(format!(
+                            "Shift/Reduce conflict detected with terminal(class): {term}"
+                        ))
+                        .with_labels(labels)
+                        .with_notes(notes)
+                }
+                rusty_lr_parser::error::Info::ReduceReduceConflictGLR {
+                    terms,
+                    reduce_rules,
+                } => {
+                    let mut labels = Vec::new();
+                    let mut notes = vec!["Set priority for the rule with %dprec".to_string()];
+
+                    for &(reduce_rule, ref r_bt) in reduce_rules {
+                        Self::extend_rule_source_label(
+                            &mut labels,
+                            file_id,
+                            reduce_rule,
+                            &grammar,
+                            "(Reduce) ",
+                            "(Reduce) ",
+                        );
+                        if self.note_backtrace {
+                            if self.is_executable {
+                                notes.push("--no-backtrace to disable backtracing".to_string());
+                            }
+                            for line in r_bt {
+                                notes.push(line.clone());
+                            }
+                        }
+                    }
+                    Diagnostic::help()
+                        .with_message(format!(
+                            "Reduce/Reduce conflict detected with terminals: {}",
+                            terms.join(", ")
+                        ))
+                        .with_labels(labels)
+                        .with_notes(notes)
+                }
+            };
+            infos.push(diag);
+        }
+
+        // print resolved conflict notes and unresolved GLR conflict help notes
+        if self.note_conflicts_resolving || self.note_conflicts {
+            for (diag, info_variant) in infos.iter().zip(&grammar.infos) {
+                let should_print = match info_variant {
+                    rusty_lr_parser::error::Info::ShiftReduceConflictGLR { .. }
+                    | rusty_lr_parser::error::Info::ReduceReduceConflictGLR { .. } => {
+                        self.note_conflicts
+                    }
+
+                    rusty_lr_parser::error::Info::ReduceReduceConflictResolved { .. }
+                    | rusty_lr_parser::error::Info::ShiftReduceConflictResolvedShift { .. }
+                    | rusty_lr_parser::error::Info::ShiftReduceConflictResolvedReduce { .. } => {
+                        self.note_conflicts_resolving
+                    }
+
+                    _ => true, // optimization notes are printed unconditionally
+                };
+                if should_print {
+                    let writer = self.stream();
+                    let config = codespan_reporting::term::Config::default();
+                    term::emit_to_write_style(&mut writer.lock(), &config, &files, diag)
+                        .expect("Failed to write verbose/verbose stream");
                 }
             }
-
-            let message = format!(
-                "Reduce/Reduce conflict detected with terminals: {}",
-                reduce_terms
-                    .into_iter()
-                    .map(class_mapper)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-
-            conflict_diags.push(
-                Diagnostic::error()
-                    .with_message(message)
-                    .with_labels(labels)
-                    .with_notes(notes),
-            );
-        }
-
-        // print note about shift/reduce conflict resolved with `%left` or `%right`
-        if self.note_conflicts_resolving {
-            for diag in conflict_diags_resolved.into_iter() {
-                let writer = self.stream();
-                let config = codespan_reporting::term::Config::default();
-                term::emit_to_write_style(&mut writer.lock(), &config, &files, &diag)
-                    .expect("Failed to write to verbose stream");
+        } else {
+            // print only optimization notes
+            for (diag, info_variant) in infos.iter().zip(&grammar.infos) {
+                let should_print = match info_variant {
+                    rusty_lr_parser::error::Info::TerminalsMerged { .. }
+                    | rusty_lr_parser::error::Info::TerminalClassRuleMerge { .. }
+                    | rusty_lr_parser::error::Info::SingleNonTerminalRule { .. } => true,
+                    _ => false,
+                };
+                if should_print {
+                    let writer = self.stream();
+                    let config = codespan_reporting::term::Config::default();
+                    term::emit_to_write_style(&mut writer.lock(), &config, &files, diag)
+                        .expect("Failed to write verbose/verbose stream");
+                }
             }
         }
 
-        if !grammar.glr {
-            let has_diags = !conflict_diags.is_empty();
-            for diag in conflict_diags.into_iter() {
-                let writer = self.stream();
-                let config = codespan_reporting::term::Config::default();
-                term::emit_to_write_style(&mut writer.lock(), &config, &files, &diag)
-                    .expect("Failed to write to stderr");
-            }
-            if has_diags {
-                return Err("Grammar building failed".to_string());
-            }
-        }
-        // print note about reduce/reduce conflict and shift/reduce conflict not resolved
-        else if self.note_conflicts {
-            for diag in conflict_diags.into_iter() {
-                let diag = Diagnostic::help()
-                    .with_message(diag.message)
-                    .with_labels(diag.labels)
-                    .with_notes(diag.notes);
-                let writer = self.stream();
-                let config = codespan_reporting::term::Config::default();
-                term::emit_to_write_style(&mut writer.lock(), &config, &files, &diag)
-                    .expect("Failed to write to stderr");
-            }
-        }
-
-        for diag in optimize_diags.into_iter() {
+        // print warnings
+        for diag in &warnings {
             let writer = self.stream();
             let config = codespan_reporting::term::Config::default();
-            term::emit_to_write_style(&mut writer.lock(), &config, &files, &diag)
+            term::emit_to_write_style(&mut writer.lock(), &config, &files, diag)
                 .expect("Failed to write to verbose stream");
+        }
+
+        // print conflict errors if not GLR
+        if !grammar.glr {
+            let has_errors = !conflict_errors.is_empty();
+            for diag in conflict_errors {
+                let writer = self.stream();
+                let config = codespan_reporting::term::Config::default();
+                term::emit_to_write_style(&mut writer.lock(), &config, &files, &diag)
+                    .expect("Failed to write to stderr");
+            }
+            if has_errors {
+                return Err("Grammar building failed".to_string());
+            }
         }
 
         // expand macro

--- a/rusty_lr_core/src/parser/table.rs
+++ b/rusty_lr_core/src/parser/table.rs
@@ -28,7 +28,11 @@ impl Index for u8 {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
-        debug_assert!(value <= u8::MAX as usize, "value {} out of bounds for u8", value);
+        debug_assert!(
+            value <= u8::MAX as usize,
+            "value {} out of bounds for u8",
+            value
+        );
         value as u8
     }
 }
@@ -38,7 +42,11 @@ impl Index for u16 {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
-        debug_assert!(value <= u16::MAX as usize, "value {} out of bounds for u16", value);
+        debug_assert!(
+            value <= u16::MAX as usize,
+            "value {} out of bounds for u16",
+            value
+        );
         value as u16
     }
 }
@@ -48,7 +56,11 @@ impl Index for u32 {
         self as usize
     }
     fn from_usize_unchecked(value: usize) -> Self {
-        debug_assert!(value <= u32::MAX as usize, "value {} out of bounds for u32", value);
+        debug_assert!(
+            value <= u32::MAX as usize,
+            "value {} out of bounds for u32",
+            value
+        );
         value as u32
     }
 }

--- a/rusty_lr_derive/src/lib.rs
+++ b/rusty_lr_derive/src/lib.rs
@@ -118,7 +118,10 @@ pub fn lr1(input: TokenStream) -> TokenStream {
         }
     }
 
+    // Emit the generated parser code at compile-time.
     let mut output = grammar.emit_compiletime();
+    // Append any grammar warnings to the output TokenStream, mapping them
+    // to their respective locations in the source code.
     for warning in &grammar.warnings {
         output.extend(warning.to_compile_warning(&grammar, &span_manager));
     }

--- a/rusty_lr_derive/src/lib.rs
+++ b/rusty_lr_derive/src/lib.rs
@@ -118,5 +118,9 @@ pub fn lr1(input: TokenStream) -> TokenStream {
         }
     }
 
-    grammar.emit_compiletime().into()
+    let mut output = grammar.emit_compiletime();
+    for warning in &grammar.warnings {
+        output.extend(warning.to_compile_warning(&grammar, &span_manager));
+    }
+    output.into()
 }

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -397,3 +397,62 @@ impl ConflictError {
         }
     }
 }
+
+#[derive(Debug, Clone)]
+pub enum Warning {
+    NonTermNotUsed {
+        nonterm_location: Location,
+    },
+    Cycle {
+        nonterm_location: Location,
+    },
+    NonTermDataNotUsed {
+        nonterm_location: Location,
+    },
+    UnusedTerminals {
+        class_name: String,
+        terminals: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum Info {
+    TerminalsMerged {
+        class_name: String,
+        terminals: Vec<String>,
+    },
+    TerminalClassRuleMerge {
+        rule_location: Location,
+    },
+    SingleNonTerminalRule {
+        nonterm_location: Location,
+        rule_location: Location,
+    },
+    ReduceReduceConflictResolved {
+        max_priority: usize,
+        reduce_rules: Vec<usize>,
+        deleted_rules: Vec<usize>,
+    },
+    ShiftReduceConflictResolvedShift {
+        term: String,
+        shift_prec: usize,
+        shift_rules: Vec<usize>,
+        reduce_rules: Vec<(usize, usize)>, // (rule_id, reduce_prec)
+    },
+    ShiftReduceConflictResolvedReduce {
+        term: String,
+        shift_prec: usize,
+        shift_rules: Vec<usize>,
+        reduce_rules: Vec<(usize, usize)>, // (rule_id, reduce_prec)
+    },
+    ShiftReduceConflictGLR {
+        term: String,
+        shift_rules: Vec<usize>,
+        shift_rules_backtrace: Vec<String>,
+        reduce_rules: Vec<(usize, Vec<String>)>, // (rule_id, backtrace)
+    },
+    ReduceReduceConflictGLR {
+        terms: Vec<String>,
+        reduce_rules: Vec<(usize, Vec<String>)>, // (rule_id, backtrace)
+    },
+}

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -6,6 +6,7 @@ use quote::quote_spanned;
 use crate::parser::args::IdentOrLiteral;
 use crate::parser::location::Located;
 use crate::parser::location::Location;
+use rusty_lr_core::TerminalSymbol;
 
 /// failed to feed() the token
 #[derive(Debug)]
@@ -400,32 +401,22 @@ impl ConflictError {
 
 #[derive(Debug, Clone)]
 pub enum Warning {
-    NonTermNotUsed {
-        nonterm_location: Location,
-    },
-    Cycle {
-        nonterm_location: Location,
-    },
-    NonTermDataNotUsed {
-        nonterm_location: Location,
-    },
-    UnusedTerminals {
-        class_name: String,
-        terminals: Vec<String>,
-    },
+    NonTermNotUsed { nonterm_idx: Located<usize> },
+    Cycle { nonterm_idx: Located<usize> },
+    NonTermDataNotUsed { nonterm_idx: Located<usize> },
+    UnusedTerminals { class_idx: usize },
 }
 
 #[derive(Debug, Clone)]
 pub enum Info {
     TerminalsMerged {
-        class_name: String,
-        terminals: Vec<String>,
+        class_idx: usize,
     },
     TerminalClassRuleMerge {
         rule_location: Location,
     },
     SingleNonTerminalRule {
-        nonterm_location: Location,
+        nonterm_idx: Located<usize>,
         rule_location: Location,
     },
     ReduceReduceConflictResolved {
@@ -434,25 +425,25 @@ pub enum Info {
         deleted_rules: Vec<usize>,
     },
     ShiftReduceConflictResolvedShift {
-        term: String,
+        term: TerminalSymbol<usize>,
         shift_prec: usize,
         shift_rules: Vec<usize>,
-        reduce_rules: Vec<(usize, usize)>, // (rule_id, reduce_prec)
+        reduce_rules: Vec<(usize, usize)>,
     },
     ShiftReduceConflictResolvedReduce {
-        term: String,
+        term: TerminalSymbol<usize>,
         shift_prec: usize,
         shift_rules: Vec<usize>,
-        reduce_rules: Vec<(usize, usize)>, // (rule_id, reduce_prec)
+        reduce_rules: Vec<(usize, usize)>,
     },
     ShiftReduceConflictGLR {
-        term: String,
+        term: TerminalSymbol<usize>,
         shift_rules: Vec<usize>,
         shift_rules_backtrace: Vec<String>,
-        reduce_rules: Vec<(usize, Vec<String>)>, // (rule_id, backtrace)
+        reduce_rules: Vec<(usize, Vec<String>)>,
     },
     ReduceReduceConflictGLR {
-        terms: Vec<String>,
-        reduce_rules: Vec<(usize, Vec<String>)>, // (rule_id, backtrace)
+        terms: Vec<TerminalSymbol<usize>>,
+        reduce_rules: Vec<(usize, Vec<String>)>,
     },
 }

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -399,6 +399,8 @@ impl ConflictError {
     }
 }
 
+/// Represents various compilation warnings encountered during grammar analysis
+/// and parser generation (e.g., unused symbols, cycles, etc.).
 #[derive(Debug, Clone)]
 pub enum Warning {
     NonTermNotUsed { nonterm_idx: Located<usize> },
@@ -408,6 +410,10 @@ pub enum Warning {
 }
 
 impl Warning {
+    /// Translates the warning into a `TokenStream` containing a compiler warning.
+    /// Since Rust does not have a stable `compile_warning!` macro, this leverages
+    /// a dummy deprecated struct definition mapped to the source code span
+    /// where the warning originated, allowing stable Rust compilers to emit a diagnostic warning.
     pub fn to_compile_warning(
         &self,
         grammar: &crate::grammar::Grammar,
@@ -443,6 +449,7 @@ impl Warning {
         output
     }
 
+    /// Retrieves all source code locations associated with this warning.
     pub fn locations(&self) -> Vec<Location> {
         match self {
             Warning::NonTermNotUsed { nonterm_idx } => vec![nonterm_idx.location()],
@@ -452,6 +459,7 @@ impl Warning {
         }
     }
 
+    /// Formats a short diagnostic message describing the warning.
     pub fn short_message(&self, grammar: &crate::grammar::Grammar) -> String {
         match self {
             Warning::NonTermNotUsed { nonterm_idx } => {
@@ -482,6 +490,8 @@ impl Warning {
     }
 }
 
+/// Represents informational diagnostics and details collected during parser construction
+/// and conflict resolution (e.g. terminals merged, conflicts resolved, backtraces for GLR).
 #[derive(Debug, Clone)]
 pub enum Info {
     TerminalsMerged {

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -407,6 +407,81 @@ pub enum Warning {
     UnusedTerminals { class_idx: usize },
 }
 
+impl Warning {
+    pub fn to_compile_warning(
+        &self,
+        grammar: &crate::grammar::Grammar,
+        span_manager: &crate::parser::location::SpanManager,
+    ) -> TokenStream {
+        let mut output = TokenStream::new();
+        let message = self.short_message(grammar);
+        let locs = self.locations();
+        if locs.is_empty() {
+            let span = Span::call_site();
+            output.extend(quote_spanned! {
+                span=>
+                const _: () = {
+                    #[deprecated(since = "0.0.0", note = #message)]
+                    struct Warning;
+                    let _ = Warning;
+                };
+            });
+        } else {
+            for loc in locs {
+                for span in span_manager.get_spans_in_location(&loc) {
+                    output.extend(quote_spanned! {
+                        span=>
+                        const _: () = {
+                            #[deprecated(since = "0.0.0", note = #message)]
+                            struct Warning;
+                            let _ = Warning;
+                        };
+                    });
+                }
+            }
+        }
+        output
+    }
+
+    pub fn locations(&self) -> Vec<Location> {
+        match self {
+            Warning::NonTermNotUsed { nonterm_idx } => vec![nonterm_idx.location()],
+            Warning::Cycle { nonterm_idx } => vec![nonterm_idx.location()],
+            Warning::NonTermDataNotUsed { nonterm_idx } => vec![nonterm_idx.location()],
+            Warning::UnusedTerminals { .. } => Vec::new(),
+        }
+    }
+
+    pub fn short_message(&self, grammar: &crate::grammar::Grammar) -> String {
+        match self {
+            Warning::NonTermNotUsed { nonterm_idx } => {
+                let name = grammar.nonterminals[*nonterm_idx.value()].name.value();
+                format!("Non-terminal `{name}` is not used in the grammar")
+            }
+            Warning::Cycle { nonterm_idx } => {
+                let name = grammar.nonterminals[*nonterm_idx.value()].name.value();
+                format!("Cycle detected: non-terminal `{name}` is involved in a bad cycle")
+            }
+            Warning::NonTermDataNotUsed { nonterm_idx } => {
+                let name = grammar.nonterminals[*nonterm_idx.value()].name.value();
+                format!("Non-terminal `{name}`'s data type is not used in any reduce action")
+            }
+            Warning::UnusedTerminals { class_idx } => {
+                let class_name = grammar.class_pretty_name_abbr(*class_idx);
+                let terminals = grammar.terminal_classes[*class_idx]
+                    .terminals
+                    .iter()
+                    .map(|&term| grammar.term_pretty_name(term))
+                    .collect::<Vec<_>>();
+                format!(
+                    "These terminals are not used: {class_name}: {}",
+                    terminals.join(", ")
+                )
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Info {
     TerminalsMerged {

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -2880,8 +2880,9 @@ impl Grammar {
             }
         };
 
-        // Collect conflict diagnostics
-        // 1. reduce_reduce_resolved
+        // Collect conflict diagnostics and populate the `self.infos` diagnostics list.
+
+        // 1. Collect resolved reduce-reduce conflicts (resolved via precedence/dprec declarations).
         for (max_priority, reduce_rules, deleted_rules) in &collector.reduce_reduce_resolved {
             self.infos.push(Info::ReduceReduceConflictResolved {
                 max_priority: *max_priority,
@@ -2890,7 +2891,7 @@ impl Grammar {
             });
         }
 
-        // 2. shift_reduce_resolved_shift
+        // 2. Collect resolved shift-reduce conflicts where shift was chosen (resolved via precedence/associativity).
         for ((term, shift_rules), (shift_prec, reduce_rules)) in
             &collector.shift_reduce_resolved_shift
         {
@@ -2907,7 +2908,7 @@ impl Grammar {
             });
         }
 
-        // 3. shift_reduce_resolved_reduce
+        // 3. Collect resolved shift-reduce conflicts where reduce was chosen (resolved via precedence/associativity).
         for ((term, shift_rules), (shift_prec, reduce_rules)) in
             &collector.shift_reduce_resolved_reduce
         {
@@ -2924,9 +2925,10 @@ impl Grammar {
             });
         }
 
-        // 4. unresolved conflicts (for GLR help notes)
+        // 4. Collect unresolved conflicts for GLR warning/help notes.
+        // In GLR parsers, unresolved conflicts are resolved at runtime, but we still report them for debugging purposes.
         if self.glr {
-            // shift_reduce_conflicts
+            // Collect unresolved shift-reduce conflicts with backtraces.
             for ((term, shift_rules, shift_rules_backtrace), reduce_rules) in
                 &collector.shift_reduce_conflicts
             {
@@ -2972,7 +2974,7 @@ impl Grammar {
                 });
             }
 
-            // reduce_reduce_conflicts
+            // Collect unresolved reduce-reduce conflicts with backtraces.
             for (reduce_rules, reduce_terms) in &collector.reduce_reduce_conflicts {
                 let mut r_rules = Vec::new();
                 for &(reduce_rule, ref reduce_rule_from) in reduce_rules {

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -11,8 +11,10 @@ use rusty_lr_core::TerminalSymbol;
 use rusty_lr_core::Token;
 
 use crate::error::ArgError;
+use crate::error::Info;
 use crate::error::ParseArgError;
 use crate::error::ParseError;
+use crate::error::Warning;
 use crate::nonterminal_info::CustomReduceAction;
 use crate::nonterminal_info::NonTerminalInfo;
 use crate::nonterminal_info::ReduceAction;
@@ -43,18 +45,6 @@ pub struct TerminalClassDefinition {
 
     /// Whether this class's data was used in any reduce action
     pub data_used: bool,
-}
-
-pub enum OptimizeRemove {
-    TerminalClassRuleMerge(Rule),
-    SingleNonTerminalRule(Rule, Location),
-    NonTermNotUsed(Location),
-    Cycle(Location),
-    NonTermDataNotUsed(usize),
-}
-pub struct OptimizeDiag {
-    /// deleted rules
-    pub removed: Vec<OptimizeRemove>,
 }
 
 /// type alias just for readability
@@ -149,6 +139,9 @@ pub struct Grammar {
     pub custom_reduce_actions: Vec<CustomSingleReduceAction>,
 
     pub span_manager: crate::parser::location::SpanManager,
+
+    pub warnings: Vec<Warning>,
+    pub infos: Vec<Info>,
 }
 
 impl Grammar {
@@ -914,6 +907,9 @@ impl Grammar {
             custom_reduce_actions: Vec::new(),
 
             span_manager: grammar_args.span_manager,
+
+            warnings: Vec::new(),
+            infos: Vec::new(),
         };
         grammar.is_char = grammar.token_typename.to_string() == "char";
         grammar.is_u8 = grammar.token_typename.to_string() == "u8";
@@ -1837,7 +1833,7 @@ impl Grammar {
     }
 
     /// optimize grammar
-    fn optimize_iterate(&mut self) -> Option<OptimizeDiag> {
+    fn optimize_iterate(&mut self) -> bool {
         // for early stopping optimization loop
         let mut something_changed = false;
 
@@ -1920,7 +1916,7 @@ impl Grammar {
                         {
                             // if it is false, it is reduce/reduce conflict (duplicated rule)
                             // so stop optimization
-                            return None;
+                            return false;
                         }
                     }
                 }
@@ -1931,9 +1927,6 @@ impl Grammar {
         let term_partition = crate::partition::minimal_partition(
             term_sets.into_iter().map(|terms| terms.into_iter()),
         );
-
-        // check if two or more terminals can be merged into one class
-        let mut removed_rules_diag = Vec::new();
 
         if term_partition.len() != self.terminal_classes.len() {
             something_changed = true;
@@ -1986,36 +1979,6 @@ impl Grammar {
             self.other_terminal_class_id = self.terminal_class_id[self.other_terminal_index];
             // terminal class optimization ends
 
-            // check for unused non-terminals
-            let mut nonterm_used = vec![false; self.nonterminals.len()];
-            for nonterm in &self.nonterminals {
-                for rule in &nonterm.rules {
-                    for token in &rule.tokens {
-                        if let Token::NonTerm(nonterm_idx) = token.token {
-                            nonterm_used[nonterm_idx] = true;
-                        }
-                    }
-                }
-            }
-            for (nonterm_idx, nonterm) in self.nonterminals.iter_mut().enumerate() {
-                // do not delete protected non-terminals
-                if nonterm.is_protected() {
-                    continue;
-                }
-                if nonterm.rules.is_empty() {
-                    continue;
-                }
-
-                if !nonterm_used[nonterm_idx] {
-                    // this rule was not used
-                    nonterm.rules.clear();
-                    if !nonterm.is_auto_generated() {
-                        let loc = nonterm.name.location();
-                        removed_rules_diag.push(OptimizeRemove::NonTermNotUsed(loc));
-                    }
-                }
-            }
-
             let mut other_was_used = false;
             for nonterm in &mut self.nonterminals {
                 let rules = std::mem::take(&mut nonterm.rules);
@@ -2037,8 +2000,9 @@ impl Grammar {
                         // so remove this rule
                         // add to diags only if it was not auto-generated
                         if !nonterm.is_auto_generated() {
-                            let diag = OptimizeRemove::TerminalClassRuleMerge(rule);
-                            removed_rules_diag.push(diag);
+                            self.infos.push(Info::TerminalClassRuleMerge {
+                                rule_location: rule.location(),
+                            });
                         }
                         continue;
                     }
@@ -2061,6 +2025,39 @@ impl Grammar {
             }
 
             self.other_used = other_was_used;
+        }
+
+        // check for unused non-terminals
+        let mut nonterm_used = vec![false; self.nonterminals.len()];
+        for nonterm in &self.nonterminals {
+            for rule in &nonterm.rules {
+                for token in &rule.tokens {
+                    if let Token::NonTerm(nonterm_idx) = token.token {
+                        nonterm_used[nonterm_idx] = true;
+                    }
+                }
+            }
+        }
+        for (nonterm_idx, nonterm) in self.nonterminals.iter_mut().enumerate() {
+            // do not delete protected non-terminals
+            if nonterm.is_protected() {
+                continue;
+            }
+            if nonterm.rules.is_empty() {
+                continue;
+            }
+
+            if !nonterm_used[nonterm_idx] {
+                // this rule was not used
+                nonterm.rules.clear();
+                something_changed = true;
+                if !nonterm.is_auto_generated() {
+                    let loc = nonterm.name.location();
+                    self.warnings.push(Warning::NonTermNotUsed {
+                        nonterm_location: loc,
+                    });
+                }
+            }
         }
 
         // remove rules that have single production rule and single token
@@ -2191,25 +2188,17 @@ impl Grammar {
             // add to diags only if it was not auto-generated
             if !nonterm.is_auto_generated() {
                 let loc = nonterm.name.location();
-                let diag = OptimizeRemove::SingleNonTerminalRule(rule, loc);
-                removed_rules_diag.push(diag);
+                self.infos.push(Info::SingleNonTerminalRule {
+                    nonterm_location: loc,
+                    rule_location: rule.location(),
+                });
             }
         }
 
-        if something_changed {
-            Some(OptimizeDiag {
-                removed: removed_rules_diag,
-            })
-        } else {
-            None
-        }
+        something_changed
     }
 
-    pub fn optimize(&mut self, max_iter: usize) -> OptimizeDiag {
-        let mut diag = OptimizeDiag {
-            removed: Vec::new(),
-        };
-
+    pub fn optimize(&mut self, max_iter: usize) {
         // check if RuleType and ReduceAction can be removed from certain non-terminals
         let mut add_to_diags = BTreeSet::new();
         loop {
@@ -2312,7 +2301,10 @@ impl Grammar {
             }
         }
         for i in add_to_diags {
-            diag.removed.push(OptimizeRemove::NonTermDataNotUsed(i));
+            let nonterm = &self.nonterminals[i];
+            self.warnings.push(Warning::NonTermDataNotUsed {
+                nonterm_location: nonterm.name.location(),
+            });
         }
 
         // check for any data of terminal symbol was used in any reduce action
@@ -2334,14 +2326,8 @@ impl Grammar {
         }
 
         for _ in 0..max_iter {
-            let ret = self.optimize_iterate();
-            match ret {
-                Some(new_diag) => {
-                    diag.removed.extend(new_diag.removed.into_iter());
-                }
-                None => {
-                    break;
-                }
+            if !self.optimize_iterate() {
+                break;
             }
         }
 
@@ -2411,7 +2397,39 @@ impl Grammar {
             }
         }
 
-        diag
+        // Collect optimization warnings and notes/infos
+        for class_def in self.terminal_classes.iter() {
+            let len: usize = class_def
+                .terminals
+                .iter()
+                .map(|term| self.terminals[*term].name.count())
+                .sum();
+            if len == 1 {
+                continue;
+            }
+            let class_name = format!("TerminalClass{}", class_def.multiterm_counter);
+            let terminals = class_def
+                .terminals
+                .iter()
+                .map(|&term| self.term_pretty_name(term))
+                .collect::<Vec<_>>();
+            self.infos.push(Info::TerminalsMerged {
+                class_name,
+                terminals,
+            });
+        }
+
+        // if other terminals were not used, print warning about removing them
+        let other_terminal_class = &self.terminal_classes[self.other_terminal_class_id];
+        if !self.other_used && other_terminal_class.terminals.len() > 1 {
+            let class_name = self.class_pretty_name_abbr(self.other_terminal_class_id);
+            let terms =
+                self.class_pretty_name_list(TerminalSymbol::Term(self.other_terminal_class_id), 10);
+            self.warnings.push(Warning::UnusedTerminals {
+                class_name,
+                terminals: vec![terms],
+            });
+        }
     }
 
     fn term_pretty_name(&self, term_idx: usize) -> String {
@@ -2874,6 +2892,134 @@ impl Grammar {
                         && (total_dense_size as f64 / total_sparse_size as f64) < 2.5)
             }
         };
+
+        // Collect conflict diagnostics
+        // 1. reduce_reduce_resolved
+        for (max_priority, reduce_rules, deleted_rules) in &collector.reduce_reduce_resolved {
+            self.infos.push(Info::ReduceReduceConflictResolved {
+                max_priority: *max_priority,
+                reduce_rules: reduce_rules.iter().cloned().collect(),
+                deleted_rules: deleted_rules.iter().cloned().collect(),
+            });
+        }
+
+        // 2. shift_reduce_resolved_shift
+        for ((term, shift_rules), (shift_prec, reduce_rules)) in
+            &collector.shift_reduce_resolved_shift
+        {
+            let term_str = self.class_pretty_name_list(*term, 5);
+            let shift_rule_indices = shift_rules.iter().map(|sr| sr.rule).collect::<Vec<_>>();
+            let reduce_rule_pairs = reduce_rules
+                .iter()
+                .map(|(&r, &p)| (r, p))
+                .collect::<Vec<_>>();
+            self.infos.push(Info::ShiftReduceConflictResolvedShift {
+                term: term_str,
+                shift_prec: *shift_prec,
+                shift_rules: shift_rule_indices,
+                reduce_rules: reduce_rule_pairs,
+            });
+        }
+
+        // 3. shift_reduce_resolved_reduce
+        for ((term, shift_rules), (shift_prec, reduce_rules)) in
+            &collector.shift_reduce_resolved_reduce
+        {
+            let term_str = self.class_pretty_name_list(*term, 5);
+            let shift_rule_indices = shift_rules.iter().map(|sr| sr.rule).collect::<Vec<_>>();
+            let reduce_rule_pairs = reduce_rules
+                .iter()
+                .map(|(&r, &p)| (r, p))
+                .collect::<Vec<_>>();
+            self.infos.push(Info::ShiftReduceConflictResolvedReduce {
+                term: term_str,
+                shift_prec: *shift_prec,
+                shift_rules: shift_rule_indices,
+                reduce_rules: reduce_rule_pairs,
+            });
+        }
+
+        // 4. unresolved conflicts (for GLR help notes)
+        if self.glr {
+            // shift_reduce_conflicts
+            for ((term, shift_rules, shift_rules_backtrace), reduce_rules) in
+                &collector.shift_reduce_conflicts
+            {
+                let term_str = self.class_pretty_name_list(*term, 5);
+                let shift_rule_indices = shift_rules.iter().map(|sr| sr.rule).collect::<Vec<_>>();
+
+                let mut s_backtrace = Vec::new();
+                for shift_rule in shift_rules_backtrace {
+                    let rule_str = self.builder.rules[shift_rule.rule]
+                        .rule
+                        .clone()
+                        .map(
+                            |c| self.class_pretty_name_list(c, 5),
+                            |nt| self.nonterm_pretty_name(nt),
+                        )
+                        .into_shifted(shift_rule.shifted);
+                    s_backtrace.push(format!("\t>>> {rule_str}"));
+                }
+
+                let mut r_rules = Vec::new();
+                for (&reduce_rule, reduce_rule_backtrace) in reduce_rules {
+                    let mut r_backtrace = Vec::new();
+                    let name = self.nonterm_pretty_name(self.builder.rules[reduce_rule].rule.name);
+                    r_backtrace.push(format!("Backtrace for the reduce rule ({name}):"));
+                    for shifted_rule in reduce_rule_backtrace {
+                        let rule_str = self.builder.rules[shifted_rule.rule]
+                            .rule
+                            .clone()
+                            .map(
+                                |c| self.class_pretty_name_list(c, 5),
+                                |nt| self.nonterm_pretty_name(nt),
+                            )
+                            .into_shifted(shifted_rule.shifted);
+                        r_backtrace.push(format!("\t>>> {rule_str}"));
+                    }
+                    r_rules.push((reduce_rule, r_backtrace));
+                }
+
+                self.infos.push(Info::ShiftReduceConflictGLR {
+                    term: term_str,
+                    shift_rules: shift_rule_indices,
+                    shift_rules_backtrace: s_backtrace,
+                    reduce_rules: r_rules,
+                });
+            }
+
+            // reduce_reduce_conflicts
+            for (reduce_rules, reduce_terms) in &collector.reduce_reduce_conflicts {
+                let term_strings = reduce_terms
+                    .iter()
+                    .map(|&t| self.class_pretty_name_list(t, 5))
+                    .collect::<Vec<_>>();
+
+                let mut r_rules = Vec::new();
+                for &(reduce_rule, ref reduce_rule_from) in reduce_rules {
+                    let mut r_backtrace = Vec::new();
+                    let name = self.nonterm_pretty_name(self.builder.rules[reduce_rule].rule.name);
+                    r_backtrace.push(format!("Backtrace for the reduce rule ({name}):"));
+                    for shifted_rule in reduce_rule_from {
+                        let rule_str = self.builder.rules[shifted_rule.rule]
+                            .rule
+                            .clone()
+                            .map(
+                                |c| self.class_pretty_name_list(c, 5),
+                                |nt| self.nonterm_pretty_name(nt),
+                            )
+                            .into_shifted(shifted_rule.shifted);
+                        r_backtrace.push(format!("\t>>> {rule_str}"));
+                    }
+                    r_rules.push((reduce_rule, r_backtrace));
+                }
+
+                self.infos.push(Info::ReduceReduceConflictGLR {
+                    terms: term_strings,
+                    reduce_rules: r_rules,
+                });
+            }
+        }
 
         collector
     }
@@ -3454,6 +3600,68 @@ mod tests {
         assert!(
             code_str.contains("* val") || code_str.contains("*val"),
             "Dereference should be generated to extract boxed value"
+        );
+    }
+
+    #[test]
+    fn test_warnings_and_infos_collection() {
+        let input = quote! {
+            %tokentype char;
+            %start Expr;
+            %left '+';
+
+            Expr : Expr '+' Expr | 'a';
+            UnusedNonTerm : 'b' 'c';
+        };
+
+        let grammar_args = Grammar::parse_args(input).expect("Failed to parse grammar");
+        let mut grammar =
+            Grammar::from_grammar_args(grammar_args).expect("Failed to construct grammar");
+
+        println!(
+            "Non-terminals before optimize: {:?}",
+            grammar
+                .nonterminals
+                .iter()
+                .map(|n| n.name.value().clone())
+                .collect::<Vec<_>>()
+        );
+        grammar.optimize(25);
+
+        println!("Warnings: {:?}", grammar.warnings);
+        println!(
+            "Non-terminals: {:?}",
+            grammar
+                .nonterminals
+                .iter()
+                .map(|n| n.name.value().clone())
+                .collect::<Vec<_>>()
+        );
+
+        let has_unused_warning = grammar
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::NonTermNotUsed { .. }));
+        assert!(
+            has_unused_warning,
+            "Expected NonTermNotUsed warning, got: {:?}",
+            grammar.warnings
+        );
+
+        grammar.builder = grammar.create_builder();
+        let _ = grammar.build_grammar();
+
+        let has_resolved_info = grammar.infos.iter().any(|info| {
+            matches!(
+                info,
+                Info::ShiftReduceConflictResolvedReduce { .. }
+                    | Info::ShiftReduceConflictResolvedShift { .. }
+            )
+        });
+        assert!(
+            has_resolved_info,
+            "Expected shift/reduce conflict resolution note, got: {:?}",
+            grammar.infos
         );
     }
 }

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -2886,8 +2886,8 @@ impl Grammar {
         for (max_priority, reduce_rules, deleted_rules) in &collector.reduce_reduce_resolved {
             self.infos.push(Info::ReduceReduceConflictResolved {
                 max_priority: *max_priority,
-                reduce_rules: reduce_rules.iter().cloned().collect(),
-                deleted_rules: deleted_rules.iter().cloned().collect(),
+                reduce_rules: reduce_rules.iter().copied().collect(),
+                deleted_rules: deleted_rules.iter().copied().collect(),
             });
         }
 

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -2054,7 +2054,7 @@ impl Grammar {
                 if !nonterm.is_auto_generated() {
                     let loc = nonterm.name.location();
                     self.warnings.push(Warning::NonTermNotUsed {
-                        nonterm_location: loc,
+                        nonterm_idx: Located::new(nonterm_idx, loc),
                     });
                 }
             }
@@ -2189,7 +2189,7 @@ impl Grammar {
             if !nonterm.is_auto_generated() {
                 let loc = nonterm.name.location();
                 self.infos.push(Info::SingleNonTerminalRule {
-                    nonterm_location: loc,
+                    nonterm_idx: Located::new(nonterm_id, loc),
                     rule_location: rule.location(),
                 });
             }
@@ -2303,7 +2303,7 @@ impl Grammar {
         for i in add_to_diags {
             let nonterm = &self.nonterminals[i];
             self.warnings.push(Warning::NonTermDataNotUsed {
-                nonterm_location: nonterm.name.location(),
+                nonterm_idx: Located::new(i, nonterm.name.location()),
             });
         }
 
@@ -2398,7 +2398,7 @@ impl Grammar {
         }
 
         // Collect optimization warnings and notes/infos
-        for class_def in self.terminal_classes.iter() {
+        for (class_idx, class_def) in self.terminal_classes.iter().enumerate() {
             let len: usize = class_def
                 .terminals
                 .iter()
@@ -2407,32 +2407,19 @@ impl Grammar {
             if len == 1 {
                 continue;
             }
-            let class_name = format!("TerminalClass{}", class_def.multiterm_counter);
-            let terminals = class_def
-                .terminals
-                .iter()
-                .map(|&term| self.term_pretty_name(term))
-                .collect::<Vec<_>>();
-            self.infos.push(Info::TerminalsMerged {
-                class_name,
-                terminals,
-            });
+            self.infos.push(Info::TerminalsMerged { class_idx });
         }
 
         // if other terminals were not used, print warning about removing them
         let other_terminal_class = &self.terminal_classes[self.other_terminal_class_id];
         if !self.other_used && other_terminal_class.terminals.len() > 1 {
-            let class_name = self.class_pretty_name_abbr(self.other_terminal_class_id);
-            let terms =
-                self.class_pretty_name_list(TerminalSymbol::Term(self.other_terminal_class_id), 10);
             self.warnings.push(Warning::UnusedTerminals {
-                class_name,
-                terminals: vec![terms],
+                class_idx: self.other_terminal_class_id,
             });
         }
     }
 
-    fn term_pretty_name(&self, term_idx: usize) -> String {
+    pub fn term_pretty_name(&self, term_idx: usize) -> String {
         if term_idx == self.other_terminal_index {
             "<Others>".to_string()
         } else {
@@ -2907,14 +2894,13 @@ impl Grammar {
         for ((term, shift_rules), (shift_prec, reduce_rules)) in
             &collector.shift_reduce_resolved_shift
         {
-            let term_str = self.class_pretty_name_list(*term, 5);
             let shift_rule_indices = shift_rules.iter().map(|sr| sr.rule).collect::<Vec<_>>();
             let reduce_rule_pairs = reduce_rules
                 .iter()
                 .map(|(&r, &p)| (r, p))
                 .collect::<Vec<_>>();
             self.infos.push(Info::ShiftReduceConflictResolvedShift {
-                term: term_str,
+                term: *term,
                 shift_prec: *shift_prec,
                 shift_rules: shift_rule_indices,
                 reduce_rules: reduce_rule_pairs,
@@ -2925,14 +2911,13 @@ impl Grammar {
         for ((term, shift_rules), (shift_prec, reduce_rules)) in
             &collector.shift_reduce_resolved_reduce
         {
-            let term_str = self.class_pretty_name_list(*term, 5);
             let shift_rule_indices = shift_rules.iter().map(|sr| sr.rule).collect::<Vec<_>>();
             let reduce_rule_pairs = reduce_rules
                 .iter()
                 .map(|(&r, &p)| (r, p))
                 .collect::<Vec<_>>();
             self.infos.push(Info::ShiftReduceConflictResolvedReduce {
-                term: term_str,
+                term: *term,
                 shift_prec: *shift_prec,
                 shift_rules: shift_rule_indices,
                 reduce_rules: reduce_rule_pairs,
@@ -2945,7 +2930,6 @@ impl Grammar {
             for ((term, shift_rules, shift_rules_backtrace), reduce_rules) in
                 &collector.shift_reduce_conflicts
             {
-                let term_str = self.class_pretty_name_list(*term, 5);
                 let shift_rule_indices = shift_rules.iter().map(|sr| sr.rule).collect::<Vec<_>>();
 
                 let mut s_backtrace = Vec::new();
@@ -2981,7 +2965,7 @@ impl Grammar {
                 }
 
                 self.infos.push(Info::ShiftReduceConflictGLR {
-                    term: term_str,
+                    term: *term,
                     shift_rules: shift_rule_indices,
                     shift_rules_backtrace: s_backtrace,
                     reduce_rules: r_rules,
@@ -2990,11 +2974,6 @@ impl Grammar {
 
             // reduce_reduce_conflicts
             for (reduce_rules, reduce_terms) in &collector.reduce_reduce_conflicts {
-                let term_strings = reduce_terms
-                    .iter()
-                    .map(|&t| self.class_pretty_name_list(t, 5))
-                    .collect::<Vec<_>>();
-
                 let mut r_rules = Vec::new();
                 for &(reduce_rule, ref reduce_rule_from) in reduce_rules {
                     let mut r_backtrace = Vec::new();
@@ -3015,7 +2994,7 @@ impl Grammar {
                 }
 
                 self.infos.push(Info::ReduceReduceConflictGLR {
-                    terms: term_strings,
+                    terms: reduce_terms.iter().cloned().collect(),
                     reduce_rules: r_rules,
                 });
             }


### PR DESCRIPTION
## Summary
This Pull Request generalizes diagnostics (`Warning` and `Info` messages) by moving them from the buildscript level (`rusty_lr_buildscript`) down to the parser generator library (`rusty_lr_parser`). It also enables the procedural macro (`rusty_lr_derive`) to emit compilation warnings on stable Rust mapped directly to their respective source code spans, and resolves a circular optimizer deadlock.
## Key Changes
### 1. `rusty_lr_parser`
* **Generalized and Refactored Diagnostics (`error.rs`):**
  * Moved the `Warning` and `Info` definitions from the buildscript down to the core parser library.
  * Structured both enums to hold raw indices (`usize`), typed symbols (`TerminalSymbol<usize>`), or `Located<usize>` wrappers carrying location spans, rather than pre-formatted strings. This keeps the core diagnostic APIs clean, decoupled, and reusable.
  * Implemented `Warning::locations()`, `Warning::short_message()`, and `Warning::to_compile_warning()`.
* **Stable Compile Warnings (`error.rs` & `to_compile_warning`):**
  * Implemented a `deprecated` lint pattern trick to emit compilation warnings on stable Rust. It generates an anonymous block (`const _: () = { #[deprecated(note = #message)] struct Warning; let _ = Warning; };`) associated with the exact source span of the warning.
* **Fixed Optimizer Deadlock / Bracket Bug (`grammar.rs`):**
  * Moved the unused non-terminal detection logic out of the terminal class partitioning conditional block. This ensures that unused non-terminal cleaning runs on every iteration of the optimization loop, preventing deadlocks where unused non-terminals blocked terminal-merging checks.
  * Adjusted diagnostic collection for both resolved and unresolved (GLR) conflicts.
* **Added Unit Tests (`grammar.rs`):**
  * Added `test_warnings_and_infos_collection` to verify that `Warning::NonTermNotUsed` and conflict resolution notes are correctly populated in the `Grammar` structure.
* **Cleanup (`grammar.rs`):**
  * Completely removed the unused and redundant `OptimizeDiag` and `OptimizeRemove` structures.
### 2. `rusty_lr_derive`
* **Procedural Macro Warning Integration (`lib.rs`):**
  * Updated the main `lr1` macro entry point to iterate through `grammar.warnings` and append the tokens generated by `to_compile_warning()` directly to the output `TokenStream`.
### 3. `rusty_lr_buildscript`
* **Decoupled Diagnostics Formatting (`lib.rs`):**
  * Refactored buildscript diagnostic generation to format and print warnings and informational notes directly from the newly generalized parser enums (`grammar.warnings` and `grammar.infos`) using `codespan_reporting`.
