### PR TITLE
Remove Dynamic Precedence and Runtime Operator Precedence Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Highly inspired by classic tools like *Bison* and *Yacc*, RustyLR uses a familia
 - **Automatic Parser Optimization:** Shrinks parsing tables and boosts runtime performance by grouping terminal symbols that exhibit identical behavior across parser states.
 - **Multiple Parsing Strategies:** Supports minimal-LR(1) (IELR-style), LALR(1) tables, and Generalized LR (GLR) parsing.
 - **Detailed Diagnostics:** Reports grammar conflicts, provides verbose traces of conflict resolution stages, and logs optimization passes.
-- **Static & Runtime Conflict Resolution:** Resolve grammar conflicts at compile time (precedence/associativity) or dynamically at runtime.
+- **Static Conflict Resolution & GLR Branching:** Resolve grammar conflicts at compile time (precedence/associativity) or dynamically using GLR parsing.
 - **Location Tracking:** Automatically tracks positions of tokens and non-terminals, simplifying error reporting in compiler diagnostics.
 - **State Machine Debugging:** The `rustylr` CLI provides a `--state` flag to inspect and visualize the generated state machine, making conflict debugging straightforward.
 

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -26,7 +26,7 @@ This document provides a comprehensive guide to the grammar definition syntax us
 - [Advanced Parser Controls](#advanced-parser-controls)
   - [Memory Optimization with `box`](#memory-optimization-with-box)
   - [Custom Token Ranges](#custom-token-ranges)
-  - [Dynamic Precedence with Non-Terminals](#dynamic-precedence-with-non-terminals)
+
   - [GLR Parser Generation (`%glr`)](#glr-parser-generation)
   - [Advanced GLR Reduce Controls](#advanced-glr-reduce-controls)
   - [Rule Priority (`%dprec`)](#rule-priority)
@@ -430,7 +430,7 @@ Expr
     ;
 ```
 
-For cases where the operator is represented by a non-terminal, see [Dynamic Precedence with Non-Terminals](#dynamic-precedence-with-non-terminals).
+
 
 ## Error Type (Optional)
 
@@ -591,19 +591,6 @@ The range `[zero-two]` matches `zero`, `one`, and `two`.
 
 For ordinary grammars, prefer explicit terminal sets like `[zero one two]` unless declaration-order ranges materially simplify the grammar.
 
-### Dynamic Precedence with Non-Terminals
-
-You can use a non-terminal in `%prec` if the operator is determined dynamically:
-
-```rust
-Expr : Expr op=BinOp Expr %prec op { ... };
-
-BinOp : '+' | '*';
-```
-
-Here, the rule's precedence matches the specific operator that `BinOp` resolved to.
-
-For ordinary unary and binary operators, a named precedence marker such as `UnaryMinus` is usually clearer.
 
 ### GLR Parser Generation
 

--- a/example/calculator_u8/src/parser.rs
+++ b/example/calculator_u8/src/parser.rs
@@ -18,19 +18,18 @@ P(f32): Number { Number as f32 }
 | WS0 '(' E ')' WS0 { E }
 ;
 
-E(_) : E Op e2=E %prec Op {
+E(_) : E '+' e2=E {
     *data += 1; // access userdata by `data`
-    println!( "{:?} {:?} {:?}", E, Op, e2 );
-    match Op {
-        '+' => E + e2,
-        '*' => E * e2,
-        _ => panic!("Unknown operator: {:?}", Op),
-    }
+    println!( "{:?} '+' {:?}", E, e2 );
+    E + e2
+}
+| E '*' e2=E {
+    *data += 1; // access userdata by `data`
+    println!( "{:?} '*' {:?}", E, e2 );
+    E * e2
 }
 | WS0 '-' E %prec UMINUS {
     -E
 }
 | P
 ;
-
-Op(_): '+' | '*' ;

--- a/rusty_lr_buildscript/src/lib.rs
+++ b/rusty_lr_buildscript/src/lib.rs
@@ -742,19 +742,7 @@ impl Builder {
                                 "refer to https://github.com/ehwan/RustyLR/blob/main/SYNTAX.md#operator-precedence".to_string()
                             ])
                     }
-                    ParseError::NonTerminalPrecedenceNotDefined(loc) => {
-                        let range = span_manager.get_byterange(&loc.location()).unwrap_or(0..0);
-                        Diagnostic::error()
-                            .with_message("Precedence is not defined for this non-terminal")
-                            .with_labels(vec![Label::primary(file_id, range)
-                                .with_message(format!("non-terminal used here"))])
-                            .with_notes(vec![
-                                "Every production rule of this non-terminal must have a precedence defined"
-                                    .to_string(),
-                                "use %left, %right, or %precedence to define precedence"
-                                    .to_string(),
-                            ])
-                    }
+
                     ParseError::RuleTypeDefinedButActionNotDefined { nonterm, rule } => {
                         // `name` must not be generated rule,
                         // since it is programmically generated, it must have a proper reduce action

--- a/rusty_lr_core/src/parser/deterministic/context.rs
+++ b/rusty_lr_core/src/parser/deterministic/context.rs
@@ -9,7 +9,7 @@ use crate::parser::table::Index;
 use crate::parser::table::ParserTables;
 use crate::parser::terminalclass::TerminalClass;
 use crate::parser::Parser;
-use crate::parser::Precedence;
+
 use crate::TerminalSymbol;
 
 /// A struct that maintains the current state and the values associated with each symbol.
@@ -22,7 +22,6 @@ pub struct Context<
     pub state_stack: Vec<StateIndex>,
     pub(crate) data_stack: Data,
     pub(crate) location_stack: Vec<Data::Location>,
-    pub(crate) precedence_stack: Vec<Precedence>,
     pub(crate) userdata: Data::UserData,
     /// Decoded parser tables initialized when the context is created.
     ///
@@ -49,7 +48,6 @@ impl<
 
             data_stack: Default::default(),
             location_stack: Vec::new(),
-            precedence_stack: Vec::new(),
             userdata,
             tables: P::get_tables(),
 
@@ -77,7 +75,6 @@ impl<
 
             data_stack: Data::with_capacity(capacity),
             location_stack: Vec::with_capacity(capacity),
-            precedence_stack: Vec::with_capacity(capacity),
             userdata,
             tables: P::get_tables(),
 
@@ -144,17 +141,13 @@ impl<
         Ok(std::iter::once(self.accept()?))
     }
 
-    /// Check if current context can be terminated and get the value of the start symbol.
     pub fn can_accept(&self) -> bool {
         let mut extra_state_stack = Vec::new();
-        let mut extra_precedence_stack = Vec::new();
 
         self.can_feed_impl(
-            self.precedence_stack.len(),
+            self.state_stack.len() - 1,
             &mut extra_state_stack,
-            &mut extra_precedence_stack,
             P::TermClass::EOF,
-            Precedence::none(),
         ) == Some(true)
     }
 
@@ -196,7 +189,7 @@ impl<
         let mut extra_state_stack = Vec::new();
         self.expected_token_impl(
             &mut extra_state_stack,
-            self.precedence_stack.len(),
+            self.state_stack.len() - 1,
             &mut terms,
             &mut nonterms,
         );
@@ -292,9 +285,8 @@ impl<
     {
         use crate::Location;
         let class = P::TermClass::from_term(&term);
-        let shift_prec = class.precedence();
 
-        match self.feed_location_impl(TerminalSymbol::Term(term), class, shift_prec, location) {
+        match self.feed_location_impl(TerminalSymbol::Term(term), class, location) {
             Ok(()) => Ok(()),
             Err(ParseError::NoAction(err)) => {
                 // nothing shifted; enters panic mode
@@ -304,10 +296,7 @@ impl<
                     return Err(ParseError::NoAction(err));
                 }
 
-                let error_prec = P::TermClass::ERROR.precedence();
-
                 let mut extra_state_stack = Vec::new();
-                let mut extra_precedence_stack = Vec::new();
 
                 use crate::TriState;
                 let mut pop_count = 0;
@@ -316,15 +305,12 @@ impl<
                     match self.tables.can_accept_error(s.into_usize()) {
                         TriState::False => {}
                         TriState::Maybe => {
-                            extra_precedence_stack.clear();
                             extra_state_stack.clear();
 
                             if self.can_feed_impl(
-                                self.precedence_stack.len() - pop_count,
+                                self.state_stack.len() - pop_count - 1,
                                 &mut extra_state_stack,
-                                &mut extra_precedence_stack,
                                 P::TermClass::ERROR,
-                                error_prec,
                             ) == Some(true)
                             {
                                 found = true;
@@ -348,12 +334,10 @@ impl<
                     Data::Location::new(self.location_stack.iter().rev(), pop_count);
                 self.location_stack
                     .truncate(self.location_stack.len() - pop_count);
+                self.data_stack
+                    .truncate(self.state_stack.len() - pop_count - 1);
                 self.state_stack
                     .truncate(self.state_stack.len() - pop_count);
-                self.data_stack
-                    .truncate(self.precedence_stack.len() - pop_count);
-                self.precedence_stack
-                    .truncate(self.precedence_stack.len() - pop_count);
 
                 #[cfg(feature = "tree")]
                 {
@@ -364,7 +348,6 @@ impl<
                 match self.feed_location_impl(
                     TerminalSymbol::Error,
                     P::TermClass::ERROR,
-                    error_prec,
                     error_location,
                 ) {
                     Ok(()) => {
@@ -387,7 +370,6 @@ impl<
                             }
 
                             self.location_stack.push(err.location.clone());
-                            self.precedence_stack.push(shift_prec);
                             self.state_stack.push(next_state.state);
                         } else {
                             // merge term with previous error
@@ -416,7 +398,6 @@ impl<
         &mut self,
         term: TerminalSymbol<P::Term>,
         class: P::TermClass,
-        shift_prec: Precedence,
         location: Data::Location,
     ) -> Result<(), ParseError<Data::Term, Data::Location, Data::ReduceActionError>>
     where
@@ -438,67 +419,9 @@ impl<
                 let rule = *self.tables.rule(reduce_rule.into_usize());
                 let tokens_len = rule.len;
 
-                let reduce_prec = match rule.precedence {
-                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
-                    crate::rule::Precedence::Dynamic(token_idx) => {
-                        // get token_idx'th precedence from back of precedence stack
-                        let idx = self.precedence_stack.len() - tokens_len + token_idx;
-                        self.precedence_stack[idx]
-                    }
-                    crate::rule::Precedence::None => Precedence::none(),
-                };
-
-                // resolve shift/reduce conflict by precedence
-                if shift.is_some() {
-                    let shift_prec = shift_prec.unwrap();
-                    let reduce_prec = reduce_prec.unwrap();
-                    use std::cmp::Ordering;
-                    match reduce_prec.cmp(&shift_prec) {
-                        Ordering::Less => {
-                            // no reduce
-                            break shift;
-                        }
-                        Ordering::Equal => {
-                            // check for reduce type
-                            use crate::rule::ReduceType;
-                            match P::precedence_types(reduce_prec) {
-                                Some(ReduceType::Left) => {
-                                    // no shift
-                                    // shift = None;
-                                }
-                                Some(ReduceType::Right) => {
-                                    // no reduce
-                                    break shift;
-                                }
-                                None => {
-                                    // error
-                                    return Err(ParseError::NoPrecedence(
-                                        super::error::NoPrecedenceError {
-                                            term,
-                                            location,
-                                            state: self.state_stack.last().unwrap().into_usize(),
-                                            rule: reduce_rule.into_usize(),
-                                        },
-                                    ));
-                                }
-                            }
-                        }
-                        Ordering::Greater => {
-                            // no shift
-                            // shift = None;
-                        }
-                    }
-                }
-
-                // if the code reaches here, it proceed to reduce, without shifting
-
                 // pop state stack
                 self.state_stack
                     .truncate(self.state_stack.len() - tokens_len);
-                // pop precedence stack
-                self.precedence_stack
-                    .truncate(self.precedence_stack.len() - tokens_len);
-                self.precedence_stack.push(reduce_prec);
 
                 let mut shift = false;
 
@@ -584,7 +507,6 @@ impl<
             }
 
             self.location_stack.push(location);
-            self.precedence_stack.push(shift_prec);
 
             Ok(())
         } else {
@@ -602,17 +524,9 @@ impl<
     /// and will return `true` if `Err` variant is returned by `reduce_action`.
     pub fn can_feed(&self, term: &Data::Term) -> bool {
         let mut extra_state_stack = Vec::new();
-        let mut extra_precedence_stack = Vec::new();
         let class = P::TermClass::from_term(term);
-        let shift_prec = class.precedence();
 
-        self.can_feed_impl(
-            self.precedence_stack.len(),
-            &mut extra_state_stack,
-            &mut extra_precedence_stack,
-            class,
-            shift_prec,
-        ) == Some(true)
+        self.can_feed_impl(self.state_stack.len() - 1, &mut extra_state_stack, class) == Some(true)
     }
 
     /// Check if current context can enter panic mode
@@ -623,19 +537,11 @@ impl<
         }
 
         let mut extra_state_stack = Vec::new();
-        let mut extra_precedence_stack = Vec::new();
         let error = P::TermClass::ERROR;
-        let error_prec = error.precedence();
-        let mut stack_len = self.precedence_stack.len();
+        let mut stack_len = self.state_stack.len() - 1;
 
         loop {
-            match self.can_feed_impl(
-                stack_len,
-                &mut extra_state_stack,
-                &mut extra_precedence_stack,
-                error,
-                error_prec,
-            ) {
+            match self.can_feed_impl(stack_len, &mut extra_state_stack, error) {
                 Some(true) => break true, // successfully shifted `error`
                 Some(false) => {
                     if stack_len == 0 {
@@ -647,7 +553,6 @@ impl<
                 None => break false,
             }
             extra_state_stack.clear();
-            extra_precedence_stack.clear();
         }
     }
 
@@ -655,9 +560,7 @@ impl<
         &self,
         mut stack_len: usize,
         extra_state_stack: &mut Vec<StateIndex>,
-        extra_precedence_stack: &mut Vec<Precedence>,
         class: P::TermClass,
-        shift_prec: Precedence,
     ) -> Option<bool> {
         let shift_to = loop {
             let state = extra_state_stack
@@ -676,69 +579,14 @@ impl<
                 let rule = *self.tables.rule(reduce_rule.into_usize());
                 let tokens_len = rule.len;
 
-                let reduce_prec = match rule.precedence {
-                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
-                    crate::rule::Precedence::Dynamic(token_idx) => {
-                        // get token_idx'th precedence from back of precedence stack
-                        let idx = stack_len + extra_precedence_stack.len() - tokens_len + token_idx;
-                        if idx < stack_len {
-                            self.precedence_stack[idx]
-                        } else {
-                            let idx = idx - stack_len;
-                            extra_precedence_stack[idx]
-                        }
-                    }
-                    crate::rule::Precedence::None => Precedence::none(),
-                };
-
-                // resolve shift/reduce conflict by precedence
-                if shift.is_some() {
-                    let shift_prec = shift_prec.unwrap();
-                    let reduce_prec = reduce_prec.unwrap();
-                    use std::cmp::Ordering;
-                    match reduce_prec.cmp(&shift_prec) {
-                        Ordering::Less => {
-                            // no reduce
-                            break shift;
-                        }
-                        Ordering::Equal => {
-                            // check for reduce type
-                            use crate::rule::ReduceType;
-                            match P::precedence_types(reduce_prec) {
-                                Some(ReduceType::Left) => {
-                                    // no shift
-                                    // shift = None;
-                                }
-                                Some(ReduceType::Right) => {
-                                    // no reduce
-                                    break shift;
-                                }
-                                None => {
-                                    // error
-                                    return None;
-                                }
-                            }
-                        }
-                        Ordering::Greater => {
-                            // no shift
-                            // shift = None;
-                        }
-                    }
-                }
-
                 // pop state stack
-                // pop precedence stack
-                if tokens_len <= extra_precedence_stack.len() {
-                    extra_precedence_stack.truncate(extra_precedence_stack.len() - tokens_len);
+                if tokens_len <= extra_state_stack.len() {
                     extra_state_stack.truncate(extra_state_stack.len() - tokens_len);
                 } else {
-                    let left = tokens_len - extra_precedence_stack.len();
-                    extra_precedence_stack.clear();
+                    let left = tokens_len - extra_state_stack.len();
                     extra_state_stack.clear();
                     stack_len -= left;
                 }
-
-                extra_precedence_stack.push(reduce_prec);
 
                 // shift with reduced nonterminal
                 let last_state = extra_state_stack
@@ -776,12 +624,7 @@ impl<
         P::NonTerm: std::fmt::Debug,
     {
         let eof_location = Data::Location::new(self.location_stack.iter().rev(), 0);
-        self.feed_location_impl(
-            TerminalSymbol::Eof,
-            P::TermClass::EOF,
-            Precedence::none(),
-            eof_location,
-        )
+        self.feed_location_impl(TerminalSymbol::Eof, P::TermClass::EOF, eof_location)
     }
 }
 
@@ -814,7 +657,6 @@ where
             state_stack: self.state_stack.clone(),
             data_stack: self.data_stack.clone(),
             location_stack: self.location_stack.clone(),
-            precedence_stack: self.precedence_stack.clone(),
             userdata: self.userdata.clone(),
             tables: self.tables,
 

--- a/rusty_lr_core/src/parser/mod.rs
+++ b/rusty_lr_core/src/parser/mod.rs
@@ -14,30 +14,6 @@ pub mod terminalclass;
 pub mod state;
 pub mod table;
 
-#[derive(Clone, Copy)]
-pub struct Precedence(u8);
-
-impl Precedence {
-    #[inline]
-    pub fn none() -> Self {
-        Precedence(u8::MAX)
-    }
-    #[inline]
-    pub fn new(level: u8) -> Self {
-        debug_assert!(level < u8::MAX);
-        Precedence(level)
-    }
-    #[inline]
-    pub fn is_some(&self) -> bool {
-        self.0 < u8::MAX
-    }
-
-    pub fn unwrap(self) -> u8 {
-        debug_assert!(self.0 < u8::MAX);
-        self.0
-    }
-}
-
 /// A trait for Parser that holds the entire parser table.
 /// This trait will be automatically implemented by rusty_lr
 pub trait Parser {
@@ -64,8 +40,4 @@ pub trait Parser {
 
     /// Get the decoded runtime parser tables.
     fn get_tables() -> &'static Self::Tables;
-    /// Get the type of precedence for i'th level.
-    /// `None` if i'th level was defined as %precedence (no reduce type).
-    /// Determined entirely at compile time and is static.
-    fn precedence_types(level: u8) -> Option<crate::rule::ReduceType>;
 }

--- a/rusty_lr_core/src/parser/nondeterministic/context.rs
+++ b/rusty_lr_core/src/parser/nondeterministic/context.rs
@@ -9,7 +9,6 @@ use crate::parser::table::Index;
 use crate::parser::table::ParserTables;
 use crate::parser::terminalclass::TerminalClass;
 use crate::parser::Parser;
-use crate::parser::Precedence;
 use crate::TerminalSymbol;
 
 /// Iterator for traverse node to root.
@@ -353,7 +352,6 @@ impl<
 
                 // truncate stacks to cut off reduce_token_count elements from back
                 node.state_stack.truncate(i);
-                node.precedence_stack.truncate(i);
 
                 node_idx
             } else {
@@ -402,14 +400,12 @@ impl<
                     let mut parent_data_stack = node.data_stack.split_off(i);
                     let mut parent_state_stack = node.state_stack.split_off(i);
                     let mut parent_location_stack = node.location_stack.split_off(i);
-                    let mut parent_precedence_stack = node.precedence_stack.split_off(i);
                     #[cfg(feature = "tree")]
                     let mut parent_tree_stack = node.tree_stack.split_off(i);
 
                     std::mem::swap(&mut parent_data_stack, &mut node.data_stack);
                     std::mem::swap(&mut parent_state_stack, &mut node.state_stack);
                     std::mem::swap(&mut parent_location_stack, &mut node.location_stack);
-                    std::mem::swap(&mut parent_precedence_stack, &mut node.precedence_stack);
                     #[cfg(feature = "tree")]
                     std::mem::swap(&mut parent_tree_stack, &mut node.tree_stack);
 
@@ -422,7 +418,6 @@ impl<
                     parent_node.data_stack = parent_data_stack;
                     parent_node.state_stack = parent_state_stack;
                     parent_node.location_stack = parent_location_stack;
-                    parent_node.precedence_stack = parent_precedence_stack;
                     #[cfg(feature = "tree")]
                     {
                         parent_node.tree_stack = parent_tree_stack;
@@ -511,7 +506,6 @@ impl<
     fn reduce(
         &mut self,
         reduce_rule: usize,
-        precedence: Precedence,
         node: usize,
         term: &crate::TerminalSymbol<P::Term>,
         shift: &mut bool,
@@ -554,7 +548,6 @@ impl<
             Ok(_) => {
                 node.state_stack.push(next_nonterm_shift.state);
                 node.location_stack.push(new_location);
-                node.precedence_stack.push(precedence);
                 #[cfg(feature = "tree")]
                 {
                     node.tree_stack
@@ -807,7 +800,6 @@ impl<
         node: usize,
         term: TerminalSymbol<P::Term>,
         class: P::TermClass,
-        shift_prec: Precedence,
         location: Data::Location,
         userdata: Data::UserData,
     ) -> Result<
@@ -834,62 +826,11 @@ impl<
             None => (None, None),
         };
         if let Some(reduce_rules) = reduce {
-            let mut shift = None;
+            let mut shift = shift_state;
             let mut reduces: arrayvec::ArrayVec<_, MAX_REDUCE_RULES> = Default::default();
 
             for reduce_rule in reduce_rules.to_iter() {
-                let rule = *self.tables.rule(reduce_rule.into_usize());
-                let reduce_prec = match rule.precedence {
-                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
-                    crate::rule::Precedence::Dynamic(token_index) => {
-                        // fix the value to the offset from current node
-                        let ith = rule.len - token_index - 1;
-                        let (node, ith) = self.skip_last_n(node, ith).unwrap();
-                        self.node(node).precedence_stack[ith]
-                    }
-                    crate::rule::Precedence::None => Precedence::none(),
-                };
-
-                // if there is shift/reduce conflict, check for reduce rule's precedence and shift terminal's precedence
-                match (shift_state.is_some(), shift_prec, reduce_prec) {
-                    (true, Precedence(shift_prec_), Precedence(reduce_prec_))
-                        if shift_prec.is_some() && reduce_prec.is_some() =>
-                    {
-                        match reduce_prec_.cmp(&shift_prec_) {
-                            std::cmp::Ordering::Less => {
-                                // no reduce
-                                shift = shift_state;
-                            }
-                            std::cmp::Ordering::Equal => {
-                                // check for reduce_type
-                                use crate::rule::ReduceType;
-                                match P::precedence_types(reduce_prec_) {
-                                    Some(ReduceType::Left) => {
-                                        // no shift
-                                        reduces.push((reduce_rule, reduce_prec));
-                                    }
-                                    Some(ReduceType::Right) => {
-                                        // no reduce
-                                        shift = shift_state;
-                                    }
-                                    None => {
-                                        // cannot determine precedence, error
-                                        self.no_precedences.push(reduce_rule.into_usize());
-                                    }
-                                }
-                            }
-                            std::cmp::Ordering::Greater => {
-                                // no shift
-                                reduces.push((reduce_rule, reduce_prec));
-                            }
-                        }
-                    }
-                    _ => {
-                        // nothing; go for both reduce and shift
-                        shift = shift_state;
-                        reduces.push((reduce_rule, reduce_prec));
-                    }
-                }
+                reduces.push(reduce_rule);
             }
 
             let mut shifted = false;
@@ -899,7 +840,7 @@ impl<
                 // Each GLR branch receives its own user data copy before running reduce actions.
                 let mut shift_ = false;
                 let l = reduces.len();
-                for (idx, (reduce_rule, precedence)) in reduces.into_iter().enumerate() {
+                for (idx, reduce_rule) in reduces.into_iter().enumerate() {
                     let mut pass = shift.is_some();
                     let mut branch_userdata = userdata.clone();
 
@@ -913,7 +854,6 @@ impl<
                     }
                     match self.reduce(
                         reduce_rule.into_usize(),
-                        precedence,
                         node,
                         &term,
                         &mut pass,
@@ -927,7 +867,6 @@ impl<
                                 next_node,
                                 term.clone(),
                                 class,
-                                shift_prec,
                                 location.clone(),
                                 branch_userdata,
                             ) {
@@ -965,7 +904,6 @@ impl<
             if let Some(shift) = shift {
                 let node_ = self.node_mut(node);
                 node_.state_stack.push(shift.state);
-                node_.precedence_stack.push(shift_prec);
                 node_.location_stack.push(location.clone());
                 #[cfg(feature = "tree")]
                 node_
@@ -1000,7 +938,6 @@ impl<
         } else if let Some(shift) = shift_state {
             let node_ = self.node_mut(node);
             node_.state_stack.push(shift.state);
-            node_.precedence_stack.push(shift_prec);
             node_.location_stack.push(location);
             #[cfg(feature = "tree")]
             node_
@@ -1035,10 +972,8 @@ impl<
     fn panic_mode(
         &mut self,
         mut node: usize,
-        error_prec: Precedence,
         userdata: Data::UserData,
         extra_state_stack: &mut Vec<StateIndex>,
-        extra_precedence_stack: &mut Vec<Precedence>,
     ) -> Data::Location
     where
         Data: Clone,
@@ -1067,15 +1002,12 @@ impl<
                 match self.tables.can_accept_error(s.into_usize()) {
                     TriState::False => {}
                     TriState::Maybe => {
-                        extra_precedence_stack.clear();
                         extra_state_stack.clear();
 
                         if self.can_feed_impl(
                             extra_state_stack,
-                            extra_precedence_stack,
                             Some((node, NonZeroUsize::new(node_.len() - pop_count).unwrap())),
                             P::TermClass::ERROR,
-                            error_prec,
                         ) == Some(true)
                         {
                             found = true;
@@ -1127,7 +1059,6 @@ impl<
         let l = node_.len() - pop_count;
         node_.location_stack.truncate(l);
         node_.state_stack.truncate(l);
-        node_.precedence_stack.truncate(l);
         node_.data_stack.truncate(l);
         #[cfg(feature = "tree")]
         {
@@ -1138,7 +1069,6 @@ impl<
             node,
             TerminalSymbol::Error,
             P::TermClass::ERROR,
-            error_prec,
             error_location.clone(),
             userdata,
         ) {
@@ -1171,7 +1101,6 @@ impl<
         self.next_userdatas.clear();
 
         let class = P::TermClass::from_term(&term);
-        let shift_prec = class.precedence();
 
         let mut current_nodes = std::mem::take(&mut self.current_nodes);
         let mut current_userdatas = std::mem::take(&mut self.current_userdatas);
@@ -1180,7 +1109,6 @@ impl<
                 node,
                 TerminalSymbol::Term(term.clone()),
                 class,
-                shift_prec,
                 location.clone(),
                 userdata,
             ) {
@@ -1211,13 +1139,10 @@ impl<
                 });
             }
 
-            let error_prec = P::TermClass::ERROR.precedence();
-
             let mut fallback_nodes = std::mem::take(&mut self.fallback_nodes);
             let mut fallback_userdatas = std::mem::take(&mut self.fallback_userdatas);
             let root_userdata = fallback_userdatas.first().cloned();
             let mut extra_state_stack = Vec::new();
-            let mut extra_precedence_stack = Vec::new();
             let mut error_location = if let Some(&first_node) = fallback_nodes.first() {
                 Data::Location::new(self.location_iter(first_node), 0)
             } else {
@@ -1225,13 +1150,7 @@ impl<
             };
             // try enter panic mode and store error nodes to next_nodes
             for (node, userdata) in fallback_nodes.drain(..).zip(fallback_userdatas.drain(..)) {
-                error_location = self.panic_mode(
-                    node,
-                    error_prec,
-                    userdata,
-                    &mut extra_state_stack,
-                    &mut extra_precedence_stack,
-                );
+                error_location = self.panic_mode(node, userdata, &mut extra_state_stack);
             }
             // put back for reuse allocated memory
             self.fallback_nodes = fallback_nodes;
@@ -1248,7 +1167,6 @@ impl<
                             node,
                             TerminalSymbol::Error,
                             P::TermClass::ERROR,
-                            error_prec,
                             error_location,
                             userdata,
                         ) {
@@ -1285,7 +1203,6 @@ impl<
                         // and b is fed, shift error and b
                         let node = self.node_mut(error_node);
                         node.state_stack.push(next_state.state);
-                        node.precedence_stack.push(shift_prec);
                         node.location_stack.push(location.clone());
                         #[cfg(feature = "tree")]
                         node.tree_stack.push(crate::tree::Tree::new_terminal(
@@ -1329,10 +1246,8 @@ impl<
     fn can_feed_impl(
         &self,
         extra_state_stack: &mut Vec<StateIndex>,
-        extra_precedence_stack: &mut Vec<Precedence>,
         mut node_and_len: Option<(usize, NonZeroUsize)>,
         class: P::TermClass,
-        shift_prec: Precedence,
     ) -> Option<bool> {
         let last_state = extra_state_stack
             .last()
@@ -1350,75 +1265,12 @@ impl<
             None => (None, None),
         };
         if let Some(reduce_rules) = reduce {
-            let mut shift = None;
+            let shift = shift_state;
             let mut reduces: arrayvec::ArrayVec<_, MAX_REDUCE_RULES> = Default::default();
 
             use crate::parser::table::ReduceRules;
             for reduce_rule in reduce_rules.to_iter() {
-                let rule = *self.tables.rule(reduce_rule.into_usize());
-                let reduce_prec = match rule.precedence {
-                    crate::rule::Precedence::Fixed(level) => Precedence::new(level as u8),
-                    crate::rule::Precedence::Dynamic(token_index) => {
-                        // fix the value to the offset from current node
-                        let mut ith = rule.len - token_index - 1;
-                        if ith < extra_precedence_stack.len() {
-                            extra_precedence_stack[extra_precedence_stack.len() - 1 - ith]
-                        } else {
-                            ith -= extra_precedence_stack.len();
-                            let (node, len) = node_and_len.unwrap();
-                            if ith < len.get() {
-                                self.node(node).precedence_stack[len.get() - 1 - ith]
-                            } else {
-                                ith -= len.get();
-                                let parent = self.node(node).parent.unwrap();
-                                let (node, ith) = self.skip_last_n(parent, ith).unwrap();
-                                self.node(node).precedence_stack[ith]
-                            }
-                            // safe unwrap since ith >= extra_precedence_stack.len()
-                        }
-                    }
-                    crate::rule::Precedence::None => Precedence::none(),
-                };
-
-                // if there is shift/reduce conflict, check for reduce rule's precedence and shift terminal's precedence
-                match (shift_state.is_some(), shift_prec, reduce_prec) {
-                    (true, Precedence(shift_prec_), Precedence(reduce_prec_))
-                        if shift_prec.is_some() && reduce_prec.is_some() =>
-                    {
-                        match reduce_prec_.cmp(&shift_prec_) {
-                            std::cmp::Ordering::Less => {
-                                // no reduce
-                                shift = shift_state;
-                            }
-                            std::cmp::Ordering::Equal => {
-                                // check for reduce_type
-                                use crate::rule::ReduceType;
-                                match P::precedence_types(reduce_prec_) {
-                                    Some(ReduceType::Left) => {
-                                        // no shift
-                                        reduces.push((reduce_rule, reduce_prec));
-                                    }
-                                    Some(ReduceType::Right) => {
-                                        // no reduce
-                                        shift = shift_state;
-                                    }
-                                    None => {
-                                        // cannot determine precedence
-                                    }
-                                }
-                            }
-                            std::cmp::Ordering::Greater => {
-                                // no shift
-                                reduces.push((reduce_rule, reduce_prec));
-                            }
-                        }
-                    }
-                    _ => {
-                        // nothing; go for both reduce and shift
-                        shift = shift_state;
-                        reduces.push((reduce_rule, reduce_prec));
-                    }
-                }
+                reduces.push(reduce_rule);
             }
 
             if shift.is_some() {
@@ -1429,18 +1281,14 @@ impl<
             }
 
             if reduces.len() == 1 {
-                let (rule, reduce_prec) = reduces[0];
-                let reduce_rule = *self.tables.rule(rule.into_usize());
-                let tokens_len = reduce_rule.len;
+                let rule = *self.tables.rule(reduces[0].into_usize());
+                let tokens_len = rule.len;
 
                 // pop state stack
-                // pop precedence stack
-                if tokens_len <= extra_precedence_stack.len() {
-                    extra_precedence_stack.truncate(extra_precedence_stack.len() - tokens_len);
+                if tokens_len <= extra_state_stack.len() {
                     extra_state_stack.truncate(extra_state_stack.len() - tokens_len);
                 } else {
-                    let left = tokens_len - extra_precedence_stack.len();
-                    extra_precedence_stack.clear();
+                    let left = tokens_len - extra_state_stack.len();
                     extra_state_stack.clear();
 
                     let (node, len) = node_and_len.unwrap();
@@ -1461,8 +1309,6 @@ impl<
                     }
                 }
 
-                extra_precedence_stack.push(reduce_prec);
-
                 // shift with reduced nonterminal
                 let last_state = extra_state_stack
                     .last()
@@ -1475,44 +1321,32 @@ impl<
                             })
                             .unwrap_or(0)
                     });
-                if let Some(next_state_id) =
-                    self.tables.shift_goto_nonterm(last_state, reduce_rule.name)
-                {
+                if let Some(next_state_id) = self.tables.shift_goto_nonterm(last_state, rule.name) {
                     extra_state_stack.push(next_state_id.state);
                 } else {
                     unreachable!(
                         "unreachable: nonterminal shift should always succeed after reduce operation. \
 Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a parser state machine bug.",
-                        reduce_rule.name.as_str(),
-                        rule.into_usize()
+                        rule.name.as_str(),
+                        reduces[0].into_usize()
                     );
                 }
 
-                self.can_feed_impl(
-                    extra_state_stack,
-                    extra_precedence_stack,
-                    node_and_len,
-                    class,
-                    shift_prec,
-                )
+                self.can_feed_impl(extra_state_stack, node_and_len, class)
             } else {
                 let mut ret = None;
-                for (reduce_rule, reduce_prec) in reduces.into_iter() {
+                for reduce_rule in reduces.into_iter() {
                     let reduce_rule = *self.tables.rule(reduce_rule.into_usize());
                     let tokens_len = reduce_rule.len;
 
                     let mut extra_state_stack = extra_state_stack.clone();
-                    let mut extra_precedence_stack = extra_precedence_stack.clone();
 
                     // pop state stack
-                    // pop precedence stack
-                    let new_node_and_len = if tokens_len <= extra_precedence_stack.len() {
-                        extra_precedence_stack.truncate(extra_precedence_stack.len() - tokens_len);
+                    let new_node_and_len = if tokens_len <= extra_state_stack.len() {
                         extra_state_stack.truncate(extra_state_stack.len() - tokens_len);
                         node_and_len
                     } else {
-                        let left = tokens_len - extra_precedence_stack.len();
-                        extra_precedence_stack.clear();
+                        let left = tokens_len - extra_state_stack.len();
                         extra_state_stack.clear();
 
                         let (node, len) = node_and_len.unwrap();
@@ -1531,8 +1365,6 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
                             }
                         }
                     };
-
-                    extra_precedence_stack.push(reduce_prec);
 
                     // shift with reduced nonterminal
                     let last_state = extra_state_stack
@@ -1559,13 +1391,7 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
                         );
                     }
 
-                    match self.can_feed_impl(
-                        &mut extra_state_stack,
-                        &mut extra_precedence_stack,
-                        new_node_and_len,
-                        class,
-                        shift_prec,
-                    ) {
+                    match self.can_feed_impl(&mut extra_state_stack, new_node_and_len, class) {
                         Some(true) => return Some(true),
                         Some(false) => {
                             ret = Some(false);
@@ -1575,7 +1401,6 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
                 }
                 ret
             }
-            // check reduce actions
         } else {
             Some(shift_state.is_some())
         }
@@ -1587,11 +1412,8 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
     /// and will return `true` if `Err` variant is returned by `reduce_action`.
     pub fn can_feed(&self, term: &P::Term) -> bool {
         let class = P::TermClass::from_term(term);
-        let shift_prec = class.precedence();
         let mut extra_state_stack = Vec::new();
-        let mut extra_precedence_stack = Vec::new();
         self.current_nodes.iter().any(move |&node| {
-            extra_precedence_stack.clear();
             extra_state_stack.clear();
 
             let node_and_len = {
@@ -1603,13 +1425,7 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
                     Some((node, NonZeroUsize::new(node_.len()).unwrap()))
                 }
             };
-            self.can_feed_impl(
-                &mut extra_state_stack,
-                &mut extra_precedence_stack,
-                node_and_len,
-                class,
-                shift_prec,
-            ) == Some(true)
+            self.can_feed_impl(&mut extra_state_stack, node_and_len, class) == Some(true)
         })
     }
 
@@ -1621,8 +1437,6 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
         }
 
         let mut extra_state_stack = Vec::new();
-        let mut extra_precedence_stack = Vec::new();
-        let error_prec = P::TermClass::ERROR.precedence();
 
         self.current_nodes.iter().any(move |&node| {
             let mut node = node;
@@ -1630,15 +1444,12 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
 
             if len > 0 {
                 loop {
-                    extra_precedence_stack.clear();
                     extra_state_stack.clear();
 
                     if self.can_feed_impl(
                         &mut extra_state_stack,
-                        &mut extra_precedence_stack,
                         Some((node, NonZeroUsize::new(len).unwrap())),
                         P::TermClass::ERROR,
-                        error_prec,
                     ) == Some(true)
                     {
                         return true;
@@ -1657,15 +1468,8 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
             }
 
             // check root node
-            extra_precedence_stack.clear();
             extra_state_stack.clear();
-            self.can_feed_impl(
-                &mut extra_state_stack,
-                &mut extra_precedence_stack,
-                None,
-                P::TermClass::ERROR,
-                error_prec,
-            ) == Some(true)
+            self.can_feed_impl(&mut extra_state_stack, None, P::TermClass::ERROR) == Some(true)
         })
     }
 
@@ -1702,7 +1506,6 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
                 node,
                 TerminalSymbol::Eof,
                 P::TermClass::EOF,
-                Precedence::none(),
                 node_eof_location,
                 userdata,
             ) {
@@ -1736,9 +1539,7 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
     /// Check if current context can be terminated and get the start value.
     pub fn can_accept(&self) -> bool {
         let mut extra_state_stack = Vec::new();
-        let mut extra_precedence_stack = Vec::new();
         self.current_nodes.iter().any(move |&node| {
-            extra_precedence_stack.clear();
             extra_state_stack.clear();
 
             let node_and_len = {
@@ -1750,13 +1551,8 @@ Failed to shift nonterminal '{}' after reducing rule '{}'. This indicates a pars
                     Some((node, NonZeroUsize::new(node_.len()).unwrap()))
                 }
             };
-            self.can_feed_impl(
-                &mut extra_state_stack,
-                &mut extra_precedence_stack,
-                node_and_len,
-                P::TermClass::EOF,
-                Precedence::none(),
-            ) == Some(true)
+            self.can_feed_impl(&mut extra_state_stack, node_and_len, P::TermClass::EOF)
+                == Some(true)
         })
     }
 }

--- a/rusty_lr_core/src/parser/nondeterministic/node.rs
+++ b/rusty_lr_core/src/parser/nondeterministic/node.rs
@@ -1,5 +1,4 @@
 use crate::parser::data_stack::DataStack;
-use crate::parser::Precedence;
 
 /// To handle multiple paths in the non-deterministic GLR parsing,
 /// this node represents a subrange in stack of the parser.
@@ -15,7 +14,6 @@ pub struct Node<Data: DataStack, StateIndex> {
     pub state_stack: Vec<StateIndex>,
     pub data_stack: Data,
     pub location_stack: Vec<Data::Location>,
-    pub precedence_stack: Vec<Precedence>,
     #[cfg(feature = "tree")]
     pub(crate) tree_stack: Vec<crate::tree::Tree<Data::Term, Data::NonTerm>>,
 }
@@ -28,7 +26,6 @@ impl<Data: DataStack, StateIndex> Default for Node<Data, StateIndex> {
             state_stack: Vec::new(),
             data_stack: Data::default(),
             location_stack: Vec::new(),
-            precedence_stack: Vec::new(),
             #[cfg(feature = "tree")]
             tree_stack: Vec::new(),
         }
@@ -43,7 +40,6 @@ impl<Data: DataStack, StateIndex> Node<Data, StateIndex> {
         self.state_stack.clear();
         self.data_stack.clear();
         self.location_stack.clear();
-        self.precedence_stack.clear();
         #[cfg(feature = "tree")]
         self.tree_stack.clear();
     }
@@ -61,7 +57,6 @@ impl<Data: DataStack, StateIndex> Node<Data, StateIndex> {
             state_stack: Vec::with_capacity(capacity),
             data_stack: Data::with_capacity(capacity),
             location_stack: Vec::with_capacity(capacity),
-            precedence_stack: Vec::with_capacity(capacity),
             #[cfg(feature = "tree")]
             tree_stack: Vec::with_capacity(capacity),
         }
@@ -70,7 +65,6 @@ impl<Data: DataStack, StateIndex> Node<Data, StateIndex> {
         self.state_stack.reserve(additional);
         self.data_stack.reserve(additional);
         self.location_stack.reserve(additional);
-        self.precedence_stack.reserve(additional);
         #[cfg(feature = "tree")]
         self.tree_stack.reserve(additional);
     }

--- a/rusty_lr_core/src/parser/table.rs
+++ b/rusty_lr_core/src/parser/table.rs
@@ -92,12 +92,11 @@ impl ShiftTarget<usize> {
 /// Hot-path information for a production rule.
 ///
 /// The full production token list is useful for diagnostics and debug output, but parsing only
-/// needs the left-hand side, right-hand-side length, and precedence.
+/// needs the left-hand side and right-hand-side length.
 #[derive(Debug, Clone, Copy)]
 pub struct RuleInfo<NonTerm> {
     pub name: NonTerm,
     pub len: usize,
-    pub precedence: crate::rule::Precedence,
 }
 
 /// Intermediate flat parser table data used by generated code before converting to a concrete

--- a/rusty_lr_core/src/parser/terminalclass.rs
+++ b/rusty_lr_core/src/parser/terminalclass.rs
@@ -11,6 +11,4 @@ pub trait TerminalClass: Copy {
     fn to_usize(&self) -> usize;
 
     fn from_term(term: &Self::Term) -> Self;
-
-    fn precedence(&self) -> crate::parser::Precedence;
 }

--- a/rusty_lr_core/src/rule.rs
+++ b/rusty_lr_core/src/rule.rs
@@ -32,9 +32,6 @@ pub enum Precedence {
 
     /// fixed precedence level
     Fixed(usize), // precedence level
-
-    /// get precedence from i'th child token; for runtime conflict resolution
-    Dynamic(usize), // token index
 }
 impl Precedence {
     pub fn is_some(self) -> bool {

--- a/rusty_lr_parser/src/emit.rs
+++ b/rusty_lr_parser/src/emit.rs
@@ -9,54 +9,6 @@ use crate::grammar::Grammar;
 use crate::terminal_info::TerminalName;
 use crate::utils;
 
-// helper function to generate match-case stream.
-// convert integer list to `a | b..=c | d` syntax
-fn list_to_case_stream(list: impl Iterator<Item = usize>) -> TokenStream {
-    let mut stream = TokenStream::new();
-    let mut prev = None;
-    for val in list {
-        if let Some((prev_start, prev_last)) = prev {
-            if prev_last + 1 == val {
-                // extend the range
-                prev = Some((prev_start, val));
-            } else {
-                // push the previous range
-                if !stream.is_empty() {
-                    stream.extend(quote! { | });
-                }
-                if prev_start == prev_last {
-                    let prev_start = proc_macro2::Literal::usize_unsuffixed(prev_start);
-                    stream.extend(quote! { #prev_start });
-                } else {
-                    let prev_start = proc_macro2::Literal::usize_unsuffixed(prev_start);
-                    let prev_last = proc_macro2::Literal::usize_unsuffixed(prev_last);
-                    stream.extend(quote! { #prev_start..=#prev_last });
-                }
-
-                prev = Some((val, val));
-            }
-        } else {
-            prev = Some((val, val));
-        }
-    }
-    // push the previous range
-    if let Some((prev_start, prev_last)) = prev {
-        if !stream.is_empty() {
-            stream.extend(quote! { | });
-        }
-        if prev_start == prev_last {
-            let prev_start = proc_macro2::Literal::usize_unsuffixed(prev_start);
-            stream.extend(quote! { #prev_start });
-        } else {
-            let prev_start = proc_macro2::Literal::usize_unsuffixed(prev_start);
-            let prev_last = proc_macro2::Literal::usize_unsuffixed(prev_last);
-            stream.extend(quote! { #prev_start..=#prev_last });
-        }
-    }
-
-    stream
-}
-
 /// emit Rust code for the parser
 impl Grammar {
     /// write type alias Context, Rule, Tables, Error...
@@ -205,48 +157,6 @@ impl Grammar {
             });
             class_variants.push(variant_name);
         }
-        // generate `Parser::class_precedence()` terminal class -> precedence level match body
-        let mut precedence_match_stream = TokenStream::new();
-        {
-            let mut level_classes = Vec::new();
-            level_classes.resize(
-                self.builder.precedence_types.len(),
-                std::collections::BTreeSet::new(),
-            );
-            for (&class, &level) in self.builder.precedence_levels.iter() {
-                level_classes[level].insert(class.into_term().unwrap());
-            }
-
-            for (level, classes) in level_classes.into_iter().enumerate() {
-                if classes.is_empty() {
-                    continue;
-                } else {
-                    debug_assert!(level < u8::MAX as usize);
-                    let iter = classes.iter().map(|&c| {
-                        let var = &class_variants[c];
-                        quote! { #termclass_typename::#var }
-                    });
-                    let level = proc_macro2::Literal::usize_unsuffixed(level);
-                    let case_stream = quote! { #(#iter)|* };
-                    precedence_match_stream.extend(quote! {
-                        #case_stream => #module_prefix::parser::Precedence::new(#level),
-                    });
-                }
-            }
-            if let Some(error_prec) = self.error_precedence {
-                debug_assert!(error_prec < u8::MAX as usize);
-                let error_prec = proc_macro2::Literal::usize_unsuffixed(error_prec);
-                precedence_match_stream.extend(quote! {
-                #termclass_typename::#error_name => #module_prefix::parser::Precedence::new(#error_prec),
-            });
-            }
-            precedence_match_stream.extend(quote! {
-                #termclass_typename::#eof_name => {
-                    unreachable!("eof token cannot be used in precedence levels")
-                },
-                _ => #module_prefix::parser::Precedence::none(),
-            });
-        }
 
         let other_class_id = self.other_terminal_class_id;
 
@@ -391,11 +301,7 @@ impl Grammar {
                 fn to_usize(&self) -> usize {
                     *self as usize
                 }
-                fn precedence(&self) -> #module_prefix::parser::Precedence {
-                    match self {
-                        #precedence_match_stream
-                    }
-                }
+
                 fn from_term(terminal: &Self::Term) -> Self {
                     #[allow(unreachable_patterns, unused_variables)]
                     match terminal {
@@ -553,63 +459,7 @@ impl Grammar {
         // ======================
         // building grammar
         // ======================
-        use rusty_lr_core::rule::ReduceType;
         use rusty_lr_core::TerminalSymbol;
-
-        // generate precedence level -> reduce type match stream
-        // match level {
-        //     0 => Left,
-        //     1 => Right,
-        //     ...
-        // }
-        let precedence_types_match_body_stream = {
-            let lefts = list_to_case_stream(
-                self.builder
-                    .precedence_types
-                    .iter()
-                    .copied()
-                    .enumerate()
-                    .filter_map(|(level, reduce_type)| {
-                        debug_assert!(level < u8::MAX as usize);
-                        if reduce_type == Some(ReduceType::Left) {
-                            Some(level)
-                        } else {
-                            None
-                        }
-                    }),
-            );
-            let rights = list_to_case_stream(
-                self.builder
-                    .precedence_types
-                    .iter()
-                    .copied()
-                    .enumerate()
-                    .filter_map(|(level, reduce_type)| {
-                        debug_assert!(level < u8::MAX as usize);
-                        if reduce_type == Some(ReduceType::Right) {
-                            Some(level)
-                        } else {
-                            None
-                        }
-                    }),
-            );
-
-            let mut stream = TokenStream::new();
-            if !lefts.is_empty() {
-                stream.extend(quote! {
-                    #lefts => Some(#module_prefix::rule::ReduceType::Left),
-                });
-            }
-            if !rights.is_empty() {
-                stream.extend(quote! {
-                    #rights => Some(#module_prefix::rule::ReduceType::Right),
-                });
-            }
-            stream.extend(quote! {
-                _ => None,
-            });
-            stream
-        };
 
         // do not build at runtime
         // write all parser tables and production rules directly here
@@ -649,7 +499,6 @@ impl Grammar {
         // Rules Serialization
         // ------------------
         let mut rule_names = Vec::new();
-        let mut rule_precedences = Vec::new();
         let mut rule_lengths = Vec::new();
 
         for rule in &self.builder.rules {
@@ -659,27 +508,6 @@ impl Grammar {
                 rule.rule.name
             );
             rule_names.push(rule.rule.name as u32);
-
-            let prec_val = match rule.rule.precedence {
-                rusty_lr_core::rule::Precedence::None => 0,
-                rusty_lr_core::rule::Precedence::Fixed(level) => {
-                    assert!(
-                        level < (1 << 30),
-                        "Precedence level {} exceeds 30-bit limit",
-                        level
-                    );
-                    ((level as u32) << 2) | 1
-                }
-                rusty_lr_core::rule::Precedence::Dynamic(idx) => {
-                    assert!(
-                        idx < (1 << 30),
-                        "Precedence dynamic token index {} exceeds 30-bit limit",
-                        idx
-                    );
-                    ((idx as u32) << 2) | 2
-                }
-            };
-            rule_precedences.push(prec_val);
             rule_lengths.push(rule.rule.rule.len() as u32);
         }
 
@@ -785,9 +613,7 @@ impl Grammar {
         let rule_names = rule_names
             .into_iter()
             .map(proc_macro2::Literal::u32_unsuffixed);
-        let rule_precedences = rule_precedences
-            .into_iter()
-            .map(proc_macro2::Literal::u32_unsuffixed);
+
         let rule_lengths = rule_lengths
             .into_iter()
             .map(proc_macro2::Literal::u32_unsuffixed);
@@ -837,12 +663,7 @@ impl Grammar {
 
                 const ERROR_USED:bool = #error_used;
 
-                fn precedence_types(level: u8) -> Option<#module_prefix::rule::ReduceType> {
-                    #[allow(unreachable_patterns)]
-                    match level {
-                        #precedence_types_match_body_stream
-                    }
-                }
+
                 // get_tables returns the decoded flat runtime parser tables.
                 // Serialized integer arrays keep the generated source compact while Context keeps the
                 // decoded table reference out of the parsing hot path.
@@ -851,10 +672,8 @@ impl Grammar {
                     TABLES.get_or_init(|| {
                         // Serialized rule properties:
                         // - RULE_NAMES: NonTerm enum value of the rule LHS name
-                        // - RULE_PRECEDENCES: Packed operator precedence level/index and type (prec_val & 3: 0 = None, 1 = Fixed, 2 = Dynamic)
                         // - RULE_LENGTHS: RHS length of each production rule
                         static RULE_NAMES: &[u32] = &[ #(#rule_names),* ];
-                        static RULE_PRECEDENCES: &[u32] = &[ #(#rule_precedences),* ];
                         static RULE_LENGTHS: &[u32] = &[ #(#rule_lengths),* ];
 
                         // Serialized table row properties:
@@ -876,18 +695,9 @@ impl Grammar {
                         for i in 0..num_rules {
                             let name = #nonterminals_enum_name::from_usize(RULE_NAMES[i] as usize);
 
-                            let prec_val = RULE_PRECEDENCES[i];
-                            let precedence = match prec_val & 3 {
-                                0 => #module_prefix::rule::Precedence::None,
-                                1 => #module_prefix::rule::Precedence::Fixed((prec_val >> 2) as usize),
-                                2 => #module_prefix::rule::Precedence::Dynamic((prec_val >> 2) as usize),
-                                _ => unreachable!(),
-                            };
-
                             rules.push(#module_prefix::parser::table::RuleInfo {
                                 name,
                                 len: RULE_LENGTHS[i] as usize,
-                                precedence,
                             });
                         }
 

--- a/rusty_lr_parser/src/error.rs
+++ b/rusty_lr_parser/src/error.rs
@@ -92,9 +92,6 @@ pub enum ParseError {
     /// Precedence not defined for the given token
     PrecedenceNotDefined(IdentOrLiteral),
 
-    /// All production rules in this non-terminal must have %prec defined
-    NonTerminalPrecedenceNotDefined(Located<usize>),
-
     /// ReduceAction must be defined but not defined
     RuleTypeDefinedButActionNotDefined { nonterm: Location, rule: Location },
 
@@ -258,7 +255,6 @@ impl ParseError {
 
             ParseError::MultiplePrecedenceOrderDefinition(locations) => locations.clone(),
             ParseError::PrecedenceNotDefined(name) => vec![name.location()],
-            ParseError::NonTerminalPrecedenceNotDefined(loc) => vec![loc.location()],
 
             ParseError::RuleTypeDefinedButActionNotDefined { nonterm, rule } => {
                 vec![*nonterm, *rule]
@@ -315,9 +311,7 @@ impl ParseError {
             ParseError::PrecedenceNotDefined(_) => {
                 "Precedence not defined for the given token".to_string()
             }
-            ParseError::NonTerminalPrecedenceNotDefined(_) => {
-                "All production rules in this non-terminal must have %prec defined".into()
-            }
+
 
             ParseError::RuleTypeDefinedButActionNotDefined { .. } => {
                 "ReduceAction must be defined for this rule".into()

--- a/rusty_lr_parser/src/grammar.rs
+++ b/rusty_lr_parser/src/grammar.rs
@@ -1175,10 +1175,7 @@ impl Grammar {
                                 }
                             }
                         } else {
-                            Some(Located::new(
-                                Precedence::Dynamic(from_token),
-                                from_token_location,
-                            ))
+                            return Err(ParseError::PrecedenceNotDefined(prec.clone()));
                         }
                     } else if let Some(&level) = grammar.precedence_levels.get(&prec) {
                         Some(level.map(Precedence::Fixed))
@@ -1652,78 +1649,6 @@ impl Grammar {
                     Some(ts) => substitute_placeholders(ts.clone(), &resolved),
                     None => None,
                 };
-            }
-        }
-
-        // check for nonterminals in %prec,
-        // all production rules in that nonterminal must have precedence defined.
-        let mut nonterm_prec_candidates: Vec<BTreeSet<Option<usize>>> =
-            vec![BTreeSet::new(); grammar.nonterminals.len()];
-        loop {
-            let mut changed = false;
-            for (nonterm_idx, nonterm) in grammar.nonterminals.iter().enumerate() {
-                for rule in &nonterm.rules {
-                    match rule.prec {
-                        Some(prec) => match *prec.value() {
-                            Precedence::Dynamic(token_idx) => {
-                                if let Token::NonTerm(token_nonterm_idx) =
-                                    rule.tokens[token_idx].token
-                                {
-                                    let mut target_candidates =
-                                        nonterm_prec_candidates[token_nonterm_idx].clone();
-                                    let len0 = nonterm_prec_candidates[nonterm_idx].len();
-                                    nonterm_prec_candidates[nonterm_idx]
-                                        .append(&mut target_candidates);
-                                    if nonterm_prec_candidates[nonterm_idx].len() != len0 {
-                                        changed = true;
-                                    }
-                                }
-                            }
-                            Precedence::Fixed(level) => {
-                                if nonterm_prec_candidates[nonterm_idx].insert(Some(level)) {
-                                    changed = true;
-                                }
-                            }
-                            Precedence::None => {
-                                if nonterm_prec_candidates[nonterm_idx].insert(None) {
-                                    changed = true;
-                                }
-                            }
-                        },
-                        _ => {
-                            if nonterm_prec_candidates[nonterm_idx].insert(None) {
-                                changed = true;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if !changed {
-                break;
-            }
-        }
-        for nonterm in &mut grammar.nonterminals {
-            for rule in &mut nonterm.rules {
-                if let Some(prec) = &mut rule.prec {
-                    if let Precedence::Dynamic(token_idx) = *prec.value() {
-                        if let Token::NonTerm(token_nonterm_idx) = rule.tokens[token_idx].token {
-                            let target_candidates = &nonterm_prec_candidates[token_nonterm_idx];
-                            if target_candidates.contains(&None) {
-                                // TODO
-                                // no need to be an error on GLR parser?
-                                return Err(ParseError::NonTerminalPrecedenceNotDefined(
-                                    Located::new(token_nonterm_idx, prec.location()),
-                                ));
-                            }
-
-                            if target_candidates.len() == 1 {
-                                let fixed = target_candidates.iter().next().unwrap().unwrap();
-                                *prec = Located::new(Precedence::Fixed(fixed), prec.location());
-                            }
-                        }
-                    }
-                }
             }
         }
 

--- a/rusty_lr_parser/src/parser/parser_expanded.rs
+++ b/rusty_lr_parser/src/parser/parser_expanded.rs
@@ -327,19 +327,6 @@ impl ::rusty_lr_core::parser::terminalclass::TerminalClass for GrammarTerminalCl
     fn to_usize(&self) -> usize {
         *self as usize
     }
-    fn precedence(&self) -> ::rusty_lr_core::parser::Precedence {
-        match self {
-            GrammarTerminalClasses::minus => ::rusty_lr_core::parser::Precedence::new(0),
-            GrammarTerminalClasses::plus
-            | GrammarTerminalClasses::star
-            | GrammarTerminalClasses::question
-            | GrammarTerminalClasses::exclamation => ::rusty_lr_core::parser::Precedence::new(1),
-            GrammarTerminalClasses::eof => {
-                unreachable!("eof token cannot be used in precedence levels")
-            }
-            _ => ::rusty_lr_core::parser::Precedence::none(),
-        }
-    }
     fn from_term(terminal: &Self::Term) -> Self {
         #[allow(unreachable_patterns, unused_variables)]
         match terminal {
@@ -6341,13 +6328,6 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
     type ReduceRules = u8;
     type Tables = GrammarTables;
     const ERROR_USED: bool = true;
-    fn precedence_types(level: u8) -> Option<::rusty_lr_core::rule::ReduceType> {
-        #[allow(unreachable_patterns)]
-        match level {
-            0..=1 => Some(::rusty_lr_core::rule::ReduceType::Left),
-            _ => None,
-        }
-    }
     fn get_tables() -> &'static GrammarTables {
         static TABLES: std::sync::OnceLock<GrammarTables> = std::sync::OnceLock::new();
         TABLES
@@ -6362,15 +6342,6 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                     25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25,
                     25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 26, 26, 27, 27, 28, 28,
                     29,
-                ];
-                static RULE_PRECEDENCES: &[u32] = &[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0,
-                    0, 0, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0, 0, 1, 0, 5, 5, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 ];
                 static RULE_LENGTHS: &[u32] = &[
                     5, 1, 0, 3, 1, 3, 3, 3, 3, 3, 2, 1, 3, 1, 3, 3, 1, 3, 3, 1, 3, 3, 4,
@@ -6736,26 +6707,10 @@ impl ::rusty_lr_core::parser::Parser for GrammarParser {
                 let mut rules = Vec::with_capacity(num_rules);
                 for i in 0..num_rules {
                     let name = GrammarNonTerminals::from_usize(RULE_NAMES[i] as usize);
-                    let prec_val = RULE_PRECEDENCES[i];
-                    let precedence = match prec_val & 3 {
-                        0 => ::rusty_lr_core::rule::Precedence::None,
-                        1 => {
-                            ::rusty_lr_core::rule::Precedence::Fixed(
-                                (prec_val >> 2) as usize,
-                            )
-                        }
-                        2 => {
-                            ::rusty_lr_core::rule::Precedence::Dynamic(
-                                (prec_val >> 2) as usize,
-                            )
-                        }
-                        _ => unreachable!(),
-                    };
                     rules
                         .push(::rusty_lr_core::parser::table::RuleInfo {
                             name,
                             len: RULE_LENGTHS[i] as usize,
-                            precedence,
                         });
                 }
                 let num_states = 167usize;

--- a/scripts/diff/calculator.rs
+++ b/scripts/diff/calculator.rs
@@ -103,16 +103,6 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for ETerminalClasses {
     fn to_usize(&self) -> usize {
         *self as usize
     }
-    fn precedence(&self) -> ::rusty_lr::parser::Precedence {
-        match self {
-            ETerminalClasses::plus => ::rusty_lr::parser::Precedence::new(0),
-            ETerminalClasses::star => ::rusty_lr::parser::Precedence::new(1),
-            ETerminalClasses::eof => {
-                unreachable!("eof token cannot be used in precedence levels")
-            }
-            _ => ::rusty_lr::parser::Precedence::none(),
-        }
-    }
     fn from_term(terminal: &Self::Term) -> Self {
         #[allow(unreachable_patterns, unused_variables)]
         match terminal {
@@ -636,19 +626,11 @@ impl ::rusty_lr::parser::Parser for EParser {
     type ReduceRules = u8;
     type Tables = ETables;
     const ERROR_USED: bool = false;
-    fn precedence_types(level: u8) -> Option<::rusty_lr::rule::ReduceType> {
-        #[allow(unreachable_patterns)]
-        match level {
-            0..=1 => Some(::rusty_lr::rule::ReduceType::Left),
-            _ => None,
-        }
-    }
     fn get_tables() -> &'static ETables {
         static TABLES: std::sync::OnceLock<ETables> = std::sync::OnceLock::new();
         TABLES
             .get_or_init(|| {
                 static RULE_NAMES: &[u32] = &[0, 0, 1, 1, 2, 2, 3, 4];
-                static RULE_PRECEDENCES: &[u32] = &[1, 0, 5, 0, 0, 0, 0, 0];
                 static RULE_LENGTHS: &[u32] = &[3, 1, 3, 1, 1, 3, 1, 2];
                 static SHIFT_TERM_DATA: &[u32] = &[
                     2147516416, 65539, 2147516416, 65539, 2147614721, 2147516416, 65539,
@@ -680,24 +662,10 @@ impl ::rusty_lr::parser::Parser for EParser {
                 let mut rules = Vec::with_capacity(num_rules);
                 for i in 0..num_rules {
                     let name = ENonTerminals::from_usize(RULE_NAMES[i] as usize);
-                    let prec_val = RULE_PRECEDENCES[i];
-                    let precedence = match prec_val & 3 {
-                        0 => ::rusty_lr::rule::Precedence::None,
-                        1 => {
-                            ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize)
-                        }
-                        2 => {
-                            ::rusty_lr::rule::Precedence::Dynamic(
-                                (prec_val >> 2) as usize,
-                            )
-                        }
-                        _ => unreachable!(),
-                    };
                     rules
                         .push(::rusty_lr::parser::table::RuleInfo {
                             name,
                             len: RULE_LENGTHS[i] as usize,
-                            precedence,
                         });
                 }
                 let num_states = 13usize;

--- a/scripts/diff/calculator_u8.rs
+++ b/scripts/diff/calculator_u8.rs
@@ -10,25 +10,24 @@
 ====================================Grammar=====================================
 
 # of terminal classes: 9
-# of states: 25
+# of states: 27
 
 0: Digit -> '0'
 1: Digit -> ['1', '2', ..., '6'-'9']
 2: Number -> ' '* Digit+ ' '*
 3: P -> Number
 4: P -> ' '* '(' E ')' ' '*
-5: E -> E Op E
-6: E -> ' '* '-' E
-7: E -> P
-8: Op -> '+'
-9: Op -> '*'
-10: ' '+ -> ' '
-11: ' '+ -> ' '+ ' '
-12: ' '* -> ' '+
-13: ' '* -> 
-14: Digit+ -> Digit
-15: Digit+ -> Digit+ Digit
-16: Augmented -> E eof
+5: E -> E '+' E
+6: E -> E '*' E
+7: E -> ' '* '-' E
+8: E -> P
+9: ' '+ -> ' '
+10: ' '+ -> ' '+ ' '
+11: ' '* -> ' '+
+12: ' '* -> 
+13: Digit+ -> Digit
+14: Digit+ -> Digit+ Digit
+15: Augmented -> E eof
 
 */
 // =============================Generated Codes Begin==============================
@@ -110,16 +109,6 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for ETerminalClasses {
     fn to_usize(&self) -> usize {
         *self as usize
     }
-    fn precedence(&self) -> ::rusty_lr::parser::Precedence {
-        match self {
-            ETerminalClasses::TermClass8 => ::rusty_lr::parser::Precedence::new(0),
-            ETerminalClasses::TermClass7 => ::rusty_lr::parser::Precedence::new(1),
-            ETerminalClasses::eof => {
-                unreachable!("eof token cannot be used in precedence levels")
-            }
-            _ => ::rusty_lr::parser::Precedence::none(),
-        }
-    }
     fn from_term(terminal: &Self::Term) -> Self {
         #[allow(unreachable_patterns, unused_variables)]
         match terminal {
@@ -164,18 +153,17 @@ pub enum ENonTerminals {
     Number,
     P,
     E,
-    Op,
-    __LiteralChar0Plus6,
-    __LiteralChar0Star7,
-    _DigitPlus9,
+    __LiteralChar0Plus5,
+    __LiteralChar0Star6,
+    _DigitPlus8,
     Augmented,
 }
 impl ENonTerminals {
     #[inline]
     pub fn from_usize(value: usize) -> Self {
         debug_assert!(
-            value < 9usize, "Non-terminal index {} is out of bounds (max {})", value,
-            9usize
+            value < 8usize, "Non-terminal index {} is out of bounds (max {})", value,
+            8usize
         );
         unsafe { ::std::mem::transmute(value) }
     }
@@ -199,10 +187,9 @@ impl ::rusty_lr::parser::nonterminal::NonTerminal for ENonTerminals {
             ENonTerminals::Number => "Number",
             ENonTerminals::P => "P",
             ENonTerminals::E => "E",
-            ENonTerminals::Op => "Op",
-            ENonTerminals::__LiteralChar0Plus6 => "' '+",
-            ENonTerminals::__LiteralChar0Star7 => "' '*",
-            ENonTerminals::_DigitPlus9 => "Digit+",
+            ENonTerminals::__LiteralChar0Plus5 => "' '+",
+            ENonTerminals::__LiteralChar0Star6 => "' '*",
+            ENonTerminals::_DigitPlus8 => "Digit+",
             ENonTerminals::Augmented => "Augmented",
         }
     }
@@ -212,14 +199,13 @@ impl ::rusty_lr::parser::nonterminal::NonTerminal for ENonTerminals {
             ENonTerminals::Number => None,
             ENonTerminals::P => None,
             ENonTerminals::E => None,
-            ENonTerminals::Op => None,
-            ENonTerminals::__LiteralChar0Plus6 => {
+            ENonTerminals::__LiteralChar0Plus5 => {
                 Some(::rusty_lr::parser::nonterminal::NonTerminalType::PlusLeft)
             }
-            ENonTerminals::__LiteralChar0Star7 => {
+            ENonTerminals::__LiteralChar0Star6 => {
                 Some(::rusty_lr::parser::nonterminal::NonTerminalType::Star)
             }
-            ENonTerminals::_DigitPlus9 => {
+            ENonTerminals::_DigitPlus8 => {
                 Some(::rusty_lr::parser::nonterminal::NonTerminalType::PlusLeft)
             }
             ENonTerminals::Augmented => {
@@ -411,7 +397,7 @@ impl EDataStack {
         }
         Ok(())
     }
-    ///E -> E Op E
+    ///E -> E '+' E
     #[inline]
     fn reduce_E_0(
         __data_stack: &mut Self,
@@ -430,7 +416,7 @@ impl EDataStack {
             );
             debug_assert!(
                 matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
-                1usize), Some(& EData::__terminals(_)))
+                1usize), Some(& EData::Empty))
             );
             debug_assert!(
                 matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
@@ -442,22 +428,63 @@ impl EDataStack {
             EData::__variant2(val) => val,
             _ => unreachable!(),
         };
-        let mut Op = match __data_stack.__stack.pop().unwrap() {
-            EData::__terminals(val) => val,
-            _ => unreachable!(),
-        };
+        __data_stack.__stack.pop();
         let mut E = match __data_stack.__stack.pop().unwrap() {
             EData::__variant2(val) => val,
             _ => unreachable!(),
         };
         let __res = {
             *data += 1;
-            println!("{:?} {:?} {:?}", E, Op, e2);
-            match Op {
-                '+' => E + e2,
-                '*' => E * e2,
-                _ => panic!("Unknown operator: {:?}", Op),
-            }
+            println!("{:?} '+' {:?}", E, e2);
+            E + e2
+        };
+        if __push_data {
+            __data_stack.__stack.push(EData::__variant2(__res));
+        } else {
+            __data_stack.__stack.push(EData::Empty);
+        }
+        Ok(())
+    }
+    ///E -> E '*' E
+    #[inline]
+    fn reduce_E_1(
+        __data_stack: &mut Self,
+        __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
+        __push_data: bool,
+        shift: &mut bool,
+        lookahead: &::rusty_lr::TerminalSymbol<char>,
+        data: &mut i32,
+        __rustylr_location0: &mut ::rusty_lr::DefaultLocation,
+    ) -> Result<(), ::rusty_lr::DefaultReduceActionError> {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                0usize), Some(& EData::__variant2(_)))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                1usize), Some(& EData::Empty))
+            );
+            debug_assert!(
+                matches!(__data_stack.__stack.get(__data_stack.__stack.len() - 1 -
+                2usize), Some(& EData::__variant2(_)))
+            );
+        }
+        __location_stack.truncate(__location_stack.len() - 3);
+        let mut e2 = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
+        __data_stack.__stack.pop();
+        let mut E = match __data_stack.__stack.pop().unwrap() {
+            EData::__variant2(val) => val,
+            _ => unreachable!(),
+        };
+        let __res = {
+            *data += 1;
+            println!("{:?} '*' {:?}", E, e2);
+            E * e2
         };
         if __push_data {
             __data_stack.__stack.push(EData::__variant2(__res));
@@ -468,7 +495,7 @@ impl EDataStack {
     }
     ///E -> ' '* '-' E
     #[inline]
-    fn reduce_E_1(
+    fn reduce_E_2(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
         __push_data: bool,
@@ -508,7 +535,7 @@ impl EDataStack {
     }
     ///' '+ -> ' '+ ' '
     #[inline]
-    fn reduce___LiteralChar0Plus6_1(
+    fn reduce___LiteralChar0Plus5_1(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
         __push_data: bool,
@@ -535,7 +562,7 @@ impl EDataStack {
     }
     ///' '* -> ' '+
     #[inline]
-    fn reduce___LiteralChar0Star7_0(
+    fn reduce___LiteralChar0Star6_0(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
         __push_data: bool,
@@ -558,7 +585,7 @@ impl EDataStack {
     }
     ///' '* ->
     #[inline]
-    fn reduce___LiteralChar0Star7_1(
+    fn reduce___LiteralChar0Star6_1(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
         __push_data: bool,
@@ -573,7 +600,7 @@ impl EDataStack {
     }
     ///Digit+ -> Digit
     #[inline]
-    fn reduce__DigitPlus9_0(
+    fn reduce__DigitPlus8_0(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
         __push_data: bool,
@@ -604,7 +631,7 @@ impl EDataStack {
     }
     ///Digit+ -> Digit+ Digit
     #[inline]
-    fn reduce__DigitPlus9_1(
+    fn reduce__DigitPlus8_1(
         __data_stack: &mut Self,
         __location_stack: &mut Vec<::rusty_lr::DefaultLocation>,
         __push_data: bool,
@@ -770,8 +797,30 @@ impl ::rusty_lr::parser::data_stack::DataStack for EDataStack {
                     location0,
                 )
             }
+            7usize => {
+                Self::reduce_E_2(
+                    data_stack,
+                    location_stack,
+                    push_data,
+                    shift,
+                    lookahead,
+                    user_data,
+                    location0,
+                )
+            }
+            10usize => {
+                Self::reduce___LiteralChar0Plus5_1(
+                    data_stack,
+                    location_stack,
+                    push_data,
+                    shift,
+                    lookahead,
+                    user_data,
+                    location0,
+                )
+            }
             11usize => {
-                Self::reduce___LiteralChar0Plus6_1(
+                Self::reduce___LiteralChar0Star6_0(
                     data_stack,
                     location_stack,
                     push_data,
@@ -782,7 +831,7 @@ impl ::rusty_lr::parser::data_stack::DataStack for EDataStack {
                 )
             }
             12usize => {
-                Self::reduce___LiteralChar0Star7_0(
+                Self::reduce___LiteralChar0Star6_1(
                     data_stack,
                     location_stack,
                     push_data,
@@ -793,7 +842,7 @@ impl ::rusty_lr::parser::data_stack::DataStack for EDataStack {
                 )
             }
             13usize => {
-                Self::reduce___LiteralChar0Star7_1(
+                Self::reduce__DigitPlus8_0(
                     data_stack,
                     location_stack,
                     push_data,
@@ -804,18 +853,7 @@ impl ::rusty_lr::parser::data_stack::DataStack for EDataStack {
                 )
             }
             14usize => {
-                Self::reduce__DigitPlus9_0(
-                    data_stack,
-                    location_stack,
-                    push_data,
-                    shift,
-                    lookahead,
-                    user_data,
-                    location0,
-                )
-            }
-            15usize => {
-                Self::reduce__DigitPlus9_1(
+                Self::reduce__DigitPlus8_1(
                     data_stack,
                     location_stack,
                     push_data,
@@ -849,101 +887,78 @@ impl ::rusty_lr::parser::Parser for EParser {
     type ReduceRules = u8;
     type Tables = ETables;
     const ERROR_USED: bool = false;
-    fn precedence_types(level: u8) -> Option<::rusty_lr::rule::ReduceType> {
-        #[allow(unreachable_patterns)]
-        match level {
-            0..=1 => Some(::rusty_lr::rule::ReduceType::Left),
-            _ => None,
-        }
-    }
     fn get_tables() -> &'static ETables {
         static TABLES: std::sync::OnceLock<ETables> = std::sync::OnceLock::new();
         TABLES
             .get_or_init(|| {
                 static RULE_NAMES: &[u32] = &[
-                    0, 0, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8,
-                ];
-                static RULE_PRECEDENCES: &[u32] = &[
-                    0, 0, 0, 0, 0, 6, 9, 0, 1, 5, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7,
                 ];
                 static RULE_LENGTHS: &[u32] = &[
-                    1, 1, 3, 1, 5, 3, 3, 1, 1, 1, 1, 2, 1, 0, 1, 2, 2,
+                    1, 1, 3, 1, 5, 3, 3, 3, 1, 1, 2, 1, 0, 1, 2, 2,
                 ];
                 static SHIFT_TERM_DATA: &[u32] = &[
-                    196608, 2147614727, 2147614728, 2147581962, 196608, 2147614727,
-                    2147614728, 229376, 294914, 753668, 589829, 2148106246, 196608,
-                    360451, 2147909639, 2147909640, 196608, 196608, 2147909639,
-                    2147909640, 294914, 524292, 589829, 2148106246, 196608, 196608,
-                    589829, 2148171782, 196608,
+                    163840, 98311, 786440, 2148335626, 163840, 196608, 262146, 753668,
+                    589829, 2148106246, 163840, 327683, 393223, 458760, 163840, 163840,
+                    262146, 524292, 589829, 2148106246, 163840, 393223, 163840, 163840,
+                    589829, 2148171782, 163840, 163840, 98311,
                 ];
                 static SHIFT_TERM_OFFSETS: &[u32] = &[
-                    0, 1, 1, 4, 4, 5, 7, 8, 8, 12, 13, 16, 17, 17, 18, 20, 24, 25, 25,
-                    25, 25, 28, 28, 28, 29, 29,
+                    0, 1, 1, 4, 5, 5, 6, 6, 10, 11, 14, 15, 15, 16, 20, 21, 22, 23, 23,
+                    23, 23, 26, 26, 26, 27, 28, 29, 29,
                 ];
                 static SHIFT_NONTERM_DATA: &[u32] = &[
-                    2147516417, 2147549186, 2147549187, 2147680261, 2147745798,
-                    2147614724, 2147516417, 2147647490, 2147647491, 2147680261,
-                    2147745798, 2147614724, 2148106240, 2148139015, 2147516417,
-                    2147811330, 2147811331, 2147680261, 2147975174, 2147909636,
-                    2147680261, 2147876870, 2147516417, 2147942402, 2147942403,
-                    2147680261, 2147975174, 2147909636, 2148106240, 2148139015,
-                    2147516417, 2148040706, 2148040707, 2147680261, 2147975174,
-                    2147909636, 2148171776, 2147680261, 2148204550, 2147516417,
-                    2148270082, 2148270083, 2147680261, 2147745798, 2147614724,
+                    2147516417, 2147549186, 2147549187, 2147647492, 2147713029,
+                    2147516417, 2147614722, 2147614723, 2147647492, 2147713029,
+                    2148106240, 2148139014, 2147516417, 2147778562, 2147778563,
+                    2147647492, 2147909637, 2147647492, 2147844101, 2147516417,
+                    2147614722, 2147614723, 2147647492, 2147909637, 2148106240,
+                    2148139014, 2147516417, 2147975170, 2147975171, 2147647492,
+                    2147909637, 2147516417, 2148040706, 2148040707, 2147647492,
+                    2147909637, 2148171776, 2147647492, 2148204549, 2147516417,
+                    2148040706, 2148040707, 2147647492, 2147713029, 2147516417,
+                    2148302850, 2148302851, 2147647492, 2147713029,
                 ];
                 static SHIFT_NONTERM_OFFSETS: &[u32] = &[
-                    0, 5, 5, 6, 6, 11, 12, 12, 12, 14, 19, 20, 22, 22, 27, 28, 30, 35,
-                    36, 36, 36, 39, 39, 39, 44, 45,
+                    0, 5, 5, 5, 10, 10, 10, 10, 12, 17, 17, 19, 19, 24, 26, 31, 31, 36,
+                    36, 36, 36, 39, 39, 39, 44, 49, 49, 49,
                 ];
                 static REDUCE_DATA: &[u32] = &[
-                    2, 1, 13, 4, 1, 13, 5, 1, 13, 6, 1, 13, 3, 1, 3, 7, 1, 3, 8, 1, 3,
-                    10, 1, 3, 2, 1, 13, 4, 1, 13, 5, 1, 13, 6, 1, 13, 7, 1, 5, 8, 1, 5,
-                    10, 1, 5, 2, 1, 12, 3, 1, 12, 4, 1, 12, 5, 1, 12, 6, 1, 12, 7, 1, 12,
-                    8, 1, 12, 10, 1, 12, 0, 1, 11, 2, 1, 11, 3, 1, 11, 4, 1, 11, 5, 1,
-                    11, 6, 1, 11, 7, 1, 11, 8, 1, 11, 10, 1, 11, 2, 1, 13, 4, 1, 13, 5,
-                    1, 13, 6, 1, 13, 3, 1, 13, 7, 1, 13, 8, 1, 13, 10, 1, 13, 3, 1, 4, 7,
-                    1, 4, 8, 1, 4, 10, 1, 4, 2, 1, 13, 4, 1, 13, 5, 1, 13, 6, 1, 13, 3,
-                    1, 5, 7, 1, 5, 8, 1, 5, 2, 1, 13, 4, 1, 13, 5, 1, 13, 6, 1, 13, 3, 1,
-                    6, 7, 1, 6, 8, 1, 6, 0, 1, 0, 3, 1, 0, 5, 1, 0, 6, 1, 0, 7, 1, 0, 8,
-                    1, 0, 10, 1, 0, 0, 1, 14, 3, 1, 14, 5, 1, 14, 6, 1, 14, 7, 1, 14, 8,
-                    1, 14, 10, 1, 14, 3, 1, 13, 7, 1, 13, 8, 1, 13, 10, 1, 13, 0, 1, 15,
-                    3, 1, 15, 5, 1, 15, 6, 1, 15, 7, 1, 15, 8, 1, 15, 10, 1, 15, 3, 1, 2,
-                    7, 1, 2, 8, 1, 2, 10, 1, 2, 2, 1, 13, 4, 1, 13, 5, 1, 13, 6, 1, 13,
-                    7, 1, 6, 8, 1, 6, 10, 1, 6,
+                    2, 1, 12, 4, 1, 12, 5, 1, 12, 6, 1, 12, 3, 1, 3, 7, 1, 3, 8, 1, 3,
+                    10, 1, 3, 2, 1, 12, 4, 1, 12, 5, 1, 12, 6, 1, 12, 3, 1, 6, 7, 1, 6,
+                    8, 1, 6, 10, 1, 6, 2, 1, 11, 3, 1, 11, 4, 1, 11, 5, 1, 11, 6, 1, 11,
+                    7, 1, 11, 8, 1, 11, 10, 1, 11, 0, 1, 10, 2, 1, 10, 3, 1, 10, 4, 1,
+                    10, 5, 1, 10, 6, 1, 10, 7, 1, 10, 8, 1, 10, 10, 1, 10, 2, 1, 12, 4,
+                    1, 12, 5, 1, 12, 6, 1, 12, 3, 1, 12, 7, 1, 12, 8, 1, 12, 10, 1, 12,
+                    3, 1, 4, 7, 1, 4, 8, 1, 4, 10, 1, 4, 2, 1, 12, 4, 1, 12, 5, 1, 12, 6,
+                    1, 12, 2, 1, 12, 4, 1, 12, 5, 1, 12, 6, 1, 12, 3, 1, 5, 8, 1, 5, 2,
+                    1, 12, 4, 1, 12, 5, 1, 12, 6, 1, 12, 3, 1, 7, 7, 1, 7, 8, 1, 7, 10,
+                    1, 7, 0, 1, 0, 3, 1, 0, 5, 1, 0, 6, 1, 0, 7, 1, 0, 8, 1, 0, 10, 1, 0,
+                    0, 1, 13, 3, 1, 13, 5, 1, 13, 6, 1, 13, 7, 1, 13, 8, 1, 13, 10, 1,
+                    13, 3, 1, 12, 7, 1, 12, 8, 1, 12, 10, 1, 12, 0, 1, 14, 3, 1, 14, 5,
+                    1, 14, 6, 1, 14, 7, 1, 14, 8, 1, 14, 10, 1, 14, 3, 1, 2, 7, 1, 2, 8,
+                    1, 2, 10, 1, 2, 2, 1, 12, 4, 1, 12, 5, 1, 12, 6, 1, 12, 2, 1, 12, 4,
+                    1, 12, 5, 1, 12, 6, 1, 12, 8, 1, 5, 10, 1, 5,
                 ];
                 static REDUCE_OFFSETS: &[u32] = &[
-                    0, 12, 24, 24, 24, 36, 45, 69, 96, 96, 108, 108, 120, 132, 144, 153,
-                    153, 165, 174, 195, 216, 228, 249, 261, 273, 282,
+                    0, 12, 24, 24, 36, 48, 72, 99, 99, 111, 111, 123, 135, 147, 147, 159,
+                    165, 177, 189, 210, 231, 243, 264, 276, 288, 300, 306, 306,
                 ];
                 static CAN_ACCEPT_ERROR: &[u8] = &[
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0,
+                    0, 0, 0, 0,
                 ];
-                let num_rules = 17usize;
+                let num_rules = 16usize;
                 let mut rules = Vec::with_capacity(num_rules);
                 for i in 0..num_rules {
                     let name = ENonTerminals::from_usize(RULE_NAMES[i] as usize);
-                    let prec_val = RULE_PRECEDENCES[i];
-                    let precedence = match prec_val & 3 {
-                        0 => ::rusty_lr::rule::Precedence::None,
-                        1 => {
-                            ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize)
-                        }
-                        2 => {
-                            ::rusty_lr::rule::Precedence::Dynamic(
-                                (prec_val >> 2) as usize,
-                            )
-                        }
-                        _ => unreachable!(),
-                    };
                     rules
                         .push(::rusty_lr::parser::table::RuleInfo {
                             name,
                             len: RULE_LENGTHS[i] as usize,
-                            precedence,
                         });
                 }
-                let num_states = 25usize;
+                let num_states = 27usize;
                 let mut state_rows = Vec::with_capacity(num_states);
                 for i in 0..num_states {
                     let term_start = SHIFT_TERM_OFFSETS[i] as usize;

--- a/scripts/diff/json.rs
+++ b/scripts/diff/json.rs
@@ -243,14 +243,6 @@ impl ::rusty_lr::parser::terminalclass::TerminalClass for JsonTerminalClasses {
     fn to_usize(&self) -> usize {
         *self as usize
     }
-    fn precedence(&self) -> ::rusty_lr::parser::Precedence {
-        match self {
-            JsonTerminalClasses::eof => {
-                unreachable!("eof token cannot be used in precedence levels")
-            }
-            _ => ::rusty_lr::parser::Precedence::none(),
-        }
-    }
     fn from_term(terminal: &Self::Term) -> Self {
         #[allow(unreachable_patterns, unused_variables)]
         match terminal {
@@ -1927,12 +1919,6 @@ impl ::rusty_lr::parser::Parser for JsonParser {
     type ReduceRules = u8;
     type Tables = JsonTables;
     const ERROR_USED: bool = true;
-    fn precedence_types(level: u8) -> Option<::rusty_lr::rule::ReduceType> {
-        #[allow(unreachable_patterns)]
-        match level {
-            _ => None,
-        }
-    }
     fn get_tables() -> &'static JsonTables {
         static TABLES: std::sync::OnceLock<JsonTables> = std::sync::OnceLock::new();
         TABLES
@@ -1944,13 +1930,6 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                     23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
                     23, 23, 23, 23, 23, 23, 23, 23, 24, 24, 25, 25, 25, 25, 25, 26, 26,
                     27, 27, 28, 29, 29, 30, 31,
-                ];
-                static RULE_PRECEDENCES: &[u32] = &[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0,
                 ];
                 static RULE_LENGTHS: &[u32] = &[
                     1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1, 3, 5, 3, 3, 3, 2, 1, 1, 1, 1, 1,
@@ -2145,24 +2124,10 @@ impl ::rusty_lr::parser::Parser for JsonParser {
                 let mut rules = Vec::with_capacity(num_rules);
                 for i in 0..num_rules {
                     let name = JsonNonTerminals::from_usize(RULE_NAMES[i] as usize);
-                    let prec_val = RULE_PRECEDENCES[i];
-                    let precedence = match prec_val & 3 {
-                        0 => ::rusty_lr::rule::Precedence::None,
-                        1 => {
-                            ::rusty_lr::rule::Precedence::Fixed((prec_val >> 2) as usize)
-                        }
-                        2 => {
-                            ::rusty_lr::rule::Precedence::Dynamic(
-                                (prec_val >> 2) as usize,
-                            )
-                        }
-                        _ => unreachable!(),
-                    };
                     rules
                         .push(::rusty_lr::parser::table::RuleInfo {
                             name,
                             len: RULE_LENGTHS[i] as usize,
-                            precedence,
                         });
                 }
                 let num_states = 119usize;


### PR DESCRIPTION
## Description
This PR completely removes the **Dynamic Precedence** feature from the parser runtime (`rusty_lr_core`) and the parser generator (`rusty_lr_parser`). All operator precedence conflict resolution is now resolved strictly at compile/build time. 
As part of this cleanup, the intermediate `Precedence::Dynamic` variant, the feed-time precedence stacks, and the `precedence` field from the hot-path `RuleInfo` struct have been entirely removed.
### Key Changes
#### 1. Parser Runtime (`rusty_lr_core`)
- **`terminalclass.rs`**: Removed the `precedence` method from the `TerminalClass` trait.
- **`mod.rs`**: Removed `precedence_types` method from the `Parser` trait and deleted the runtime `Precedence(u8)` struct.
- **`deterministic/context.rs` & `nondeterministic/context.rs`**:
  - Removed the `precedence_stack` and all dynamic conflict resolution checks during feed time.
  - In deterministic panic mode, fixed the stack truncation order (`data_stack` before `state_stack`) to prevent subtraction overflow/underflow.
  - GLR parsers now branch/split directly on conflicts without querying runtime operator precedence.
- **`rule.rs`**: Deleted the `Precedence::Dynamic(usize)` variant from the `Precedence` enum.
- **`table.rs`**: Removed the `precedence` field from the `RuleInfo` struct.
#### 2. Parser Generator (`rusty_lr_parser` & `rusty_lr_buildscript`)
- **`grammar.rs`**: Updated `%prec` parsing to return a `PrecedenceNotDefined` error if a non-terminal is specified. Deleted the `nonterm_prec_candidates` tracking and validation block completely.
- **`error.rs`**: Removed the `NonTerminalPrecedenceNotDefined` parse error.
- **`emit.rs`**:
  - Removed generation of the unused `RULE_PRECEDENCES` static arrays.
  - Stopped generating `precedence` and `precedence_types` implementations in the expanded parser files.
  - Cleaned up the `RuleInfo` constructor by removing the `precedence` field.
  - Removed the unused `list_to_case_stream` helper function.
- **`rusty_lr_buildscript/src/lib.rs`**: Removed diagnostic formatting for `ParseError::NonTerminalPrecedenceNotDefined`.
#### 3. Examples & Documentation
- **`example/calculator_u8`**: Updated the parser definition to resolve conflicts using static precedence on terminals directly, replacing the previous dynamic operator precedence on the `Op` non-terminal.
- **`SYNTAX.md` & `README.md`**: Removed all references, code examples, and explanations regarding dynamic operator precedence and using non-terminals in `%prec`.