### PR TITLE
Integrate RustyLR LSP into the rustylr executable and publish VSCode extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The VSCode extension launches the language server from the `rustylr` executable.
 cargo install rustylr
 ```
 
-The extension checks the installed `rustylr` version before starting the server and suggests the matching `cargo install rustylr --version ... --force` command if the versions are incompatible.
+The extension checks the installed `rustylr` version before starting the server and suggests the exact versioned install command if the versions are incompatible.
 
 The extension source is available in [`editors/vscode-rustylr`](editors/vscode-rustylr).
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ The VSCode extension launches the language server from the `rustylr` executable.
 cargo install rustylr
 ```
 
+When installed this way, Cargo places the `rustylr` executable in Cargo's binary directory (commonly `~/.cargo/bin` on Unix-like systems). Make sure that directory is in your `PATH`; the extension looks for `rustylr` on `PATH` when no custom server command is configured.
+
 The extension checks the installed `rustylr` version before starting the server and suggests the exact versioned install command if the versions are incompatible.
 
 The extension source is available in [`editors/vscode-rustylr`](editors/vscode-rustylr).

--- a/README.md
+++ b/README.md
@@ -260,9 +260,25 @@ println!("{}", context);   // Formats the state tree (requires 'tree' feature)
 
 ## Editor Support
 
-An experimental RustyLR language server is included in the `rustylr` executable and can be started with `rustylr lsp`.
-A temporary VSCode client is available in [`editors/vscode-rustylr`](editors/vscode-rustylr).
-It currently targets `*.rustylr` files and files named `rustylr.rs`.
+RustyLR provides LSP-based editor support through the `rustylr lsp` language server, which is included in the `rustylr` executable.
+
+For VSCode, install [RustyLR LSP from the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp), or run:
+
+```text
+ext install ehwan.rustylr-lsp
+```
+
+The extension targets `*.rustylr` files and files named `rustylr.rs`. It provides diagnostics, quick fixes, formatting, go to definition, find references, hover documentation, inlay hints, semantic tokens, and completion.
+
+The VSCode extension launches the language server from the `rustylr` executable. Install it with:
+
+```bash
+cargo install rustylr
+```
+
+The extension checks the installed `rustylr` version before starting the server and suggests the matching `cargo install rustylr --version ... --force` command if the versions are incompatible.
+
+The extension source is available in [`editors/vscode-rustylr`](editors/vscode-rustylr).
 
 ---
 

--- a/editors/vscode-rustylr/.vscodeignore
+++ b/editors/vscode-rustylr/.vscodeignore
@@ -3,3 +3,5 @@
 package-lock.json
 extension.js
 node_modules/**
+npm-debug.log
+*.vsix

--- a/editors/vscode-rustylr/CHANGELOG.md
+++ b/editors/vscode-rustylr/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "RustyLR" extension will be documented in this file.
 ## 0.1.0
 
 - First public release of RustyLR language support!
+- Published as a preview extension while the language server continues to evolve.
 - Fully integrated with the `rustylr lsp` language server:
   - **Syntax Highlighting (Semantic Tokens):** Distinct syntax coloring for terminals, non-terminals, directives, bindings, location bindings, and variables.
   - **Diagnostics:** Inline warning and error reporting directly in the editor.

--- a/editors/vscode-rustylr/CHANGELOG.md
+++ b/editors/vscode-rustylr/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-All notable changes to the "RustyLR" extension will be documented in this file.
+All notable changes to the "RustyLR LSP" extension will be documented in this file.
 
 ## 0.1.0
 
-- First public release of RustyLR language support!
+- First public release of RustyLR LSP language support!
 - Published as a preview extension while the language server continues to evolve.
 - Fully integrated with the `rustylr lsp` language server:
   - **Syntax Highlighting (Semantic Tokens):** Distinct syntax coloring for terminals, non-terminals, directives, bindings, location bindings, and variables.

--- a/editors/vscode-rustylr/LICENSE
+++ b/editors/vscode-rustylr/LICENSE
@@ -1,3 +1,14 @@
+RustyLR LSP is distributed under the same license terms as RustyLR.
+
+Licensed under either of:
+
+- Apache License, Version 2.0
+- MIT License
+
+at your option.
+
+----- MIT License -----
+
 MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -17,3 +28,207 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----- Apache License, Version 2.0 -----
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2024 Taehwan Kim
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/editors/vscode-rustylr/README.md
+++ b/editors/vscode-rustylr/README.md
@@ -1,6 +1,6 @@
-# RustyLR Language Support
+# RustyLR LSP
 
-This extension provides rich language support for [RustyLR](https://github.com/ehwan/RustyLR) grammar files (`*.rustylr` and `rustylr.rs`). Language features are powered by the `rustylr lsp` language server.
+RustyLR LSP provides rich language support for [RustyLR](https://github.com/ehwan/RustyLR) grammar files (`*.rustylr` and `rustylr.rs`). Language features are powered by the `rustylr lsp` language server.
 
 ## Features
 

--- a/editors/vscode-rustylr/README.md
+++ b/editors/vscode-rustylr/README.md
@@ -50,7 +50,7 @@ You can install the RustyLR executable globally using Cargo:
 cargo install rustylr
 ```
 
-Ensure that your cargo binary directory (usually `~/.cargo/bin`) is in your system's `PATH`. The extension will automatically detect it.
+When installed this way, Cargo places the `rustylr` executable in Cargo's binary directory (commonly `~/.cargo/bin` on Unix-like systems). Make sure that directory is in your `PATH`; the extension looks for `rustylr` on `PATH` when `rustylr.server.command` is empty.
 
 The extension checks the `rustylr` executable version before starting the language server. If the installed version is not compatible with this extension release, it shows the exact versioned install command for the expected server version.
 

--- a/editors/vscode-rustylr/README.md
+++ b/editors/vscode-rustylr/README.md
@@ -52,11 +52,7 @@ cargo install rustylr
 
 Ensure that your cargo binary directory (usually `~/.cargo/bin`) is in your system's `PATH`. The extension will automatically detect it.
 
-The extension checks the `rustylr` executable version before starting the language server. If the installed version is not compatible with this extension release, install the expected version:
-
-```bash
-cargo install rustylr --version 1.34.0 --force
-```
+The extension checks the `rustylr` executable version before starting the language server. If the installed version is not compatible with this extension release, it shows the exact versioned install command for the expected server version.
 
 If you use a custom path instead of automatic detection:
 

--- a/editors/vscode-rustylr/README.md
+++ b/editors/vscode-rustylr/README.md
@@ -38,6 +38,12 @@ cargo install rustylr
 
 Ensure that your cargo binary directory (usually `~/.cargo/bin`) is in your system's `PATH`. The extension will automatically detect it.
 
+The extension checks the `rustylr` executable version before starting the language server. If the installed version is not compatible with this extension release, install the expected version:
+
+```bash
+cargo install rustylr --version 1.34.0 --force
+```
+
 If you use a custom path instead of automatic detection:
 
 ```json

--- a/editors/vscode-rustylr/README.md
+++ b/editors/vscode-rustylr/README.md
@@ -2,6 +2,12 @@
 
 RustyLR LSP provides rich language support for [RustyLR](https://github.com/ehwan/RustyLR) grammar files (`*.rustylr` and `rustylr.rs`). Language features are powered by the `rustylr lsp` language server.
 
+Install it from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp), or run this command from VS Code Quick Open:
+
+```text
+ext install ehwan.rustylr-lsp
+```
+
 ## Features
 
 - **Diagnostics & Error Reporting:** Real-time diagnostics for grammar syntax errors, unused symbols, conflict resolutions, and more.
@@ -28,7 +34,15 @@ This extension contributes the following settings to control the language server
 
 This extension requires the **RustyLR Language Server**, which is built into the `rustylr` executable and started with `rustylr lsp`.
 
-### 1. Install the Language Server (Recommended)
+### 1. Install the VSCode Extension
+
+Install [RustyLR LSP](https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp) from the Marketplace, or use VS Code Quick Open:
+
+```text
+ext install ehwan.rustylr-lsp
+```
+
+### 2. Install the Language Server
 
 You can install the RustyLR executable globally using Cargo:
 
@@ -53,7 +67,11 @@ If you use a custom path instead of automatic detection:
 }
 ```
 
-### 2. For RustyLR Workspace Contributors
+### 3. Open a RustyLR Grammar File
+
+Open any `*.rustylr` file or a file named `rustylr.rs`. The extension starts `rustylr lsp` automatically and enables diagnostics, completion, hover, formatting, go to definition, find references, inlay hints, semantic tokens, and quick fixes.
+
+### 4. For RustyLR Workspace Contributors
 
 If you are developing or contributing to the RustyLR repository:
 - The extension will automatically detect built binaries in the `target/debug` or `target/release` folders of your repository root.
@@ -61,4 +79,4 @@ If you are developing or contributing to the RustyLR repository:
 
 ## Marketplace Status
 
-This extension is published as a preview while the RustyLR language server continues to evolve.
+This extension is published as [RustyLR LSP](https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp) and remains in preview while the RustyLR language server continues to evolve.

--- a/editors/vscode-rustylr/README.md
+++ b/editors/vscode-rustylr/README.md
@@ -1,6 +1,6 @@
 # RustyLR Language Support
 
-This extension provides rich language support for the [RustyLR](https://github.com/ehwan/RustyLR) parser generator grammar files (`*.rustylr` and `rustylr.rs`).
+This extension provides rich language support for [RustyLR](https://github.com/ehwan/RustyLR) grammar files (`*.rustylr` and `rustylr.rs`). Language features are powered by the `rustylr lsp` language server.
 
 ## Features
 
@@ -19,8 +19,9 @@ This extension provides rich language support for the [RustyLR](https://github.c
 This extension contributes the following settings to control the language server behavior:
 
 * `rustylr.server.command`: Path to the `rustylr` executable. Leave empty to automatically detect or run from Cargo.
-* `rustylr.server.args`: Arguments passed to the language server command. When pointing directly at `rustylr`, use `["lsp"]`.
+* `rustylr.server.args`: Arguments passed to the language server command. Leave empty for automatic detection; when pointing directly at `rustylr`, use `["lsp"]`.
 * `rustylr.server.cwd`: Working directory for the language server.
+* `rustylr.server.documentPatterns`: Additional file globs handled by the RustyLR language server.
 * `rustylr.semanticTokens.enabled`: Toggle semantic token syntax highlighting.
 
 ## Installation & Requirements
@@ -37,8 +38,21 @@ cargo install rustylr
 
 Ensure that your cargo binary directory (usually `~/.cargo/bin`) is in your system's `PATH`. The extension will automatically detect it.
 
+If you use a custom path instead of automatic detection:
+
+```json
+{
+  "rustylr.server.command": "/path/to/rustylr",
+  "rustylr.server.args": ["lsp"]
+}
+```
+
 ### 2. For RustyLR Workspace Contributors
 
 If you are developing or contributing to the RustyLR repository:
 - The extension will automatically detect built binaries in the `target/debug` or `target/release` folders of your repository root.
 - If no prebuilt binary is found, it falls back to running the server dynamically using `cargo run --package rustylr -- lsp`.
+
+## Marketplace Status
+
+This extension is published as a preview while the RustyLR language server continues to evolve.

--- a/editors/vscode-rustylr/dist/extension.js
+++ b/editors/vscode-rustylr/dist/extension.js
@@ -22699,6 +22699,7 @@ var require_main3 = __commonJS({
 // extension.js
 var fs = require("fs");
 var path = require("path");
+var { execFile } = require("child_process");
 var vscode = require("vscode");
 var { LanguageClient, TransportKind } = require_main3();
 var client;
@@ -22751,6 +22752,7 @@ async function doStartClient(context) {
     repoRoot,
     cwd
   });
+  await ensureCompatibleServerVersion(server, cwd, context);
   const patterns = config.get("documentPatterns", [
     "**/*.rustylr",
     "**/rustylr.rs"
@@ -22806,9 +22808,12 @@ function expandPath(value, vars) {
 }
 function resolveServerCommand(configuredCommand, configuredArgs, vars) {
   if (configuredCommand) {
+    const command = expandPath(configuredCommand, vars);
+    const args = configuredArgs.map((arg) => expandPath(arg, vars));
     return {
-      command: expandPath(configuredCommand, vars),
-      args: configuredArgs.map((arg) => expandPath(arg, vars))
+      command,
+      args,
+      versionCommand: resolveVersionCommand(command, args)
     };
   }
   const binaryName = process.platform === "win32" ? "rustylr.exe" : "rustylr";
@@ -22820,7 +22825,11 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
     ];
     for (const candidate of candidates) {
       if (fs.existsSync(candidate)) {
-        return { command: candidate, args: lspArgs };
+        return {
+          command: candidate,
+          args: lspArgs,
+          versionCommand: { command: candidate, args: ["--version"] }
+        };
       }
     }
   }
@@ -22831,7 +22840,11 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
     const fullPath = path.join(dir, binaryName);
     try {
       if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
-        return { command: fullPath, args: lspArgs };
+        return {
+          command: fullPath,
+          args: lspArgs,
+          versionCommand: { command: fullPath, args: ["--version"] }
+        };
       }
     } catch (_e) {
     }
@@ -22839,13 +22852,104 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
   if (vars.repoRoot) {
     return {
       command: "cargo",
-      args: ["run", "--quiet", "--package", "rustylr", "--", "lsp"]
+      args: ["run", "--quiet", "--package", "rustylr", "--", "lsp"],
+      versionCommand: {
+        command: "cargo",
+        args: ["run", "--quiet", "--package", "rustylr", "--", "--version"]
+      }
     };
   }
   return {
     command: binaryName,
-    args: lspArgs
+    args: lspArgs,
+    versionCommand: { command: binaryName, args: ["--version"] }
   };
+}
+function resolveVersionCommand(command, args) {
+  const commandName = path.basename(command).toLowerCase();
+  if (commandName === "cargo" || commandName === "cargo.exe") {
+    const separatorIndex = args.indexOf("--");
+    if (separatorIndex >= 0) {
+      return {
+        command,
+        args: [...args.slice(0, separatorIndex + 1), "--version"]
+      };
+    }
+    return {
+      command,
+      args: [...args, "--", "--version"]
+    };
+  }
+  return { command, args: ["--version"] };
+}
+async function ensureCompatibleServerVersion(server, cwd, context) {
+  const expectedVersion = getRequiredServerVersion(context);
+  if (!expectedVersion) {
+    return;
+  }
+  const versionCommand = server.versionCommand || resolveVersionCommand(server.command, server.args);
+  const output = await execFileText(versionCommand.command, versionCommand.args, cwd);
+  const actualVersion = parseRustylrVersion(output);
+  if (!actualVersion) {
+    throw new Error(
+      `Could not parse RustyLR language server version from '${versionCommand.command} ${versionCommand.args.join(" ")}'. Output: ${output.trim()}`
+    );
+  }
+  if (actualVersion === expectedVersion) {
+    outputChannel.appendLine(`RustyLR LSP version check passed: ${actualVersion}`);
+    return;
+  }
+  const installCommand = `cargo install rustylr --version ${expectedVersion} --force`;
+  outputChannel.appendLine(
+    `RustyLR LSP version mismatch: expected ${expectedVersion}, found ${actualVersion}.`
+  );
+  outputChannel.appendLine(`Install the compatible server with: ${installCommand}`);
+  const selection = await vscode.window.showErrorMessage(
+    `RustyLR extension expects rustylr ${expectedVersion}, but found ${actualVersion}. Install the compatible rustylr version before using the language server.`,
+    "Copy Install Command",
+    "Continue Anyway"
+  );
+  if (selection === "Copy Install Command") {
+    await vscode.env.clipboard.writeText(installCommand);
+    vscode.window.showInformationMessage(`Copied: ${installCommand}`);
+  } else if (selection === "Continue Anyway") {
+    outputChannel.appendLine("Continuing with an incompatible RustyLR language server version.");
+    return;
+  }
+  throw new Error(
+    `RustyLR language server version mismatch. Expected ${expectedVersion}, found ${actualVersion}. Run: ${installCommand}`
+  );
+}
+function getRequiredServerVersion(context) {
+  return context.extension.packageJSON && context.extension.packageJSON.rustylr && context.extension.packageJSON.rustylr.requiredServerVersion ? context.extension.packageJSON.rustylr.requiredServerVersion : void 0;
+}
+function execFileText(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      {
+        cwd,
+        timeout: 1e4,
+        maxBuffer: 1024 * 1024
+      },
+      (error, stdout, stderr) => {
+        const output = `${stdout || ""}${stderr || ""}`;
+        if (error) {
+          error.message = `${error.message}
+Command: ${command} ${args.join(" ")}
+${output}`;
+          reject(error);
+          return;
+        }
+        resolve(output);
+      }
+    );
+  });
+}
+function parseRustylrVersion(output) {
+  const match = output.match(/\brustylr\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)/);
+  return match ? match[1] : void 0;
 }
 function findRustyLrRoot(startPath) {
   if (!startPath) {

--- a/editors/vscode-rustylr/extension.js
+++ b/editors/vscode-rustylr/extension.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { execFile } = require("child_process");
 const vscode = require("vscode");
 const { LanguageClient, TransportKind } = require("vscode-languageclient/node");
 
@@ -67,6 +68,7 @@ async function doStartClient(context) {
     repoRoot,
     cwd,
   });
+  await ensureCompatibleServerVersion(server, cwd, context);
 
   const patterns = config.get("documentPatterns", [
     "**/*.rustylr",
@@ -139,9 +141,12 @@ function expandPath(value, vars) {
 
 function resolveServerCommand(configuredCommand, configuredArgs, vars) {
   if (configuredCommand) {
+    const command = expandPath(configuredCommand, vars);
+    const args = configuredArgs.map((arg) => expandPath(arg, vars));
     return {
-      command: expandPath(configuredCommand, vars),
-      args: configuredArgs.map((arg) => expandPath(arg, vars)),
+      command,
+      args,
+      versionCommand: resolveVersionCommand(command, args),
     };
   }
 
@@ -156,7 +161,11 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
     ];
     for (const candidate of candidates) {
       if (fs.existsSync(candidate)) {
-        return { command: candidate, args: lspArgs };
+        return {
+          command: candidate,
+          args: lspArgs,
+          versionCommand: { command: candidate, args: ["--version"] },
+        };
       }
     }
   }
@@ -169,7 +178,11 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
     const fullPath = path.join(dir, binaryName);
     try {
       if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
-        return { command: fullPath, args: lspArgs };
+        return {
+          command: fullPath,
+          args: lspArgs,
+          versionCommand: { command: fullPath, args: ["--version"] },
+        };
       }
     } catch (_e) {
       // Ignore filesystem errors for inaccessible path entries
@@ -181,6 +194,10 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
     return {
       command: "cargo",
       args: ["run", "--quiet", "--package", "rustylr", "--", "lsp"],
+      versionCommand: {
+        command: "cargo",
+        args: ["run", "--quiet", "--package", "rustylr", "--", "--version"],
+      },
     };
   }
 
@@ -188,7 +205,108 @@ function resolveServerCommand(configuredCommand, configuredArgs, vars) {
   return {
     command: binaryName,
     args: lspArgs,
+    versionCommand: { command: binaryName, args: ["--version"] },
   };
+}
+
+function resolveVersionCommand(command, args) {
+  const commandName = path.basename(command).toLowerCase();
+  if (commandName === "cargo" || commandName === "cargo.exe") {
+    const separatorIndex = args.indexOf("--");
+    if (separatorIndex >= 0) {
+      return {
+        command,
+        args: [...args.slice(0, separatorIndex + 1), "--version"],
+      };
+    }
+    return {
+      command,
+      args: [...args, "--", "--version"],
+    };
+  }
+
+  return { command, args: ["--version"] };
+}
+
+async function ensureCompatibleServerVersion(server, cwd, context) {
+  const expectedVersion = getRequiredServerVersion(context);
+  if (!expectedVersion) {
+    return;
+  }
+
+  const versionCommand = server.versionCommand || resolveVersionCommand(server.command, server.args);
+  const output = await execFileText(versionCommand.command, versionCommand.args, cwd);
+  const actualVersion = parseRustylrVersion(output);
+  if (!actualVersion) {
+    throw new Error(
+      `Could not parse RustyLR language server version from '${versionCommand.command} ${versionCommand.args.join(" ")}'. Output: ${output.trim()}`
+    );
+  }
+
+  if (actualVersion === expectedVersion) {
+    outputChannel.appendLine(`RustyLR LSP version check passed: ${actualVersion}`);
+    return;
+  }
+
+  const installCommand = `cargo install rustylr --version ${expectedVersion} --force`;
+  outputChannel.appendLine(
+    `RustyLR LSP version mismatch: expected ${expectedVersion}, found ${actualVersion}.`
+  );
+  outputChannel.appendLine(`Install the compatible server with: ${installCommand}`);
+
+  const selection = await vscode.window.showErrorMessage(
+    `RustyLR extension expects rustylr ${expectedVersion}, but found ${actualVersion}. Install the compatible rustylr version before using the language server.`,
+    "Copy Install Command",
+    "Continue Anyway"
+  );
+
+  if (selection === "Copy Install Command") {
+    await vscode.env.clipboard.writeText(installCommand);
+    vscode.window.showInformationMessage(`Copied: ${installCommand}`);
+  } else if (selection === "Continue Anyway") {
+    outputChannel.appendLine("Continuing with an incompatible RustyLR language server version.");
+    return;
+  }
+
+  throw new Error(
+    `RustyLR language server version mismatch. Expected ${expectedVersion}, found ${actualVersion}. Run: ${installCommand}`
+  );
+}
+
+function getRequiredServerVersion(context) {
+  return context.extension.packageJSON &&
+    context.extension.packageJSON.rustylr &&
+    context.extension.packageJSON.rustylr.requiredServerVersion
+    ? context.extension.packageJSON.rustylr.requiredServerVersion
+    : undefined;
+}
+
+function execFileText(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      {
+        cwd,
+        timeout: 10000,
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        const output = `${stdout || ""}${stderr || ""}`;
+        if (error) {
+          error.message = `${error.message}\nCommand: ${command} ${args.join(" ")}\n${output}`;
+          reject(error);
+          return;
+        }
+        resolve(output);
+      }
+    );
+  });
+}
+
+function parseRustylrVersion(output) {
+  const match = output.match(/\brustylr\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)/);
+  return match ? match[1] : undefined;
 }
 
 function findRustyLrRoot(startPath) {

--- a/editors/vscode-rustylr/package-lock.json
+++ b/editors/vscode-rustylr/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "rustylr-vscode",
+  "name": "rustylr-lsp",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rustylr-vscode",
+      "name": "rustylr-lsp",
       "version": "0.1.0",
-      "license": "MIT OR Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.0"
       },

--- a/editors/vscode-rustylr/package-lock.json
+++ b/editors/vscode-rustylr/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "rustylr-lsp",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.0.0"
       },

--- a/editors/vscode-rustylr/package.json
+++ b/editors/vscode-rustylr/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rustylr-vscode",
   "displayName": "RustyLR",
-  "description": "Rich language support for the RustyLR parser generator, featuring diagnostics, formatting, auto-completion, hover, goto-definition, find-references, and inlay hints.",
+  "description": "Language support for RustyLR grammar files powered by the rustylr lsp language server.",
   "version": "0.1.0",
   "publisher": "ehwan",
-  "license": "MIT OR Apache-2.0",
+  "license": "MIT",
+  "preview": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/ehwan/RustyLR.git"
@@ -31,6 +32,10 @@
     "Linters",
     "Formatters"
   ],
+  "galleryBanner": {
+    "color": "#1f2937",
+    "theme": "dark"
+  },
   "main": "./dist/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -56,7 +61,7 @@
         "rustylr.server.command": {
           "type": "string",
           "default": "",
-          "description": "Command used to start the RustyLR LSP server. Empty means auto-detect target/debug/rustylr and fall back to cargo run."
+          "description": "Command used to start the RustyLR LSP server. Empty means auto-detect target/debug/rustylr, then PATH rustylr, then fall back to cargo run."
         },
         "rustylr.server.args": {
           "type": "array",
@@ -64,7 +69,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Arguments passed to rustylr.server.command."
+          "description": "Arguments passed to rustylr.server.command. Leave empty for automatic detection; use [\"lsp\"] when manually pointing at rustylr."
         },
         "rustylr.server.cwd": {
           "type": "string",

--- a/editors/vscode-rustylr/package.json
+++ b/editors/vscode-rustylr/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "rustylr-vscode",
-  "displayName": "RustyLR",
-  "description": "Language support for RustyLR grammar files powered by the rustylr lsp language server.",
+  "name": "rustylr-lsp",
+  "displayName": "RustyLR LSP",
+  "description": "LSP-powered language support for RustyLR grammar files.",
   "version": "0.1.0",
   "publisher": "ehwan",
   "license": "MIT",

--- a/editors/vscode-rustylr/package.json
+++ b/editors/vscode-rustylr/package.json
@@ -36,6 +36,9 @@
     "color": "#1f2937",
     "theme": "dark"
   },
+  "rustylr": {
+    "requiredServerVersion": "1.34.0"
+  },
   "main": "./dist/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/editors/vscode-rustylr/package.json
+++ b/editors/vscode-rustylr/package.json
@@ -4,7 +4,7 @@
   "description": "LSP-powered language support for RustyLR grammar files.",
   "version": "0.1.0",
   "publisher": "ehwan",
-  "license": "MIT",
+  "license": "MIT OR Apache-2.0",
   "preview": true,
   "repository": {
     "type": "git",

--- a/llms.txt
+++ b/llms.txt
@@ -36,4 +36,8 @@ Main crates:
 - `rusty_lr_buildscript`: Build-script helper API.
 - `rusty_lr_derive`: Procedural macro API.
 
+Editor support:
+- RustyLR LSP for VSCode is published at https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp.
+- The extension requires a compatible `rustylr` executable and starts the server with `rustylr lsp`.
+
 The `rustylr` CLI and `rusty_lr` runtime must use compatible releases. Follow the README's versioning guidance.

--- a/rusty_lr_executable/README.md
+++ b/rusty_lr_executable/README.md
@@ -92,7 +92,7 @@ Options:
 
 ### Language Server
 
-`rustylr lsp` starts the RustyLR language server over stdio. It is intended to be launched by editor clients such as the VSCode extension in [`../editors/vscode-rustylr`](../editors/vscode-rustylr). For LSP clients that append an explicit transport argument, `rustylr lsp --stdio` is accepted as an equivalent form.
+`rustylr lsp` starts the RustyLR language server over stdio. It is intended to be launched by editor clients such as the [RustyLR LSP VSCode extension](https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp) in [`../editors/vscode-rustylr`](../editors/vscode-rustylr). For LSP clients that append an explicit transport argument, `rustylr lsp --stdio` is accepted as an equivalent form.
 
 The language server currently targets `*.rustylr` files and files named `rustylr.rs`, and supports diagnostics, quick fixes, formatting, go to definition, find references, hover documentation, inlay hints, semantic tokens, and completion.
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -91,7 +91,6 @@ def calculate_bumped_version(version_str):
 def update_vscode_extension_versions(root_dir, old_version, new_version):
     """Update the VSCode extension version, required rustylr server version, and matching docs."""
     package_json_path = os.path.join(root_dir, 'editors', 'vscode-rustylr', 'package.json')
-    readme_path = os.path.join(root_dir, 'editors', 'vscode-rustylr', 'README.md')
     
     if os.path.exists(package_json_path):
         with open(package_json_path, 'r', encoding='utf-8') as f:
@@ -132,27 +131,6 @@ def update_vscode_extension_versions(root_dir, old_version, new_version):
     else:
         print(f"Warning: {package_json_path} does not exist.")
         
-    if os.path.exists(readme_path):
-        with open(readme_path, 'r', encoding='utf-8') as f:
-            readme_content = f.read()
-            
-        pattern = r'(cargo install rustylr --version\s+)[^\s]+(\s+--force)'
-        if re.search(pattern, readme_content):
-            readme_content = re.sub(pattern, rf'\g<1>{new_version}\g<2>', readme_content)
-            with open(readme_path, 'w', encoding='utf-8') as f:
-                f.write(readme_content)
-            print(
-                f"Updated VSCode extension README server install command in "
-                f"{os.path.relpath(readme_path, root_dir)}: {old_version} -> {new_version}"
-            )
-        else:
-            print(
-                f"Warning: Could not find VSCode extension server install command in "
-                f"{os.path.relpath(readme_path, root_dir)}"
-            )
-    else:
-        print(f"Warning: {readme_path} does not exist.")
-
 def run_bump(root_dir):
     """Bumps all project versions and updates their inter-dependencies."""
     print("=== STARTING VERSION BUMP ===")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,8 +88,8 @@ def calculate_bumped_version(version_str):
         return f"{major}.{minor + 1}.0"
     return version_str
 
-def update_vscode_extension_server_version(root_dir, old_version, new_version):
-    """Update the VSCode extension's required rustylr server version and matching docs."""
+def update_vscode_extension_versions(root_dir, old_version, new_version):
+    """Update the VSCode extension version, required rustylr server version, and matching docs."""
     package_json_path = os.path.join(root_dir, 'editors', 'vscode-rustylr', 'package.json')
     readme_path = os.path.join(root_dir, 'editors', 'vscode-rustylr', 'README.md')
     
@@ -97,11 +97,25 @@ def update_vscode_extension_server_version(root_dir, old_version, new_version):
         with open(package_json_path, 'r', encoding='utf-8') as f:
             package_content = f.read()
             
-        pattern = r'("requiredServerVersion"\s*:\s*")[^"]+(")'
-        if re.search(pattern, package_content):
-            package_content = re.sub(pattern, rf'\g<1>{new_version}\g<2>', package_content)
-            with open(package_json_path, 'w', encoding='utf-8') as f:
-                f.write(package_content)
+        updated_package = False
+        version_pattern = r'("version"\s*:\s*")[^"]+(")'
+        if re.search(version_pattern, package_content):
+            package_content = re.sub(version_pattern, rf'\g<1>{new_version}\g<2>', package_content, count=1)
+            updated_package = True
+            print(
+                f"Updated VSCode extension package version in "
+                f"{os.path.relpath(package_json_path, root_dir)}: {old_version} -> {new_version}"
+            )
+        else:
+            print(
+                f"Warning: Could not find extension version in "
+                f"{os.path.relpath(package_json_path, root_dir)}"
+            )
+            
+        server_pattern = r'("requiredServerVersion"\s*:\s*")[^"]+(")'
+        if re.search(server_pattern, package_content):
+            package_content = re.sub(server_pattern, rf'\g<1>{new_version}\g<2>', package_content)
+            updated_package = True
             print(
                 f"Updated VSCode extension requiredServerVersion in "
                 f"{os.path.relpath(package_json_path, root_dir)}: {old_version} -> {new_version}"
@@ -111,6 +125,10 @@ def update_vscode_extension_server_version(root_dir, old_version, new_version):
                 f"Warning: Could not find requiredServerVersion in "
                 f"{os.path.relpath(package_json_path, root_dir)}"
             )
+            
+        if updated_package:
+            with open(package_json_path, 'w', encoding='utf-8') as f:
+                f.write(package_content)
     else:
         print(f"Warning: {package_json_path} does not exist.")
         
@@ -246,7 +264,7 @@ def run_bump(root_dir):
                 
     rustylr_info = package_map.get('rustylr')
     if rustylr_info:
-        update_vscode_extension_server_version(
+        update_vscode_extension_versions(
             root_dir,
             rustylr_info['old_version'],
             rustylr_info['new_version']
@@ -294,7 +312,7 @@ def run_git_commit(root_dir, package_map):
     rustylr_info = package_map.get('rustylr')
     if rustylr_info:
         commit_msg += (
-            f"- vscode extension requiredServerVersion: "
+            f"- vscode extension: "
             f"{rustylr_info['old_version']} -> {rustylr_info['new_version']}\n"
         )
         

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,53 @@ def calculate_bumped_version(version_str):
         return f"{major}.{minor + 1}.0"
     return version_str
 
+def update_vscode_extension_server_version(root_dir, old_version, new_version):
+    """Update the VSCode extension's required rustylr server version and matching docs."""
+    package_json_path = os.path.join(root_dir, 'editors', 'vscode-rustylr', 'package.json')
+    readme_path = os.path.join(root_dir, 'editors', 'vscode-rustylr', 'README.md')
+    
+    if os.path.exists(package_json_path):
+        with open(package_json_path, 'r', encoding='utf-8') as f:
+            package_content = f.read()
+            
+        pattern = r'("requiredServerVersion"\s*:\s*")[^"]+(")'
+        if re.search(pattern, package_content):
+            package_content = re.sub(pattern, rf'\g<1>{new_version}\g<2>', package_content)
+            with open(package_json_path, 'w', encoding='utf-8') as f:
+                f.write(package_content)
+            print(
+                f"Updated VSCode extension requiredServerVersion in "
+                f"{os.path.relpath(package_json_path, root_dir)}: {old_version} -> {new_version}"
+            )
+        else:
+            print(
+                f"Warning: Could not find requiredServerVersion in "
+                f"{os.path.relpath(package_json_path, root_dir)}"
+            )
+    else:
+        print(f"Warning: {package_json_path} does not exist.")
+        
+    if os.path.exists(readme_path):
+        with open(readme_path, 'r', encoding='utf-8') as f:
+            readme_content = f.read()
+            
+        pattern = r'(cargo install rustylr --version\s+)[^\s]+(\s+--force)'
+        if re.search(pattern, readme_content):
+            readme_content = re.sub(pattern, rf'\g<1>{new_version}\g<2>', readme_content)
+            with open(readme_path, 'w', encoding='utf-8') as f:
+                f.write(readme_content)
+            print(
+                f"Updated VSCode extension README server install command in "
+                f"{os.path.relpath(readme_path, root_dir)}: {old_version} -> {new_version}"
+            )
+        else:
+            print(
+                f"Warning: Could not find VSCode extension server install command in "
+                f"{os.path.relpath(readme_path, root_dir)}"
+            )
+    else:
+        print(f"Warning: {readme_path} does not exist.")
+
 def run_bump(root_dir):
     """Bumps all project versions and updates their inter-dependencies."""
     print("=== STARTING VERSION BUMP ===")
@@ -197,6 +244,14 @@ def run_bump(root_dir):
             else:
                 print(f"Warning: {lib_rs_path} does not exist.")
                 
+    rustylr_info = package_map.get('rustylr')
+    if rustylr_info:
+        update_vscode_extension_server_version(
+            root_dir,
+            rustylr_info['old_version'],
+            rustylr_info['new_version']
+        )
+                
     print("\n=== SUMMARY OF VERSION CHANGES ===")
     for name, info in package_map.items():
         print(f"  {name: <25}: {info['old_version']} -> {info['new_version']}")
@@ -236,6 +291,12 @@ def run_git_commit(root_dir, package_map):
     commit_msg = "Release: Bump versions and execute cargo publish\n\nVersion updates:\n"
     for name, info in package_map.items():
         commit_msg += f"- {name}: {info['old_version']} -> {info['new_version']}\n"
+    rustylr_info = package_map.get('rustylr')
+    if rustylr_info:
+        commit_msg += (
+            f"- vscode extension requiredServerVersion: "
+            f"{rustylr_info['old_version']} -> {rustylr_info['new_version']}\n"
+        )
         
     try:
         # Run 'git add .'


### PR DESCRIPTION
## Summary

- Move the RustyLR LSP server into the `rustylr` executable as the `rustylr lsp` subcommand.
- Remove the standalone `rusty_lr_lsp` workspace crate.
- Update the VSCode extension to launch `rustylr lsp` and verify the installed server version before startup.
- Rename and prepare the VSCode extension as `RustyLR LSP`.
- Add Marketplace installation documentation and LSP usage guidance.
- Keep VSCode extension version metadata synchronized through `scripts/release.py`.

## Details

- The VSCode extension now resolves the language server in this order:
  - configured `rustylr.server.command`
  - local `target/debug/rustylr` or `target/release/rustylr` in a RustyLR checkout
  - `rustylr` on `PATH`
  - `cargo run --quiet --package rustylr -- lsp` inside a RustyLR checkout
- `rustylr lsp --stdio` is accepted for clients that append an explicit stdio transport argument.
- The extension checks `rustylr --version` against its required server version and suggests a compatible install command if needed.
- Documentation now links to the published Marketplace extension:
  https://marketplace.visualstudio.com/items?itemName=ehwan.rustylr-lsp
- The extension package uses the same dual license as RustyLR: `MIT OR Apache-2.0`.
